### PR TITLE
Add config paths without admin rights

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitConfig.xml
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitConfig.xml
@@ -22,6 +22,12 @@
 		<!-- Registry key used to store toolkit information (with PSAppDeployToolkit as child registry key), e.g. deferral history. -->
 		<Toolkit_LogPath>$envWinDir\Logs\Software</Toolkit_LogPath>
 		<!-- Log path used for Toolkit logging. -->
+		<Toolkit_TempPathNoAdminRights>$envTemp</Toolkit_TempPathNoAdminRights>
+		<!-- Same as TempPath but used when RequireAdmin is False. -->
+		<Toolkit_RegPathNoAdminRights>HKCU:SOFTWARE</Toolkit_RegPathNoAdminRights>
+		<!-- Same as RegPath but used when RequireAdmin is False. Bear in mind that since this Registry Key should be writable without admin permission, regular users can modify it also. -->
+		<Toolkit_LogPathNoAdminRights>$envProgramData\Logs\Software</Toolkit_LogPathNoAdminRights>
+		<!-- Same as LogPath but used when RequireAdmin is False. -->
 		<Toolkit_CompressLogs>False</Toolkit_CompressLogs>
 		<!-- Specify if the log files should be bundled together in a compressed zip file -->
 		<Toolkit_LogStyle>CMTrace</Toolkit_LogStyle>
@@ -52,6 +58,8 @@
 		<!-- Logging level used for MSI logging. -->
 		<MSI_LogPath>$envWinDir\Logs\Software</MSI_LogPath>
 		<!-- Log path used for MSI logging. -->
+		<MSI_LogPathNoAdminRights>$envProgramData\Logs\Software</MSI_LogPathNoAdminRights>
+		<!-- Log path used for MSI logging when RequireAdmin is False. -->
 		<MSI_InstallParams>REBOOT=ReallySuppress /QB-!</MSI_InstallParams>
 		<!-- Installation parameters used for non-silent MSI actions. -->
 		<MSI_SilentParams>REBOOT=ReallySuppress /QN</MSI_SilentParams>

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -299,6 +299,21 @@ if ($appDeployLogoBannerHeight -gt $appDeployLogoBannerMaxHeight) {
 [string]$configMSIUninstallParams = $ExecutionContext.InvokeCommand.ExpandString($xmlConfigMSIOptions.MSI_UninstallParams)
 [string]$configMSILogDir = $ExecutionContext.InvokeCommand.ExpandString($xmlConfigMSIOptions.MSI_LogPath)
 [int32]$configMSIMutexWaitTime = $xmlConfigMSIOptions.MSI_MutexWaitTime
+#  Change paths to user accessible ones if RequireAdmin is false
+If ($configToolkitRequireAdmin -eq $false){
+	If ($xmlToolkitOptions.Toolkit_TempPathNoAdminRights) {
+		[string]$configToolkitTempPath = $ExecutionContext.InvokeCommand.ExpandString($xmlToolkitOptions.Toolkit_TempPathNoAdminRights)
+	}
+	If ($xmlToolkitOptions.Toolkit_RegPathNoAdminRights) {
+		[string]$configToolkitRegPath = $xmlToolkitOptions.Toolkit_RegPathNoAdminRights
+	}
+	If ($xmlToolkitOptions.Toolkit_LogPathNoAdminRights) {
+		[string]$configToolkitLogDir = $ExecutionContext.InvokeCommand.ExpandString($xmlToolkitOptions.Toolkit_LogPathNoAdminRights)
+	}
+	If ($xmlConfigMSIOptions.MSI_LogPathNoAdminRights) {
+		[string]$configMSILogDir = $ExecutionContext.InvokeCommand.ExpandString($xmlConfigMSIOptions.MSI_LogPathNoAdminRights)
+	}
+}
 #  Get UI Options
 [Xml.XmlElement]$xmlConfigUIOptions = $xmlConfig.UI_Options
 [string]$configInstallationUILanguageOverride = $xmlConfigUIOptions.InstallationUI_LanguageOverride
@@ -662,7 +677,7 @@ Function Write-Log {
 		[int16]$Severity = 1,
 		[Parameter(Mandatory=$false,Position=2)]
 		[ValidateNotNull()]
-		[string]$Source = 'Unknown',
+		[string]$Source = $([string]$parentFunctionName = [IO.Path]::GetFileNameWithoutExtension((Get-Variable -Name MyInvocation -Scope 1 -ErrorAction SilentlyContinue).Value.MyCommand.Name); If($parentFunctionName) {$parentFunctionName} Else {'Unknown'}),
 		[Parameter(Mandatory=$false,Position=3)]
 		[ValidateNotNullorEmpty()]
 		[string]$ScriptSection = $script:installPhase,


### PR DESCRIPTION
Adds config paths for installations where RequireAdmin is False.

Also changes default -Source value for Write-Log to a more useful value: it will be set to Parent's function name and if not inside a function then the name of the script. If not inside a function or a script, then the value will be set to 'Unknown'

#482 
#503 