### PR TITLE
Show-InstallationRestartPrompt timer fix

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -6779,7 +6779,7 @@ Function Show-InstallationRestartPrompt {
 			$timerCountdown.Start()
 			## Set up the form
 			[timespan]$remainingTime = $countdownTime.Subtract($currentTime)
-			$labelCountdown.Text = [string]::Format('{0}:{1:d2}:{2:d2}', $remainingTime.Hours, $remainingTime.Minutes, $remainingTime.Seconds)
+			$labelCountdown.Text = [string]::Format('{0}:{1:d2}:{2:d2}', $remainingTime.Days * 24 + $remainingTime.Hours, $remainingTime.Minutes, $remainingTime.Seconds)
 			If ($remainingTime.TotalSeconds -le $countdownNoHideSeconds) { $buttonRestartLater.Enabled = $false }
 			$formRestart.WindowState = 'Normal'
 			$formRestart.TopMost = $true


### PR DESCRIPTION
Fixes the issue where the time remaining doesn't show more than 24 hours.

Credit to adipiciu for the fix.