### PR TITLE
Write-Log function escape character fix

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -674,7 +674,7 @@ Function Write-Log {
 		
 		## Logging Variables
 		#  Log file date/time
-		[string]$LogTime = (Get-Date -Format 'HH:mm:ss.fff').ToString()
+		[string]$LogTime = (Get-Date -Format 'HH\:mm\:ss.fff').ToString()
 		[string]$LogDate = (Get-Date -Format 'MM-dd-yyyy').ToString()
 		If (-not (Test-Path -LiteralPath 'variable:LogTimeZoneBias')) { [int32]$script:LogTimeZoneBias = [timezone]::CurrentTimeZone.GetUtcOffset([datetime]::Now).TotalMinutes }
 		[string]$LogTimePlusBias = $LogTime + $script:LogTimeZoneBias


### PR DESCRIPTION
Added escape characters to $LogTime, for example Finnish culture info changes ":" to "." and cmtrace will parse it wrong. 

Bad formatting (seen in cmtrace):
[Initialization] :: Installation is running in [Interactive] mode.		1.1.1601 0.00.00	0 (0x0000)
->
Log file:
<![LOG[[Initialization] :: Installation is running in [Interactive] mode.]LOG]!><time="13.02.20.943120" date="03-06-2019" component="PSAppDeployToolkit" context="Computer\User" type="1" thread="1172" file="AppDeployToolkitMain.ps1">

Working (seen in cmtrace):
[Initialization] :: Installation is running in [Interactive] mode.	PSAppDeployToolkit	13.3.2019 13.41.13	7356 (0x1CBC)
->
Log file:
<![LOG[[Initialization] :: Installation is running in [Interactive] mode.]LOG]!><time="13:34:13.930+120" date="03-13-2019" component="PSAppDeployToolkit" context="Computer\User" type="1" thread="7356" file="AppDeployToolkitMain.ps1">