### PR TITLE
Fix Set-ActiveSetup purging error

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -9646,7 +9646,11 @@ Function Set-ActiveSetup {
 				Remove-RegistryKey -Key $ActiveSetupKey -Recurse
 				
 				Write-Log -Message "Remove Active Setup entry [$HKCUActiveSetupKey] for all log on user registry hives on the system." -Source ${CmdletName}
-				[scriptblock]$RemoveHKCUActiveSetupKey = { Remove-RegistryKey -Key $HKCUActiveSetupKey -SID $UserProfile.SID -Recurse }
+				[scriptblock]$RemoveHKCUActiveSetupKey = { 
+					If (Test-Path -Path $HKCUActiveSetupKey) {
+						Remove-RegistryKey -Key $HKCUActiveSetupKey -SID $UserProfile.SID -Recurse
+					}
+				}
 				Invoke-HKCURegistrySettingsForAllUsers -RegistrySettings $RemoveHKCUActiveSetupKey -UserProfiles (Get-UserProfiles -ExcludeDefaultUser)
 				Return
 			}


### PR DESCRIPTION
The function goes through all active-setup entries in the HKCU for the specified name and removes them however not every user might have logged in to have it written via Active Setup so this would lead to a lot of error messages where the function would not find the registry key in the user's hive.
This change adds a check to test whether the key exists before removing it.