### PR TITLE
Improved handling of title variables

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitConfig.xml
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitConfig.xml
@@ -9,7 +9,7 @@
 	<!--Configuration File Details-->
 	<Config_File>
 		<Config_Version>3.8.2</Config_Version>
-		<Config_Date>13/04/2020</Config_Date>
+		<Config_Date>08/05/2020</Config_Date>
 	</Config_File>
 
 	<!--Toolkit Options-->

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitExtensions.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitExtensions.ps1
@@ -28,7 +28,7 @@ Param (
 [string]$appDeployToolkitExtName = 'PSAppDeployToolkitExt'
 [string]$appDeployExtScriptFriendlyName = 'App Deploy Toolkit Extensions'
 [version]$appDeployExtScriptVersion = [version]'3.8.2'
-[string]$appDeployExtScriptDate = '13/04/2020'
+[string]$appDeployExtScriptDate = '08/05/2020'
 [hashtable]$appDeployExtScriptParameters = $PSBoundParameters
 
 ##*===============================================

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitHelp.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitHelp.ps1
@@ -23,7 +23,7 @@
 [string]$appDeployToolkitHelpName = 'PSAppDeployToolkitHelp'
 [string]$appDeployHelpScriptFriendlyName = 'App Deploy Toolkit Help'
 [version]$appDeployHelpScriptVersion = [version]'3.8.2'
-[string]$appDeployHelpScriptDate = '13/04/2020'
+[string]$appDeployHelpScriptDate = '08/05/2020'
 
 ## Variables: Environment
 [string]$scriptDirectory = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.cs
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.cs
@@ -1,5 +1,5 @@
-﻿// Date Modified: 28-03-2020
-// Version Number: 3.8.1
+﻿// Date Modified: 08/05/2020
+// Version Number: 3.8.2
 
 using System;
 using System.Text;

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -72,7 +72,7 @@ Param (
 ## Variables: Script Info
 [version]$appDeployMainScriptVersion = [version]'3.8.2'
 [version]$appDeployMainScriptMinimumConfigVersion = [version]'3.8.2'
-[string]$appDeployMainScriptDate = '13/04/2020'
+[string]$appDeployMainScriptDate = '08/05/2020'
 [hashtable]$appDeployMainScriptParameters = $PSBoundParameters
 
 ## Variables: Datetime and Culture

--- a/Toolkit/Deploy-Application.ps1
+++ b/Toolkit/Deploy-Application.ps1
@@ -68,7 +68,7 @@ Try {
 	[string]$appLang = 'EN'
 	[string]$appRevision = '01'
 	[string]$appScriptVersion = '1.0.0'
-	[string]$appScriptDate = '13/04/2020'
+	[string]$appScriptDate = 'XX/XX/20XX'
 	[string]$appScriptAuthor = '<author name>'
 	##*===============================================
 	## Variables: Install Titles (Only set here to override defaults set by the toolkit)
@@ -84,7 +84,7 @@ Try {
 	## Variables: Script
 	[string]$deployAppScriptFriendlyName = 'Deploy Application'
 	[version]$deployAppScriptVersion = [version]'3.8.2'
-	[string]$deployAppScriptDate = '13/04/2020'
+	[string]$deployAppScriptDate = '08/05/2020'
 	[hashtable]$deployAppScriptParameters = $psBoundParameters
 
 	## Variables: Environment


### PR DESCRIPTION
Adds sanitization for $installTitle, $ReferredInstallTitle and $ReferredInstallName

Restores the previous powershell window title in Exit-Script

$app* variables no longer have all space characters removed, only the beginning and the ending ones. $installName still removes spaces from these variables, like before, because it is used for file names.

$installName changes are collapsed to one line and also removed the Remove-InvalidFileNameChars function from it, since we already use it on all variables that this variable can contain.

#491 
#264 

Includes version bump