### PR TITLE
Execute-Process -MsiExecWaitTime parameter fix

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -2766,7 +2766,7 @@ Function Execute-Process {
 		[switch]$WaitForMsiExec = $false,
 		[Parameter(Mandatory=$false)]
 		[ValidateNotNullorEmpty()]
-		[timespan]$MsiExecWaitTime = $(New-TimeSpan -Seconds $configMSIMutexWaitTime),
+		[int]$MsiExecWaitTime = $configMSIMutexWaitTime,
 		[Parameter(Mandatory=$false)]
 		[ValidateNotNullorEmpty()]
 		[string]$IgnoreExitCodes,
@@ -2821,7 +2821,8 @@ Function Execute-Process {
 			## Please note that a race condition is possible after this check where another process waiting for the MSI installer
 			##  to become available grabs the MSI Installer mutex before we do. Not too concerned about this possible race condition.
 			If (($Path -match 'msiexec') -or ($WaitForMsiExec)) {
-				[boolean]$MsiExecAvailable = Test-IsMutexAvailable -MutexName 'Global\_MSIExecute' -MutexWaitTimeInMilliseconds $MsiExecWaitTime.TotalMilliseconds
+				[timespan]$MsiExecWaitTimeSpan = New-TimeSpan -Seconds $MsiExecWaitTime
+				[boolean]$MsiExecAvailable = Test-IsMutexAvailable -MutexName 'Global\_MSIExecute' -MutexWaitTimeInMilliseconds $MsiExecWaitTimeSpan.TotalMilliseconds
 				Start-Sleep -Seconds 1
 				If (-not $MsiExecAvailable) {
 					#  Default MSI exit code for install already in progress


### PR DESCRIPTION
The parameter -MsiExecWaitTime is creating a timespan variable through New-TimeSpan when its not specified but when it is, its created through the variable which creates a timespan variable with incorrect value set, because it assumes you want to use that value for Ticks not seconds. This change fixes it by changing it to an integer and then creating a new timespan variable where this integer is used for seconds.