### PR TITLE
Fix Execute-MSI issue related to Remove-InvalidFileNameChars

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -871,7 +871,7 @@ Function Write-Log {
 }
 #endregion
 
-#region Function Get-LoggedOnUser
+#region Function Remove-InvalidFileNameChars
 Function Remove-InvalidFileNameChars {
 	<#
 	.SYNOPSIS
@@ -2342,10 +2342,10 @@ Function Execute-MSI {
 			If (-not $logName) {
 				If ($productCodeNameVersion) {
 					If ($productCodeNameVersion.Publisher) {
-						$logName = Remove-InvalidFileNameChars -Name ($productCodeNameVersion.Publisher + '_' + $productCodeNameVersion.DisplayName + '_' + $productCodeNameVersion.DisplayVersion) -replace ' ',''
+						$logName = (Remove-InvalidFileNameChars -Name ($productCodeNameVersion.Publisher + '_' + $productCodeNameVersion.DisplayName + '_' + $productCodeNameVersion.DisplayVersion)) -replace ' ',''
 					}
 					Else {
-						$logName = Remove-InvalidFileNameChars -Name ($productCodeNameVersion.DisplayName + '_' + $productCodeNameVersion.DisplayVersion) -replace ' ',''
+						$logName = (Remove-InvalidFileNameChars -Name ($productCodeNameVersion.DisplayName + '_' + $productCodeNameVersion.DisplayVersion)) -replace ' ',''
 					}
 				}
 				Else {


### PR DESCRIPTION
Execute-MSI uses Remove-InvalidFileNameChars to remove invalid chars from the name, however it then uses -replace operator to remove spaces and Powershell considers it a parameter so this PR adds brackets around the function to fix this issue.

Also fixes the comment above the Remove-InvalidFileNameChars function that specifies incorrect function.