### PR TITLE
Change default value for -Source parameter for Write-Log

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -659,7 +659,7 @@ Function Write-Log {
 		[int16]$Severity = 1,
 		[Parameter(Mandatory=$false,Position=2)]
 		[ValidateNotNull()]
-		[string]$Source = '',
+		[string]$Source = 'Unknown',
 		[Parameter(Mandatory=$false,Position=3)]
 		[ValidateNotNullorEmpty()]
 		[string]$ScriptSection = $script:installPhase,


### PR DESCRIPTION
CMTrace requires all parameters to be filled in, otherwise the highlighting doesn't work.
This PR sets the -Source to Unknown unless it is defined in the parameter.