### PR TITLE
Grey out the X(close) button

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.cs
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.cs
@@ -221,6 +221,15 @@ namespace PSADT
 		[DllImport("user32.dll", EntryPoint = "GetWindowLongPtr", CharSet = CharSet.Auto, SetLastError = false)]
 		public static extern IntPtr GetWindowLongPtr64(IntPtr hWnd, int nIndex);
 		
+		[DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = false)]
+		public static extern IntPtr GetSystemMenu(IntPtr hWnd, bool bRevert);
+
+		[DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = false)]
+		public static extern bool EnableMenuItem(IntPtr hMenu, uint uIDEnableItem, uint uEnable);
+
+		[DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = false)]
+		public static extern IntPtr DestroyMenu(IntPtr hWnd);
+
 		public delegate bool EnumWindowsProcD(IntPtr hWnd, ref IntPtr lItems);
 		
 		public static bool EnumWindowsProc(IntPtr hWnd, ref IntPtr lItems)

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -7320,7 +7320,7 @@ Function Show-InstallationProgress {
 				$script:ProgressSyncHash.Window = [Windows.Markup.XamlReader]::Load($progressReader)
 				#  Grey out the X button
 				$script:ProgressSyncHash.Window.add_Loaded({
-					$windowHandle = (New-Object -TypeName System.Windows.Interop.WindowInteropHelper -ArgumentList $this).Handle
+					[IntPtr]$windowHandle = (New-Object -TypeName System.Windows.Interop.WindowInteropHelper -ArgumentList $this).Handle
 					If ($null -ne $windowHandle) {
 						[IntPtr]$menuHandle = [PSADT.UiAutomation]::GetSystemMenu($windowHandle, $false)
 						If ($menuHandle -ne [IntPtr]::Zero) {

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -7318,6 +7318,18 @@ Function Show-InstallationProgress {
 				#  Parse the XAML
 				$progressReader = New-Object -TypeName 'System.Xml.XmlNodeReader' -ArgumentList $xamlProgress
 				$script:ProgressSyncHash.Window = [Windows.Markup.XamlReader]::Load($progressReader)
+				#  Grey out the X button
+				$script:ProgressSyncHash.Window.add_Loaded({
+					$windowHandle = (New-Object -TypeName System.Windows.Interop.WindowInteropHelper -ArgumentList $this).Handle
+					If ($null -ne $windowHandle) {
+						[IntPtr]$menuHandle = [PSADT.UiAutomation]::GetSystemMenu($windowHandle, $false)
+						If ($menuHandle -ne [IntPtr]::Zero) {
+							[PSADT.UiAutomation]::EnableMenuItem($menuHandle, 0xF060, 0x00000001)
+							[PSADT.UIAutomation]::DestroyMenu($menuHandle)
+						}
+					}
+				})
+				
 				$script:ProgressSyncHash.ProgressText = $script:ProgressSyncHash.Window.FindName('ProgressText')
 				#  Add an action to the Window.Closing event handler to disable the close button
 				$script:ProgressSyncHash.Window.Add_Closing({ $_.Cancel = $true })

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -7325,11 +7325,11 @@ Function Show-InstallationProgress {
 						[IntPtr]$menuHandle = [PSADT.UiAutomation]::GetSystemMenu($windowHandle, $false)
 						If ($menuHandle -ne [IntPtr]::Zero) {
 							[PSADT.UiAutomation]::EnableMenuItem($menuHandle, 0xF060, 0x00000001)
-							[PSADT.UIAutomation]::DestroyMenu($menuHandle)
+							[PSADT.UiAutomation]::DestroyMenu($menuHandle)
 						}
 					}
 				})
-				
+				#  Prepare the ProgressText variable so we can use it to change the text in the text area
 				$script:ProgressSyncHash.ProgressText = $script:ProgressSyncHash.Window.FindName('ProgressText')
 				#  Add an action to the Window.Closing event handler to disable the close button
 				$script:ProgressSyncHash.Window.Add_Closing({ $_.Cancel = $true })


### PR DESCRIPTION
Disable/grey out the X(close) button on the Installation Progress window so the user knows the window can't be closed this way. Also disables it in the context menu.
![disabledx](https://user-images.githubusercontent.com/20016096/67159115-a8fb2a80-f340-11e9-9690-f7ab6e5d3c13.PNG)
