### PR TITLE
Remove BOM from toolkit files

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitExtensions.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitExtensions.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
 	This script is a template that allows you to extend the toolkit with your own custom functions.
     # LICENSE #

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.cs
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.cs
@@ -1,4 +1,4 @@
-﻿// Date Modified: 08/05/2020
+// Date Modified: 08/05/2020
 // Version Number: 3.8.2
 
 using System;

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -251,7 +251,7 @@ If (-not (Test-Path -LiteralPath $appDeployCustomTypesSourceCode -PathType 'Leaf
 [string]$appDeployToolkitDotSourceExtensions = 'AppDeployToolkitExtensions.ps1'
 
 ## Import variables from XML configuration file
-[Xml.XmlDocument]$xmlConfigFile = Get-Content -LiteralPath $AppDeployConfigFile
+[Xml.XmlDocument]$xmlConfigFile = Get-Content -LiteralPath $AppDeployConfigFile -Encoding UTF8
 [Xml.XmlElement]$xmlConfig = $xmlConfigFile.AppDeployToolkit_Config
 #  Get Config File Details
 [Xml.XmlElement]$configConfigDetails = $xmlConfig.Config_File

--- a/Toolkit/Deploy-Application.ps1
+++ b/Toolkit/Deploy-Application.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
 	This script performs the installation or uninstallation of an application(s).
 	# LICENSE #


### PR DESCRIPTION
Removes BOM from Toolkit files that were encoded with UTF8 with BOM.
Make sure we are reading the xml file as UTF8.