### PR TITLE
Proposed Fix for Issue #335

### DIFF
--- a/Sources/Deploy-Application/Deploy-Application/DeployApplication.cs
+++ b/Sources/Deploy-Application/Deploy-Application/DeployApplication.cs
@@ -23,7 +23,8 @@ namespace PSAppDeployToolkit
                 string appDeployToolkitXMLPath = Path.Combine(appDeployToolkitFolder, "AppDeployToolkitConfig.xml");
                 string powershellExePath = Path.Combine(Environment.GetEnvironmentVariable("WinDir"), "System32\\WindowsPowerShell\\v1.0\\PowerShell.exe");
                 string powershellArgs = "-ExecutionPolicy Bypass -NoProfile -NoLogo -WindowStyle Hidden";
-                List<string> commandLineArgs = new List<string>(Environment.GetCommandLineArgs());
+                //List<string> commandLineArgs = new List<string>(Environment.GetCommandLineArgs());
+                List<string> commandLineArgs = new List<string>(Environment.CommandLine.Split(new[] { " -" }, StringSplitOptions.None));
                 bool isForceX86Mode = false;
                 bool isRequireAdmin = false;
 
@@ -80,7 +81,8 @@ namespace PSAppDeployToolkit
                 powershellArgs = powershellArgs + " -Command & { & '" + appDeployScriptPath + "'";
                 if (commandLineArgs.Count > 0)
                 {
-                    powershellArgs = powershellArgs + " " + string.Join(" ", commandLineArgs.ToArray());
+                    //powershellArgs = powershellArgs + " " + string.Join(" ", commandLineArgs.ToArray());
+                    powershellArgs = powershellArgs + " -" + string.Join(" -", commandLineArgs.ToArray());
                 }
                 powershellArgs = powershellArgs + "; Exit $LastExitCode }";
 


### PR DESCRIPTION
Proposed Fix for Issue #335 and in extension #200.

Change the use of Environment.GetCommandLineArgs to Environment.CommandLine and then manually parse it in the script. We'll need to split the string on the hyphen character as this is the character used to denote arguments in PowerShell. This will cause an issue with strings that contain hyphens such as "Deploy-Application", but if we split on a space and a hyphens (ex " -") as all arguments have to be separated by spaces preceding the hyphens. Line 84/85 has to be modified as the split command I'm using removes the hyphen so I have to put it back in somewhere.

A better solution would be to use Regex to do the splitting to preserve the hyphen but that requires an additional reference not currently being used. I believe this subject should be discussed further for a more ideal solution.