### PR TITLE
[Get-InstalledApplication] Search by Publisher

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1940,159 +1940,122 @@ Function Get-FreeDiskSpace {
 
 #region Function Get-InstalledApplication
 Function Get-InstalledApplication {
-<#
-.SYNOPSIS
-	Retrieves information about installed applications.
-.DESCRIPTION
-	Retrieves information about installed applications by querying the registry. You can specify an application name, a product code, or both.
-	Returns information about application publisher, name & version, product code, uninstall string, install source, location, date, and application architecture.
-.PARAMETER Name
-	The name of the application to retrieve information for. Performs a contains match on the application display name by default.
-.PARAMETER Exact
-	Specifies that the named application must be matched using the exact name.
-.PARAMETER WildCard
-	Specifies that the named application must be matched using a wildcard search.
-.PARAMETER RegEx
-	Specifies that the named application must be matched using a regular expression search.
-.PARAMETER ProductCode
-	The product code of the application to retrieve information for.
-.PARAMETER IncludeUpdatesAndHotfixes
-	Include matches against updates and hotfixes in results.
-.EXAMPLE
-	Get-InstalledApplication -Name 'Adobe Flash'
-.EXAMPLE
-	Get-InstalledApplication -ProductCode '{1AD147D0-BE0E-3D6C-AC11-64F6DC4163F1}'
-.NOTES
-.LINK
-	http://psappdeploytoolkit.com
-#>
-	[CmdletBinding()]
-	Param (
-		[Parameter(Mandatory=$false)]
-		[ValidateNotNullorEmpty()]
-		[string[]]$Name,
-		[Parameter(Mandatory=$false)]
-		[switch]$Exact = $false,
-		[Parameter(Mandatory=$false)]
-		[switch]$WildCard = $false,
-		[Parameter(Mandatory=$false)]
-		[switch]$RegEx = $false,
-		[Parameter(Mandatory=$false)]
-		[ValidateNotNullorEmpty()]
-		[string]$ProductCode,
-		[Parameter(Mandatory=$false)]
-		[switch]$IncludeUpdatesAndHotfixes
-	)
-	
-	Begin {
-		## Get the name of this function and write header
-		[string]${CmdletName} = $PSCmdlet.MyInvocation.MyCommand.Name
-		Write-FunctionHeaderOrFooter -CmdletName ${CmdletName} -CmdletBoundParameters $PSBoundParameters -Header
-	}
-	Process {
-		If ($name) {
-			Write-Log -Message "Get information for installed Application Name(s) [$($name -join ', ')]..." -Source ${CmdletName}
-		}
-		If ($productCode) {
-			Write-Log -Message "Get information for installed Product Code [$ProductCode]..." -Source ${CmdletName}
-		}
+	<#
+	.SYNOPSIS
+		Retrieves information about installed applications.
+	.DESCRIPTION
+		Retrieves information about installed applications by querying the registry. You can specify an application name, a product code, or both.
+		Returns information about application publisher, name & version, product code, uninstall string, install source, location, date, and application architecture.
+	.PARAMETER Name
+		The name of the application to retrieve information for. Performs a contains match on the application display name by default.
+	.PARAMETER Exact
+		Specifies that the named application must be matched using the exact name.
+	.PARAMETER WildCard
+		Specifies that the named application must be matched using a wildcard search.
+	.PARAMETER RegEx
+		Specifies that the named application must be matched using a regular expression search.
+	.PARAMETER ProductCode
+		The product code of the application to retrieve information for.
+	.PARAMETER Publisher
+		The publisher of the application to retrieve information for.
+	.PARAMETER IncludeUpdatesAndHotfixes
+		Include matches against updates and hotfixes in results.
+	.EXAMPLE
+		Get-InstalledApplication -Name 'Adobe Flash'
+	.EXAMPLE
+		Get-InstalledApplication -ProductCode '{1AD147D0-BE0E-3D6C-AC11-64F6DC4163F1}'
+	.EXAMPLE
+		Get-InstalledApplication -Publisher 'Google'
+	.NOTES
+	.LINK
+		http://psappdeploytoolkit.com
+	#>
+		[CmdletBinding()]
+		Param (
+			[Parameter(Mandatory=$false)]
+			[ValidateNotNullorEmpty()]
+			[string[]]$Name,
+			[Parameter(Mandatory=$false)]
+			[ValidateNotNullorEmpty()]
+			[string[]]$Publisher,
+			[Parameter(Mandatory=$false)]
+			[switch]$Exact = $false,
+			[Parameter(Mandatory=$false)]
+			[switch]$WildCard = $false,
+			[Parameter(Mandatory=$false)]
+			[switch]$RegEx = $false,
+			[Parameter(Mandatory=$false)]
+			[ValidateNotNullorEmpty()]
+			[string]$ProductCode,
+			[Parameter(Mandatory=$false)]
+			[switch]$IncludeUpdatesAndHotfixes
+		)
 		
-		## Enumerate the installed applications from the registry for applications that have the "DisplayName" property
-		[psobject[]]$regKeyApplication = @()
-		ForEach ($regKey in $regKeyApplications) {
-			If (Test-Path -LiteralPath $regKey -ErrorAction 'SilentlyContinue' -ErrorVariable '+ErrorUninstallKeyPath') {
-				[psobject[]]$UninstallKeyApps = Get-ChildItem -LiteralPath $regKey -ErrorAction 'SilentlyContinue' -ErrorVariable '+ErrorUninstallKeyPath'
-				ForEach ($UninstallKeyApp in $UninstallKeyApps) {
-					Try {
-						[psobject]$regKeyApplicationProps = Get-ItemProperty -LiteralPath $UninstallKeyApp.PSPath -ErrorAction 'Stop'
-						If ($regKeyApplicationProps.DisplayName) { [psobject[]]$regKeyApplication += $regKeyApplicationProps }
-					}
-					Catch{
-						Write-Log -Message "Unable to enumerate properties from registry key path [$($UninstallKeyApp.PSPath)]. `n$(Resolve-Error)" -Severity 2 -Source ${CmdletName}
-						Continue
+		Begin {
+			## Get the name of this function and write header
+			[string]${CmdletName} = $PSCmdlet.MyInvocation.MyCommand.Name
+			Write-FunctionHeaderOrFooter -CmdletName ${CmdletName} -CmdletBoundParameters $PSBoundParameters -Header
+		}
+		Process {
+			If ($name) {
+				Write-Log -Message "Get information for installed Application Name(s) [$($name -join ', ')]..." -Source ${CmdletName}
+			}
+			If ($productCode) {
+				Write-Log -Message "Get information for installed Product Code [$ProductCode]..." -Source ${CmdletName}
+			}
+			If ($publisher) {
+				Write-Log -Message "Get information for installed Product Code [$Publisher]..." -Source ${CmdletName}
+			}
+	
+			## Enumerate the installed applications from the registry for applications that have the "DisplayName" property
+			[psobject[]]$regKeyApplication = @()
+			ForEach ($regKey in $regKeyApplications) {
+				If (Test-Path -LiteralPath $regKey -ErrorAction 'SilentlyContinue' -ErrorVariable '+ErrorUninstallKeyPath') {
+					[psobject[]]$UninstallKeyApps = Get-ChildItem -LiteralPath $regKey -ErrorAction 'SilentlyContinue' -ErrorVariable '+ErrorUninstallKeyPath'
+					ForEach ($UninstallKeyApp in $UninstallKeyApps) {
+						Try {
+							[psobject]$regKeyApplicationProps = Get-ItemProperty -LiteralPath $UninstallKeyApp.PSPath -ErrorAction 'Stop'
+							If ($regKeyApplicationProps.DisplayName) { [psobject[]]$regKeyApplication += $regKeyApplicationProps }
+						}
+						Catch{
+							Write-Log -Message "Unable to enumerate properties from registry key path [$($UninstallKeyApp.PSPath)]. `n$(Resolve-Error)" -Severity 2 -Source ${CmdletName}
+							Continue
+						}
 					}
 				}
 			}
-		}
-		If ($ErrorUninstallKeyPath) {
-			Write-Log -Message "The following error(s) took place while enumerating installed applications from the registry. `n$(Resolve-Error -ErrorRecord $ErrorUninstallKeyPath)" -Severity 2 -Source ${CmdletName}
-		}
-		
-		## Create a custom object with the desired properties for the installed applications and sanitize property details
-		[psobject[]]$installedApplication = @()
-		ForEach ($regKeyApp in $regKeyApplication) {
-			Try {
-				[string]$appDisplayName = ''
-				[string]$appDisplayVersion = ''
-				[string]$appPublisher = ''
-				
-				## Bypass any updates or hotfixes
-				If (-not $IncludeUpdatesAndHotfixes) {
-					If ($regKeyApp.DisplayName -match '(?i)kb\d+') { Continue }
-					If ($regKeyApp.DisplayName -match 'Cumulative Update') { Continue }
-					If ($regKeyApp.DisplayName -match 'Security Update') { Continue }
-					If ($regKeyApp.DisplayName -match 'Hotfix') { Continue }
-				}
-				
-				## Remove any control characters which may interfere with logging and creating file path names from these variables
-				$appDisplayName = $regKeyApp.DisplayName -replace '[^\u001F-\u007F]',''
-				$appDisplayVersion = $regKeyApp.DisplayVersion -replace '[^\u001F-\u007F]',''
-				$appPublisher = $regKeyApp.Publisher -replace '[^\u001F-\u007F]',''
-				
-				## Determine if application is a 64-bit application
-				[boolean]$Is64BitApp = If (($is64Bit) -and ($regKeyApp.PSPath -notmatch '^Microsoft\.PowerShell\.Core\\Registry::HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node')) { $true } Else { $false }
-				
-				If ($ProductCode) {
-					## Verify if there is a match with the product code passed to the script
-					If ($regKeyApp.PSChildName -match [regex]::Escape($productCode)) {
-						Write-Log -Message "Found installed application [$appDisplayName] version [$appDisplayVersion] matching product code [$productCode]." -Source ${CmdletName}
-						$installedApplication += New-Object -TypeName 'PSObject' -Property @{
-							UninstallSubkey = $regKeyApp.PSChildName
-							ProductCode = If ($regKeyApp.PSChildName -match $MSIProductCodeRegExPattern) { $regKeyApp.PSChildName } Else { [string]::Empty }
-							DisplayName = $appDisplayName
-							DisplayVersion = $appDisplayVersion
-							UninstallString = $regKeyApp.UninstallString
-							InstallSource = $regKeyApp.InstallSource
-							InstallLocation = $regKeyApp.InstallLocation
-							InstallDate = $regKeyApp.InstallDate
-							Publisher = $appPublisher
-							Is64BitApplication = $Is64BitApp
-						}
+			If ($ErrorUninstallKeyPath) {
+				Write-Log -Message "The following error(s) took place while enumerating installed applications from the registry. `n$(Resolve-Error -ErrorRecord $ErrorUninstallKeyPath)" -Severity 2 -Source ${CmdletName}
+			}
+			
+			## Create a custom object with the desired properties for the installed applications and sanitize property details
+			[psobject[]]$installedApplication = @()
+			ForEach ($regKeyApp in $regKeyApplication) {
+				Try {
+					[string]$appDisplayName = ''
+					[string]$appDisplayVersion = ''
+					[string]$appPublisher = ''
+					
+					## Bypass any updates or hotfixes
+					If (-not $IncludeUpdatesAndHotfixes) {
+						If ($regKeyApp.DisplayName -match '(?i)kb\d+') { Continue }
+						If ($regKeyApp.DisplayName -match 'Cumulative Update') { Continue }
+						If ($regKeyApp.DisplayName -match 'Security Update') { Continue }
+						If ($regKeyApp.DisplayName -match 'Hotfix') { Continue }
 					}
-				}
-				
-				If ($name) {
-					## Verify if there is a match with the application name(s) passed to the script
-					ForEach ($application in $Name) {
-						$applicationMatched = $false
-						If ($exact) {
-							#  Check for an exact application name match
-							If ($regKeyApp.DisplayName -eq $application) {
-								$applicationMatched = $true
-								Write-Log -Message "Found installed application [$appDisplayName] version [$appDisplayVersion] using exact name matching for search term [$application]." -Source ${CmdletName}
-							}
-						}
-						ElseIf ($WildCard) {
-							#  Check for wildcard application name match
-							If ($regKeyApp.DisplayName -like $application) {
-								$applicationMatched = $true
-								Write-Log -Message "Found installed application [$appDisplayName] version [$appDisplayVersion] using wildcard matching for search term [$application]." -Source ${CmdletName}
-							}
-						}
-						ElseIf ($RegEx) {
-							#  Check for a regex application name match
-							If ($regKeyApp.DisplayName -match $application) {
-								$applicationMatched = $true
-								Write-Log -Message "Found installed application [$appDisplayName] version [$appDisplayVersion] using regex matching for search term [$application]." -Source ${CmdletName}
-							}
-						}
-						#  Check for a contains application name match
-						ElseIf ($regKeyApp.DisplayName -match [regex]::Escape($application)) {
-							$applicationMatched = $true
-							Write-Log -Message "Found installed application [$appDisplayName] version [$appDisplayVersion] using contains matching for search term [$application]." -Source ${CmdletName}
-						}
-						
-						If ($applicationMatched) {
+					
+					## Remove any control characters which may interfere with logging and creating file path names from these variables
+					$appDisplayName = $regKeyApp.DisplayName -replace '[^\u001F-\u007F]',''
+					$appDisplayVersion = $regKeyApp.DisplayVersion -replace '[^\u001F-\u007F]',''
+					$appPublisher = $regKeyApp.Publisher -replace '[^\u001F-\u007F]',''
+					
+					## Determine if application is a 64-bit application
+					[boolean]$Is64BitApp = If (($is64Bit) -and ($regKeyApp.PSPath -notmatch '^Microsoft\.PowerShell\.Core\\Registry::HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node')) { $true } Else { $false }
+					
+					If ($ProductCode) {
+						## Verify if there is a match with the product code passed to the script
+						If ($regKeyApp.PSChildName -match [regex]::Escape($productCode)) {
+							Write-Log -Message "Found installed application [$appDisplayName] version [$appDisplayVersion] matching product code [$productCode]." -Source ${CmdletName}
 							$installedApplication += New-Object -TypeName 'PSObject' -Property @{
 								UninstallSubkey = $regKeyApp.PSChildName
 								ProductCode = If ($regKeyApp.PSChildName -match $MSIProductCodeRegExPattern) { $regKeyApp.PSChildName } Else { [string]::Empty }
@@ -2107,20 +2070,115 @@ Function Get-InstalledApplication {
 							}
 						}
 					}
+					
+					If ($name) {
+						## Verify if there is a match with the application name(s) passed to the script
+						ForEach ($application in $Name) {
+							$applicationMatched = $false
+							If ($exact) {
+								#  Check for an exact application name match
+								If ($regKeyApp.DisplayName -eq $application) {
+									$applicationMatched = $true
+									Write-Log -Message "Found installed application [$appDisplayName] version [$appDisplayVersion] using exact name matching for search term [$application]." -Source ${CmdletName}
+								}
+							}
+							ElseIf ($WildCard) {
+								#  Check for wildcard application name match
+								If ($regKeyApp.DisplayName -like $application) {
+									$applicationMatched = $true
+									Write-Log -Message "Found installed application [$appDisplayName] version [$appDisplayVersion] using wildcard matching for search term [$application]." -Source ${CmdletName}
+								}
+							}
+							ElseIf ($RegEx) {
+								#  Check for a regex application name match
+								If ($regKeyApp.DisplayName -match $application) {
+									$applicationMatched = $true
+									Write-Log -Message "Found installed application [$appDisplayName] version [$appDisplayVersion] using regex matching for search term [$application]." -Source ${CmdletName}
+								}
+							}
+							#  Check for a contains application name match
+							ElseIf ($regKeyApp.DisplayName -match [regex]::Escape($application)) {
+								$applicationMatched = $true
+								Write-Log -Message "Found installed application [$appDisplayName] version [$appDisplayVersion] using contains matching for search term [$application]." -Source ${CmdletName}
+							}
+							
+							If ($applicationMatched) {
+								$installedApplication += New-Object -TypeName 'PSObject' -Property @{
+									UninstallSubkey = $regKeyApp.PSChildName
+									ProductCode = If ($regKeyApp.PSChildName -match $MSIProductCodeRegExPattern) { $regKeyApp.PSChildName } Else { [string]::Empty }
+									DisplayName = $appDisplayName
+									DisplayVersion = $appDisplayVersion
+									UninstallString = $regKeyApp.UninstallString
+									InstallSource = $regKeyApp.InstallSource
+									InstallLocation = $regKeyApp.InstallLocation
+									InstallDate = $regKeyApp.InstallDate
+									Publisher = $appPublisher
+									Is64BitApplication = $Is64BitApp
+								}
+							}
+						}
+					}
+	
+					If ($publisher) {
+						## Verify if there is a match with the application name(s) passed to the script
+						ForEach ($application in $publisher) {
+							$applicationMatched = $false
+							If ($exact) {
+								#  Check for an exact application name match
+								If ($regKeyApp.Publisher -eq $application) {
+									$applicationMatched = $true
+									Write-Log -Message "Found installed application [$appPublisher] version [$appDisplayVersion] using exact name matching for search term [$application]." -Source ${CmdletName}
+								}
+							}
+							ElseIf ($WildCard) {
+								#  Check for wildcard application name match
+								If ($regKeyApp.Publisher -like $application) {
+									$applicationMatched = $true
+									Write-Log -Message "Found installed application [$appPublisher] version [$appDisplayVersion] using wildcard matching for search term [$application]." -Source ${CmdletName}
+								}
+							}
+							ElseIf ($RegEx) {
+								#  Check for a regex application name match
+								If ($regKeyApp.Publisher -match $application) {
+									$applicationMatched = $true
+									Write-Log -Message "Found installed application [$appPublisher] version [$appDisplayVersion] using regex matching for search term [$application]." -Source ${CmdletName}
+								}
+							}
+							#  Check for a contains application name match
+							ElseIf ($regKeyApp.Publisher -match [regex]::Escape($application)) {
+								$applicationMatched = $true
+								Write-Log -Message "Found installed application [$appPublisher] version [$appDisplayVersion] using contains matching for search term [$application]." -Source ${CmdletName}
+							}
+							
+							If ($applicationMatched) {
+								$installedApplication += New-Object -TypeName 'PSObject' -Property @{
+									UninstallSubkey = $regKeyApp.PSChildName
+									ProductCode = If ($regKeyApp.PSChildName -match $MSIProductCodeRegExPattern) { $regKeyApp.PSChildName } Else { [string]::Empty }
+									DisplayName = $appDisplayName
+									DisplayVersion = $appDisplayVersion
+									UninstallString = $regKeyApp.UninstallString
+									InstallSource = $regKeyApp.InstallSource
+									InstallLocation = $regKeyApp.InstallLocation
+									InstallDate = $regKeyApp.InstallDate
+									Publisher = $appPublisher
+									Is64BitApplication = $Is64BitApp
+								}
+							}
+						}
+					}
+				}
+				Catch {
+					Write-Log -Message "Failed to resolve application details from registry for [$appDisplayName]. `n$(Resolve-Error)" -Severity 3 -Source ${CmdletName}
+					Continue
 				}
 			}
-			Catch {
-				Write-Log -Message "Failed to resolve application details from registry for [$appDisplayName]. `n$(Resolve-Error)" -Severity 3 -Source ${CmdletName}
-				Continue
-			}
+			
+			Write-Output -InputObject $installedApplication
 		}
-		
-		Write-Output -InputObject $installedApplication
+		End {
+			Write-FunctionHeaderOrFooter -CmdletName ${CmdletName} -Footer
+		}
 	}
-	End {
-		Write-FunctionHeaderOrFooter -CmdletName ${CmdletName} -Footer
-	}
-}
 #endregion
 
 

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1940,122 +1940,169 @@ Function Get-FreeDiskSpace {
 
 #region Function Get-InstalledApplication
 Function Get-InstalledApplication {
-	<#
-	.SYNOPSIS
-		Retrieves information about installed applications.
-	.DESCRIPTION
-		Retrieves information about installed applications by querying the registry. You can specify an application name, a product code, or both.
-		Returns information about application publisher, name & version, product code, uninstall string, install source, location, date, and application architecture.
-	.PARAMETER Name
-		The name of the application to retrieve information for. Performs a contains match on the application display name by default.
-	.PARAMETER Exact
-		Specifies that the named application must be matched using the exact name.
-	.PARAMETER WildCard
-		Specifies that the named application must be matched using a wildcard search.
-	.PARAMETER RegEx
-		Specifies that the named application must be matched using a regular expression search.
-	.PARAMETER ProductCode
-		The product code of the application to retrieve information for.
-	.PARAMETER Publisher
-		The publisher of the application to retrieve information for.
-	.PARAMETER IncludeUpdatesAndHotfixes
-		Include matches against updates and hotfixes in results.
-	.EXAMPLE
-		Get-InstalledApplication -Name 'Adobe Flash'
-	.EXAMPLE
-		Get-InstalledApplication -ProductCode '{1AD147D0-BE0E-3D6C-AC11-64F6DC4163F1}'
-	.EXAMPLE
-		Get-InstalledApplication -Publisher 'Google'
-	.NOTES
-	.LINK
-		http://psappdeploytoolkit.com
-	#>
-		[CmdletBinding()]
-		Param (
-			[Parameter(Mandatory=$false)]
-			[ValidateNotNullorEmpty()]
-			[string[]]$Name,
-			[Parameter(Mandatory=$false)]
-			[ValidateNotNullorEmpty()]
-			[string[]]$Publisher,
-			[Parameter(Mandatory=$false)]
-			[switch]$Exact = $false,
-			[Parameter(Mandatory=$false)]
-			[switch]$WildCard = $false,
-			[Parameter(Mandatory=$false)]
-			[switch]$RegEx = $false,
-			[Parameter(Mandatory=$false)]
-			[ValidateNotNullorEmpty()]
-			[string]$ProductCode,
-			[Parameter(Mandatory=$false)]
-			[switch]$IncludeUpdatesAndHotfixes
-		)
-		
-		Begin {
-			## Get the name of this function and write header
-			[string]${CmdletName} = $PSCmdlet.MyInvocation.MyCommand.Name
-			Write-FunctionHeaderOrFooter -CmdletName ${CmdletName} -CmdletBoundParameters $PSBoundParameters -Header
-		}
-		Process {
-			If ($name) {
-				Write-Log -Message "Get information for installed Application Name(s) [$($name -join ', ')]..." -Source ${CmdletName}
-			}
-			If ($productCode) {
-				Write-Log -Message "Get information for installed Product Code [$ProductCode]..." -Source ${CmdletName}
-			}
-			If ($publisher) {
-				Write-Log -Message "Get information for installed Product Code [$Publisher]..." -Source ${CmdletName}
-			}
+<#
+.SYNOPSIS
+	Retrieves information about installed applications.
+.DESCRIPTION
+	Retrieves information about installed applications by querying the registry. You can specify an application name, a product code, or both.
+	Returns information about application publisher, name & version, product code, uninstall string, install source, location, date, and application architecture.
+.PARAMETER Name
+	The name of the application to retrieve information for. Performs a contains match on the application display name by default.
+.PARAMETER Exact
+	Specifies that the named application must be matched using the exact name.
+.PARAMETER WildCard
+	Specifies that the named application must be matched using a wildcard search.
+.PARAMETER RegEx
+	Specifies that the named application must be matched using a regular expression search.
+.PARAMETER ProductCode
+	The product code of the application to retrieve information for.
+.PARAMETER Publisher
+	The publisher of the application to retrieve information for.
+.PARAMETER IncludeUpdatesAndHotfixes
+	Include matches against updates and hotfixes in results.
+.EXAMPLE
+	Get-InstalledApplication -Name 'Adobe Flash'
+.EXAMPLE
+	Get-InstalledApplication -ProductCode '{1AD147D0-BE0E-3D6C-AC11-64F6DC4163F1}'
+.EXAMPLE
+	Get-InstalledApplication -Publisher 'Google'
+.NOTES
+.LINK
+	http://psappdeploytoolkit.com
+#>
+	[CmdletBinding()]
+	Param (
+		[Parameter(Mandatory=$false)]
+		[ValidateNotNullorEmpty()]
+		[string[]]$Name,
+		[Parameter(Mandatory=$false)]
+		[ValidateNotNullorEmpty()]
+		[string[]]$Publisher,
+		[Parameter(Mandatory=$false)]
+		[switch]$Exact = $false,
+		[Parameter(Mandatory=$false)]
+		[switch]$WildCard = $false,
+		[Parameter(Mandatory=$false)]
+		[switch]$RegEx = $false,
+		[Parameter(Mandatory=$false)]
+		[ValidateNotNullorEmpty()]
+		[string]$ProductCode,
+		[Parameter(Mandatory=$false)]
+		[switch]$IncludeUpdatesAndHotfixes
+	)
 	
-			## Enumerate the installed applications from the registry for applications that have the "DisplayName" property
-			[psobject[]]$regKeyApplication = @()
-			ForEach ($regKey in $regKeyApplications) {
-				If (Test-Path -LiteralPath $regKey -ErrorAction 'SilentlyContinue' -ErrorVariable '+ErrorUninstallKeyPath') {
-					[psobject[]]$UninstallKeyApps = Get-ChildItem -LiteralPath $regKey -ErrorAction 'SilentlyContinue' -ErrorVariable '+ErrorUninstallKeyPath'
-					ForEach ($UninstallKeyApp in $UninstallKeyApps) {
-						Try {
-							[psobject]$regKeyApplicationProps = Get-ItemProperty -LiteralPath $UninstallKeyApp.PSPath -ErrorAction 'Stop'
-							If ($regKeyApplicationProps.DisplayName) { [psobject[]]$regKeyApplication += $regKeyApplicationProps }
-						}
-						Catch{
-							Write-Log -Message "Unable to enumerate properties from registry key path [$($UninstallKeyApp.PSPath)]. `n$(Resolve-Error)" -Severity 2 -Source ${CmdletName}
-							Continue
-						}
+	Begin {
+		## Get the name of this function and write header
+		[string]${CmdletName} = $PSCmdlet.MyInvocation.MyCommand.Name
+		Write-FunctionHeaderOrFooter -CmdletName ${CmdletName} -CmdletBoundParameters $PSBoundParameters -Header
+	}
+	Process {
+		If ($name) {
+			Write-Log -Message "Get information for installed Application Name(s) [$($name -join ', ')]..." -Source ${CmdletName}
+		}
+		If ($productCode) {
+			Write-Log -Message "Get information for installed Product Code [$ProductCode]..." -Source ${CmdletName}
+		}
+		If ($publisher) {
+			Write-Log -Message "Get information for installed Product Code [$Publisher]..." -Source ${CmdletName}
+		}
+
+		## Enumerate the installed applications from the registry for applications that have the "DisplayName" property
+		[psobject[]]$regKeyApplication = @()
+		ForEach ($regKey in $regKeyApplications) {
+			If (Test-Path -LiteralPath $regKey -ErrorAction 'SilentlyContinue' -ErrorVariable '+ErrorUninstallKeyPath') {
+				[psobject[]]$UninstallKeyApps = Get-ChildItem -LiteralPath $regKey -ErrorAction 'SilentlyContinue' -ErrorVariable '+ErrorUninstallKeyPath'
+				ForEach ($UninstallKeyApp in $UninstallKeyApps) {
+					Try {
+						[psobject]$regKeyApplicationProps = Get-ItemProperty -LiteralPath $UninstallKeyApp.PSPath -ErrorAction 'Stop'
+						If ($regKeyApplicationProps.DisplayName) { [psobject[]]$regKeyApplication += $regKeyApplicationProps }
+					}
+					Catch{
+						Write-Log -Message "Unable to enumerate properties from registry key path [$($UninstallKeyApp.PSPath)]. `n$(Resolve-Error)" -Severity 2 -Source ${CmdletName}
+						Continue
 					}
 				}
 			}
-			If ($ErrorUninstallKeyPath) {
-				Write-Log -Message "The following error(s) took place while enumerating installed applications from the registry. `n$(Resolve-Error -ErrorRecord $ErrorUninstallKeyPath)" -Severity 2 -Source ${CmdletName}
-			}
-			
-			## Create a custom object with the desired properties for the installed applications and sanitize property details
-			[psobject[]]$installedApplication = @()
-			ForEach ($regKeyApp in $regKeyApplication) {
-				Try {
-					[string]$appDisplayName = ''
-					[string]$appDisplayVersion = ''
-					[string]$appPublisher = ''
-					
-					## Bypass any updates or hotfixes
-					If (-not $IncludeUpdatesAndHotfixes) {
-						If ($regKeyApp.DisplayName -match '(?i)kb\d+') { Continue }
-						If ($regKeyApp.DisplayName -match 'Cumulative Update') { Continue }
-						If ($regKeyApp.DisplayName -match 'Security Update') { Continue }
-						If ($regKeyApp.DisplayName -match 'Hotfix') { Continue }
+		}
+		If ($ErrorUninstallKeyPath) {
+			Write-Log -Message "The following error(s) took place while enumerating installed applications from the registry. `n$(Resolve-Error -ErrorRecord $ErrorUninstallKeyPath)" -Severity 2 -Source ${CmdletName}
+		}
+		
+		## Create a custom object with the desired properties for the installed applications and sanitize property details
+		[psobject[]]$installedApplication = @()
+		ForEach ($regKeyApp in $regKeyApplication) {
+			Try {
+				[string]$appDisplayName = ''
+				[string]$appDisplayVersion = ''
+				[string]$appPublisher = ''
+				
+				## Bypass any updates or hotfixes
+				If (-not $IncludeUpdatesAndHotfixes) {
+					If ($regKeyApp.DisplayName -match '(?i)kb\d+') { Continue }
+					If ($regKeyApp.DisplayName -match 'Cumulative Update') { Continue }
+					If ($regKeyApp.DisplayName -match 'Security Update') { Continue }
+					If ($regKeyApp.DisplayName -match 'Hotfix') { Continue }
+				}
+				
+				## Remove any control characters which may interfere with logging and creating file path names from these variables
+				$appDisplayName = $regKeyApp.DisplayName -replace '[^\u001F-\u007F]',''
+				$appDisplayVersion = $regKeyApp.DisplayVersion -replace '[^\u001F-\u007F]',''
+				$appPublisher = $regKeyApp.Publisher -replace '[^\u001F-\u007F]',''
+				
+				## Determine if application is a 64-bit application
+				[boolean]$Is64BitApp = If (($is64Bit) -and ($regKeyApp.PSPath -notmatch '^Microsoft\.PowerShell\.Core\\Registry::HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node')) { $true } Else { $false }
+				
+				If ($ProductCode) {
+					## Verify if there is a match with the product code passed to the script
+					If ($regKeyApp.PSChildName -match [regex]::Escape($productCode)) {
+						Write-Log -Message "Found installed application [$appDisplayName] version [$appDisplayVersion] matching product code [$productCode]." -Source ${CmdletName}
+						$installedApplication += New-Object -TypeName 'PSObject' -Property @{
+							UninstallSubkey = $regKeyApp.PSChildName
+							ProductCode = If ($regKeyApp.PSChildName -match $MSIProductCodeRegExPattern) { $regKeyApp.PSChildName } Else { [string]::Empty }
+							DisplayName = $appDisplayName
+							DisplayVersion = $appDisplayVersion
+							UninstallString = $regKeyApp.UninstallString
+							InstallSource = $regKeyApp.InstallSource
+							InstallLocation = $regKeyApp.InstallLocation
+							InstallDate = $regKeyApp.InstallDate
+							Publisher = $appPublisher
+							Is64BitApplication = $Is64BitApp
+						}
 					}
-					
-					## Remove any control characters which may interfere with logging and creating file path names from these variables
-					$appDisplayName = $regKeyApp.DisplayName -replace '[^\u001F-\u007F]',''
-					$appDisplayVersion = $regKeyApp.DisplayVersion -replace '[^\u001F-\u007F]',''
-					$appPublisher = $regKeyApp.Publisher -replace '[^\u001F-\u007F]',''
-					
-					## Determine if application is a 64-bit application
-					[boolean]$Is64BitApp = If (($is64Bit) -and ($regKeyApp.PSPath -notmatch '^Microsoft\.PowerShell\.Core\\Registry::HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node')) { $true } Else { $false }
-					
-					If ($ProductCode) {
-						## Verify if there is a match with the product code passed to the script
-						If ($regKeyApp.PSChildName -match [regex]::Escape($productCode)) {
-							Write-Log -Message "Found installed application [$appDisplayName] version [$appDisplayVersion] matching product code [$productCode]." -Source ${CmdletName}
+				}
+				
+				If ($name) {
+					## Verify if there is a match with the application name(s) passed to the script
+					ForEach ($application in $Name) {
+						$applicationMatched = $false
+						If ($exact) {
+							#  Check for an exact application name match
+							If ($regKeyApp.DisplayName -eq $application) {
+								$applicationMatched = $true
+								Write-Log -Message "Found installed application [$appDisplayName] version [$appDisplayVersion] using exact name matching for search term [$application]." -Source ${CmdletName}
+							}
+						}
+						ElseIf ($WildCard) {
+							#  Check for wildcard application name match
+							If ($regKeyApp.DisplayName -like $application) {
+								$applicationMatched = $true
+								Write-Log -Message "Found installed application [$appDisplayName] version [$appDisplayVersion] using wildcard matching for search term [$application]." -Source ${CmdletName}
+							}
+						}
+						ElseIf ($RegEx) {
+							#  Check for a regex application name match
+							If ($regKeyApp.DisplayName -match $application) {
+								$applicationMatched = $true
+								Write-Log -Message "Found installed application [$appDisplayName] version [$appDisplayVersion] using regex matching for search term [$application]." -Source ${CmdletName}
+							}
+						}
+						#  Check for a contains application name match
+						ElseIf ($regKeyApp.DisplayName -match [regex]::Escape($application)) {
+							$applicationMatched = $true
+							Write-Log -Message "Found installed application [$appDisplayName] version [$appDisplayVersion] using contains matching for search term [$application]." -Source ${CmdletName}
+						}
+						
+						If ($applicationMatched) {
 							$installedApplication += New-Object -TypeName 'PSObject' -Property @{
 								UninstallSubkey = $regKeyApp.PSChildName
 								ProductCode = If ($regKeyApp.PSChildName -match $MSIProductCodeRegExPattern) { $regKeyApp.PSChildName } Else { [string]::Empty }
@@ -2070,115 +2117,68 @@ Function Get-InstalledApplication {
 							}
 						}
 					}
-					
-					If ($name) {
-						## Verify if there is a match with the application name(s) passed to the script
-						ForEach ($application in $Name) {
-							$applicationMatched = $false
-							If ($exact) {
-								#  Check for an exact application name match
-								If ($regKeyApp.DisplayName -eq $application) {
-									$applicationMatched = $true
-									Write-Log -Message "Found installed application [$appDisplayName] version [$appDisplayVersion] using exact name matching for search term [$application]." -Source ${CmdletName}
-								}
-							}
-							ElseIf ($WildCard) {
-								#  Check for wildcard application name match
-								If ($regKeyApp.DisplayName -like $application) {
-									$applicationMatched = $true
-									Write-Log -Message "Found installed application [$appDisplayName] version [$appDisplayVersion] using wildcard matching for search term [$application]." -Source ${CmdletName}
-								}
-							}
-							ElseIf ($RegEx) {
-								#  Check for a regex application name match
-								If ($regKeyApp.DisplayName -match $application) {
-									$applicationMatched = $true
-									Write-Log -Message "Found installed application [$appDisplayName] version [$appDisplayVersion] using regex matching for search term [$application]." -Source ${CmdletName}
-								}
-							}
-							#  Check for a contains application name match
-							ElseIf ($regKeyApp.DisplayName -match [regex]::Escape($application)) {
-								$applicationMatched = $true
-								Write-Log -Message "Found installed application [$appDisplayName] version [$appDisplayVersion] using contains matching for search term [$application]." -Source ${CmdletName}
-							}
-							
-							If ($applicationMatched) {
-								$installedApplication += New-Object -TypeName 'PSObject' -Property @{
-									UninstallSubkey = $regKeyApp.PSChildName
-									ProductCode = If ($regKeyApp.PSChildName -match $MSIProductCodeRegExPattern) { $regKeyApp.PSChildName } Else { [string]::Empty }
-									DisplayName = $appDisplayName
-									DisplayVersion = $appDisplayVersion
-									UninstallString = $regKeyApp.UninstallString
-									InstallSource = $regKeyApp.InstallSource
-									InstallLocation = $regKeyApp.InstallLocation
-									InstallDate = $regKeyApp.InstallDate
-									Publisher = $appPublisher
-									Is64BitApplication = $Is64BitApp
-								}
-							}
-						}
-					}
-	
-					If ($publisher) {
-						## Verify if there is a match with the application name(s) passed to the script
-						ForEach ($application in $publisher) {
-							$applicationMatched = $false
-							If ($exact) {
-								#  Check for an exact application name match
-								If ($regKeyApp.Publisher -eq $application) {
-									$applicationMatched = $true
-									Write-Log -Message "Found installed application [$appPublisher] version [$appDisplayVersion] using exact name matching for search term [$application]." -Source ${CmdletName}
-								}
-							}
-							ElseIf ($WildCard) {
-								#  Check for wildcard application name match
-								If ($regKeyApp.Publisher -like $application) {
-									$applicationMatched = $true
-									Write-Log -Message "Found installed application [$appPublisher] version [$appDisplayVersion] using wildcard matching for search term [$application]." -Source ${CmdletName}
-								}
-							}
-							ElseIf ($RegEx) {
-								#  Check for a regex application name match
-								If ($regKeyApp.Publisher -match $application) {
-									$applicationMatched = $true
-									Write-Log -Message "Found installed application [$appPublisher] version [$appDisplayVersion] using regex matching for search term [$application]." -Source ${CmdletName}
-								}
-							}
-							#  Check for a contains application name match
-							ElseIf ($regKeyApp.Publisher -match [regex]::Escape($application)) {
-								$applicationMatched = $true
-								Write-Log -Message "Found installed application [$appPublisher] version [$appDisplayVersion] using contains matching for search term [$application]." -Source ${CmdletName}
-							}
-							
-							If ($applicationMatched) {
-								$installedApplication += New-Object -TypeName 'PSObject' -Property @{
-									UninstallSubkey = $regKeyApp.PSChildName
-									ProductCode = If ($regKeyApp.PSChildName -match $MSIProductCodeRegExPattern) { $regKeyApp.PSChildName } Else { [string]::Empty }
-									DisplayName = $appDisplayName
-									DisplayVersion = $appDisplayVersion
-									UninstallString = $regKeyApp.UninstallString
-									InstallSource = $regKeyApp.InstallSource
-									InstallLocation = $regKeyApp.InstallLocation
-									InstallDate = $regKeyApp.InstallDate
-									Publisher = $appPublisher
-									Is64BitApplication = $Is64BitApp
-								}
-							}
-						}
-					}
 				}
-				Catch {
-					Write-Log -Message "Failed to resolve application details from registry for [$appDisplayName]. `n$(Resolve-Error)" -Severity 3 -Source ${CmdletName}
-					Continue
+
+				If ($publisher) {
+					## Verify if there is a match with the application name(s) passed to the script
+					ForEach ($application in $publisher) {
+						$applicationMatched = $false
+						If ($exact) {
+							#  Check for an exact application name match
+							If ($regKeyApp.Publisher -eq $application) {
+								$applicationMatched = $true
+								Write-Log -Message "Found installed application [$appPublisher] version [$appDisplayVersion] using exact name matching for search term [$application]." -Source ${CmdletName}
+							}
+						}
+						ElseIf ($WildCard) {
+							#  Check for wildcard application name match
+							If ($regKeyApp.Publisher -like $application) {
+								$applicationMatched = $true
+								Write-Log -Message "Found installed application [$appPublisher] version [$appDisplayVersion] using wildcard matching for search term [$application]." -Source ${CmdletName}
+							}
+						}
+						ElseIf ($RegEx) {
+							#  Check for a regex application name match
+							If ($regKeyApp.Publisher -match $application) {
+								$applicationMatched = $true
+								Write-Log -Message "Found installed application [$appPublisher] version [$appDisplayVersion] using regex matching for search term [$application]." -Source ${CmdletName}
+							}
+						}
+						#  Check for a contains application name match
+						ElseIf ($regKeyApp.Publisher -match [regex]::Escape($application)) {
+							$applicationMatched = $true
+							Write-Log -Message "Found installed application [$appPublisher] version [$appDisplayVersion] using contains matching for search term [$application]." -Source ${CmdletName}
+						}
+						
+						If ($applicationMatched) {
+							$installedApplication += New-Object -TypeName 'PSObject' -Property @{
+								UninstallSubkey = $regKeyApp.PSChildName
+								ProductCode = If ($regKeyApp.PSChildName -match $MSIProductCodeRegExPattern) { $regKeyApp.PSChildName } Else { [string]::Empty }
+								DisplayName = $appDisplayName
+								DisplayVersion = $appDisplayVersion
+								UninstallString = $regKeyApp.UninstallString
+								InstallSource = $regKeyApp.InstallSource
+								InstallLocation = $regKeyApp.InstallLocation
+								InstallDate = $regKeyApp.InstallDate
+								Publisher = $appPublisher
+								Is64BitApplication = $Is64BitApp
+							}
+						}
+					}
 				}
 			}
-			
-			Write-Output -InputObject $installedApplication
+			Catch {
+				Write-Log -Message "Failed to resolve application details from registry for [$appDisplayName]. `n$(Resolve-Error)" -Severity 3 -Source ${CmdletName}
+				Continue
+			}
 		}
-		End {
-			Write-FunctionHeaderOrFooter -CmdletName ${CmdletName} -Footer
-		}
+		
+		Write-Output -InputObject $installedApplication
 	}
+	End {
+		Write-FunctionHeaderOrFooter -CmdletName ${CmdletName} -Footer
+	}
+}
 #endregion
 
 


### PR DESCRIPTION
Allows to search by publisher name. Useful in some edge cases like "Please uninstall everything from Amazon". 

I personally think Get-InstalledApplication and Remove-MSIApplications need an overhaul. Get-InstalledApplication should just get everything, then use the pipe for filtering before maybe giving it to Remove-MSIApplications for proper uninstallation. But changing as much as I imagine would break a lot in the toolkit. Sadly Get-Package and Uninstall-Package do not give the same properties as the cmdlets in PSADT.