### PR TITLE
Fixing issue Error Test-MSUpdates (Refer to : #164)

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -8079,7 +8079,7 @@ Function Test-MSUpdates {
 														'Description' |
 								Sort-Object -Property 'Date' -Descending
 				ForEach ($Update in $UpdateHistory) {
-					If (($Update.Operation -ne 'Other') -and ($Update.Title -match $KBNumber)) {
+					If (($Update.Operation -ne 'Other') -and ($Update.Title -match  "($KBNumber)")) {
 						$LatestUpdateHistory = $Update
 						Break
 					}

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -8079,7 +8079,7 @@ Function Test-MSUpdates {
 														'Description' |
 								Sort-Object -Property 'Date' -Descending
 				ForEach ($Update in $UpdateHistory) {
-					If (($Update.Operation -ne 'Other') -and ($Update.Title -match  "($KBNumber)")) {
+					If (($Update.Operation -ne 'Other') -and ($Update.Title -match "\($KBNumber\)")) {
 						$LatestUpdateHistory = $Update
 						Break
 					}


### PR DESCRIPTION
For fixing issue : https://github.com/PSAppDeployToolkit/PSAppDeployToolkit/issues/164

I added to -match parenthesis between KBNumber because it always showed with parenthesis in title of KBUpdate. I don't know if it same in all countries (but i think yes).