### PR TITLE
Fix parameter description for Remove-MSIApplications

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -2593,7 +2593,7 @@ Function Remove-MSIApplications {
 .PARAMETER PassThru
 	Returns ExitCode, STDOut, and STDErr output from the process.
 .PARAMETER ContinueOnError
-	Continue if an exit code is returned by msiexec that is not recognized by the App Deploy Toolkit. Default is: $true.
+	Continue if an error occured while trying to start the processes. Default: $true.
 .EXAMPLE
 	Remove-MSIApplications -Name 'Adobe Flash'
 	Removes all versions of software that match the name "Adobe Flash"


### PR DESCRIPTION
Execute-Process was changed and Remove-MSIApplications uses it through Execute-MSI. -ContinueOnError needs a new description.