### PR TITLE
Fix Set-ActiveSetup purging incorrectly testing registry values

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -9647,7 +9647,7 @@ Function Set-ActiveSetup {
 
 				Write-Log -Message "Remove Active Setup entry [$HKCUActiveSetupKey] for all log on user registry hives on the system." -Source ${CmdletName}
 				[scriptblock]$RemoveHKCUActiveSetupKey = {
-					If (Test-Path -Path $HKCUActiveSetupKey) {
+					If (Get-RegistryKey -Key $HKCUActiveSetupKey -SID $UserProfile.SID) {
 						Remove-RegistryKey -Key $HKCUActiveSetupKey -SID $UserProfile.SID -Recurse
 					}
 				}


### PR DESCRIPTION
Due to how Invoke-HKCURegistrySettingsForAllUsers loads user registry hives, Active setup purging did not test the registry key correctly. This fixes it, 

#439 