### PR TITLE
Show-InstallationPrompt and Show-InstallationWelcome visual improvements

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitConfig.xml
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitConfig.xml
@@ -134,8 +134,7 @@
 		<ClosePrompt_Message>The following programs must be closed before the installation can proceed.
 
 		Please save your work, close the programs, and then continue.
-		Alternatively, save your work and click "Close Programs".
-		</ClosePrompt_Message>
+		Alternatively, save your work and click "Close Programs".</ClosePrompt_Message>
 		<!-- Text displayed when prompting to close running programs. -->
 		<ClosePrompt_CountdownMessage>NOTE: The program(s) will be automatically closed in:</ClosePrompt_CountdownMessage>
 		<!-- Text displayed when counting down to automatically closing applications. -->
@@ -209,8 +208,7 @@
 		<ClosePrompt_Message>Følgende programmer skal lukkes før installationen kan fortsætte.
 
 		Gem dit arbejde, luk programmerne og fortsæt.
-		Alternativt kan du gemme dit arbejde og trykke på "Luk Programmer".
-		</ClosePrompt_Message>
+		Alternativt kan du gemme dit arbejde og trykke på "Luk Programmer".</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>BEMÆRK: Programmet/Programmerne vil automatisk blive lukket om:</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>Følgende applikation vil nu blive installeret:</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>Du kan vælge at udsætte installationen indtil udsættelsesperioden udløber:</DeferPrompt_ExpiryMessage>
@@ -259,8 +257,7 @@
 		<ClosePrompt_Message>Les programmes suivants doivent être fermés afin que l'installation s'initialise.
 
 		Merci de sauvegarder votre travail, fermer tous les programmes, et continuer.
-		Vous pouvez aussi sauvegarder votre travail puis cliquez sur « Fermer Programmes ».
-		</ClosePrompt_Message>
+		Vous pouvez aussi sauvegarder votre travail puis cliquez sur « Fermer Programmes ».</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>REMARQUE: Les programmes seront automatiquement fermés dans:</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>L'application suivante est sur le point d'être installée:</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>Vous pouvez choisir de reporter l'installation:</DeferPrompt_ExpiryMessage>
@@ -308,8 +305,7 @@
 		<ClosePrompt_Message>Die folgenden Programme müssen geschlossen werden, bevor die Installation fortgesetzt werden kann.
 
 		Bitte speichern Sie Ihre Arbeit, schließen Sie die Programme und fahren Sie dann fort.
-		Alternativ können Sie Ihre Arbeit speichern und dann auf „Programme Schließen“ klicken.
-		</ClosePrompt_Message>
+		Alternativ können Sie Ihre Arbeit speichern und dann auf „Programme Schließen“ klicken.</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>HINWEIS: Diese Programme werden automatisch geschlossen:</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>Die folgende Anwendung soll installiert werden:</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>Sie können die Installation verzögern, bis die Rückstellung abläuft:</DeferPrompt_ExpiryMessage>
@@ -357,8 +353,7 @@
 		<ClosePrompt_Message>I seguenti programmi devono essere chiusi prima che l'installazione possa procedere.
 
 		Salvare il lavoro , chiudere i programmi, e poi continuare.
-		In alternativa, salvare il lavoro e fare clic su "Chiudi Programmi".
-		</ClosePrompt_Message>
+		In alternativa, salvare il lavoro e fare clic su "Chiudi Programmi".</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>NOTA: il programma(s) sarà chiuso automaticamente in:</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>La seguente applicazione sta per essere installata:</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>Si può decidere di posticipare l'installazione fino alla prossima richiesta automatica:</DeferPrompt_ExpiryMessage>
@@ -406,8 +401,7 @@
 		<ClosePrompt_Message>インストールを実行するために、下記のプログラムを閉じる必要があります。
 
 		実行中のアプリケーションを保存し、閉じてから続行してください。
-		または、実行中のアプリケーションを保存し、プログラムを強制終了ボタンをクリックしてくだい
-		</ClosePrompt_Message>
+		または、実行中のアプリケーションを保存し、プログラムを強制終了ボタンをクリックしてくだい</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>注意: これらのプログラムは自動的に閉じられます:</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>このアプリケーションはこれからインストールされます。</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>再試行可能回数が0になるまでは、都合の良い時にインストール可能です。</DeferPrompt_ExpiryMessage>
@@ -455,8 +449,7 @@
 		<ClosePrompt_Message>Følgende programmer må lukkes før installasjonen kan fortsette.
 
 		Lagre arbeidet, lukk programmene og velg "Fortsett"
-		Eller velg "Lukk Programmer" uten å lagre.
-		</ClosePrompt_Message>
+		Eller velg "Lukk Programmer" uten å lagre.</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>OBS: Programmet vil automatisk lukkes om:</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>Følgende program vil bli installert:</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>Du kan velge å utsette installasjonen et begrenset antall ganger inntil fristen utløper:</DeferPrompt_ExpiryMessage>
@@ -504,8 +497,7 @@
 		<ClosePrompt_Message>De volgende applicaties moeten afgesloten worden om de installatie te voltooien.
 
 		Sla je werk op, sluit de applicaties, en ga verder.
-		Of, sla je werk op en klik op 'Sluit Applicaties'.
-		</ClosePrompt_Message>
+		Of, sla je werk op en klik op 'Sluit Applicaties'.</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>LET OP: De applicatie(s) worden afgesloten over:</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>De volgende applicatie wordt zometeen geïnstalleerd:</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>Je kan de installatie uitstellen tot het maximale uitsteltermijn is verstreken:</DeferPrompt_ExpiryMessage>
@@ -553,8 +545,7 @@
 		<ClosePrompt_Message>Następujące programy muszą zostać zamknięte przed rozpoczęciem instalacji.
 
 		Proszę zapisać wszystkie dokumenty i zamknąć programy, a następnie kliknąć przycisk „Kontynuuj”.
-		Alternatywnie zapisz wszystkie dokumenty i kliknij przycisk „Zamknij Programy”.
-		</ClosePrompt_Message>
+		Alternatywnie zapisz wszystkie dokumenty i kliknij przycisk „Zamknij Programy”.</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>UWAGA: Programy zostaną automatycznie zamknięte za:</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>Zostanie zainstalowana następująca aplikacja:</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>Instalacja może zostać przełożona na późniejszy termin.</DeferPrompt_ExpiryMessage>
@@ -602,8 +593,7 @@
 		<ClosePrompt_Message>Programas de seguir devem ser fechados antes que a instalação possa prosseguir.
 
 		Por favor, guarde o seu trabalho, feche os programas e em seguida continuar.
-		Como alternativa, salve seu trabalho e clique em "Fechar Programas".
-		</ClosePrompt_Message>
+		Como alternativa, salve seu trabalho e clique em "Fechar Programas".</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>NOTA: O programa será fechado automaticamente em:</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>O seguinte aplicativo está prestes a ser instalado:</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>Você pode optar por adiar a instalação até que expire o diferimento:</DeferPrompt_ExpiryMessage>
@@ -651,8 +641,7 @@
 		<ClosePrompt_Message>Os seguintes programas precisam ser fechados antes que a instalação possa prosseguir.
 
 		Salve seu trabalho, feche os programas e depois continue.
-		Como alternativa, salve seu trabalho e clique em "Fechar Programas".
-		</ClosePrompt_Message>
+		Como alternativa, salve seu trabalho e clique em "Fechar Programas".</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>OBSERVAÇÃO: O(s) programa(s) será(ão) automaticamente fechado(s) em:</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>O seguinte aplicativo está prestes a ser instalado:</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>Você pode optar por adiar a instalação até que o adiamento expire:</DeferPrompt_ExpiryMessage>
@@ -700,8 +689,7 @@
 		<ClosePrompt_Message>Los siguientes programas deben cerrarse antes de la instalación puede proceder.
 
 		Por favor, guarde el trabajo, cerrar los programas y luego continuar.
-		Alternativamente, guarde su trabajo y haga clic en "Cerrar Programas".
-		</ClosePrompt_Message>
+		Alternativamente, guarde su trabajo y haga clic en "Cerrar Programas".</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>NOTA: El programa se cerrará automáticamente en:</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>La siguiente aplicación está a punto de instalarse:</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>Puede decidir aplazar la instalación hasta que expire el aplazamiento:</DeferPrompt_ExpiryMessage>
@@ -749,8 +737,7 @@
 		<ClosePrompt_Message>Följande program måste stängas innan installationen kan fortsätta.
 
 		Se till att spara ditt arbete, stäng de öppna programmen och klicka sen på "Fortsätt".
-		Alternativt, spara ditt arbete och klicka på "Stäng Program".
-		</ClosePrompt_Message>
+		Alternativt, spara ditt arbete och klicka på "Stäng Program".</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>OBS: Programmen kommer automatiskt att avslutas om:</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>Följande applikation kommer att installeras:</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>Du kan välja att fördröja installationen ett begränsat antal gånger under en begränsad tid:</DeferPrompt_ExpiryMessage>
@@ -798,8 +785,7 @@
 		<ClosePrompt_Message>يجب إغلاق البرامج التالية قبل التمكن من متابعة عملية التثبيت.
 
 		يرجى حفظ عملك، وإغلاق البرامج، ومن ثم المتابعة.
-		يمكنك بدلا من ذلك، حفظ عملك والنقر فوق "إغلاق البرامج".
-		</ClosePrompt_Message>
+		يمكنك بدلا من ذلك، حفظ عملك والنقر فوق "إغلاق البرامج".</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>ملاحظة: سيتم إغلاق البرنامج/البرامج بشكل تلقائي خلال:</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>التطبيق التالي على وشك التثبيت:</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>بإمكانك اختيار تأجيل التثبيت إلى حين انتهاء صلاحية التأجيل:</DeferPrompt_ExpiryMessage>
@@ -847,8 +833,7 @@
 		<ClosePrompt_Message>יש לסגור את התכנות הבאות בטרם ההתקנה תוכל להתחיל.
 
 		אנא שמור על העבודה שלך, סגור את התכניות, ואז המשך.
-		לחילופין, שמור על העבודה שלך והקלק על "סגור תכניות".
-		</ClosePrompt_Message>
+		לחילופין, שמור על העבודה שלך והקלק על "סגור תכניות".</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>שים לב: התכנית(ות) תסגרנה באופן אוטומטי תוך:</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>היישום הבא עומד להיות מותקן:</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>אתה יכול לבחור לדחות את ההתקנה עד שמשך זמן הדחיה יפוג.</DeferPrompt_ExpiryMessage>
@@ -896,8 +881,7 @@
 		<ClosePrompt_Message>설치를 계속하려면 다음의 프로그램을 종료해야 합니다.
 
 		사용자 작업을 저장하고 프로그램을 종료한 후 계속하세요.
-		다른 방법으로는 사용자 작업을 저장하고 "프로그램 종료"를 클릭하세요.
-		</ClosePrompt_Message>
+		다른 방법으로는 사용자 작업을 저장하고 "프로그램 종료"를 클릭하세요.</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>참고: 프로그램이 자동으로 종료되는 경우:</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>다음의 응용 프로그램을 설치합니다:</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>지연 기간이 만료될 때까지 설치를 연기할 수 있습니다:</DeferPrompt_ExpiryMessage>
@@ -945,8 +929,7 @@
 		<ClosePrompt_Message>Перед продолжением установки необходимо закрыть следующие программы.
 
 		Пожалуйста, сохраните вашу работу и закройте программы, а затем продолжите установку.
-		Также вы можете сохранить вашу работу и нажать "Закрыть программы".
-		</ClosePrompt_Message>
+		Также вы можете сохранить вашу работу и нажать "Закрыть программы".</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>ПРИМЕЧАНИЕ: Эти программы будут автоматически закрыты через:</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>Планируется установка следующего приложения:</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>Вы можете отложить установку приложения до тех пор, пока не истечет срок действия этой отсрочки:</DeferPrompt_ExpiryMessage>
@@ -994,8 +977,7 @@
 		<ClosePrompt_Message>为继续安装，必须关闭下列程序。
 
 		请保存您的工作，关闭程序，然后继续。
-		或者保存您的工作，点击"关闭程序"。
-		</ClosePrompt_Message>
+		或者保存您的工作，点击"关闭程序"。</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>注：下列程序将自动关闭：</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>即将安装下列应用程式：</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>在延期失效前，可选择延迟安装：</DeferPrompt_ExpiryMessage>
@@ -1043,8 +1025,7 @@
 		<ClosePrompt_Message>在繼續安裝前必須關閉下列程序。
 
 		請保存您的工作，關閉程序，然後繼續。
-		或者保存您的工作，然後點擊"關閉程序"。
-		</ClosePrompt_Message>
+		或者保存您的工作，然後點擊"關閉程序"。</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>注：下列程序將自動關閉：</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>即將安裝下列應用程式：</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>在延期失效前，可選擇延遲安裝：</DeferPrompt_ExpiryMessage>
@@ -1092,8 +1073,7 @@
 		<ClosePrompt_Message>Nasledujúce programy musia byť zatvorené, než bude inštalácia pokračovať.
 
 		Prosím, uložte svoju prácu, zatvorte dané programy a potom kliknite na pokračovať.
-		Prípadne môžete uložiť svoju prácu a potom kliknite na tlačidlo "Ukončiť programy".
-		</ClosePrompt_Message>
+		Prípadne môžete uložiť svoju prácu a potom kliknite na tlačidlo "Ukončiť programy".</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>Poznámka: Programy budú automaticky ukončené za:</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>Nasledujúca aplikácia bude nainštalovaná:</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>Inštaláciu môžete niekoľkokrát odložiť:</DeferPrompt_ExpiryMessage>
@@ -1141,8 +1121,7 @@
 		<ClosePrompt_Message>Následující programy musí být zavřené, aby instalace mohla pokračovat.
 
 		Prosím, uložte svou práci, zavřete program a potom klikněte na "Pokračovat".
-		Případně můžete svou práci uložit a kliknout na tlačítko "Ukončit programy".
-		</ClosePrompt_Message>
+		Případně můžete svou práci uložit a kliknout na tlačítko "Ukončit programy".</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>Upozornění: Programy budou automaticky zavřené za:</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>Nasledující aplikace bude nainstalována:</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>Instalaci můžete několikrát odložit:</DeferPrompt_ExpiryMessage>
@@ -1189,8 +1168,7 @@
 
 		Kérjük mentse munkáját és a folytatáshoz zárja be a futó alkalmazásokat.
 		Vagy
-		Kérjük mentse munkáját és kattintson a „Programok bezárása”-ra.
-		</ClosePrompt_Message>
+		Kérjük mentse munkáját és kattintson a „Programok bezárása”-ra.</ClosePrompt_Message>
 		<ClosePrompt_CountdownMessage>Megjegyzés: a programok automatikusan bezárásra kerülnek,:</ClosePrompt_CountdownMessage>
 		<DeferPrompt_WelcomeMessage>A következő alkalmazások telepítésre kerülnek:</DeferPrompt_WelcomeMessage>
 		<DeferPrompt_ExpiryMessage>A telepítést elhalaszthatja amíg a rendelkezésre álló idő lejár:</DeferPrompt_ExpiryMessage>

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -6665,7 +6665,7 @@ Function Show-WelcomePrompt {
 		$labelAppName.Size = $defaultControlSize
 		$labelAppName.MinimumSize = $defaultControlSize
 		$labelAppName.MaximumSize = $defaultControlSize
-		$labelAppName.Margin = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 0,5,0,2
+		$labelAppName.Margin = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 0,5,0,5
 		$labelAppName.Padding = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 10,0,10,0
 		$labelAppName.TabIndex = 1
 
@@ -6674,7 +6674,7 @@ Function Show-WelcomePrompt {
 		If ($showCloseApps) {
 			$labelAppNameText = "$labelAppNameText`n`n$configClosePromptMessage"
 		}
-		If ($CustomText) {
+		If ($CustomText -and $configWelcomePromptCustomMessage) {
 			$labelAppNameText = "$labelAppNameText`n`n$configWelcomePromptCustomMessage"
 		}
 		$labelAppName.Text = $labelAppNameText
@@ -6700,7 +6700,7 @@ Function Show-WelcomePrompt {
 		$labelDefer.Size = $defaultControlSize
 		$labelDefer.MinimumSize = $defaultControlSize
 		$labelDefer.MaximumSize = $defaultControlSize
-		$labelDefer.Margin = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 0,2,0,5
+		$labelDefer.Margin = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 0,0,0,5
 		$labelDefer.Padding = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 10,0,10,0
 		$labelDefer.TabIndex = 4
 		$deferralText = "$configDeferPromptExpiryMessage`n"

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1517,12 +1517,16 @@ Function Show-InstallationPrompt {
 		[Windows.Forms.Application]::EnableVisualStyles()
 		$formInstallationPrompt = New-Object -TypeName 'System.Windows.Forms.Form'
 		$pictureBanner = New-Object -TypeName 'System.Windows.Forms.PictureBox'
-		$pictureIcon = New-Object -TypeName 'System.Windows.Forms.PictureBox'
+		If ($Icon -ne 'None') {
+			$pictureIcon = New-Object -TypeName 'System.Windows.Forms.PictureBox'
+		}
 		$labelText = New-Object -TypeName 'System.Windows.Forms.Label'
 		$buttonRight = New-Object -TypeName 'System.Windows.Forms.Button'
 		$buttonMiddle = New-Object -TypeName 'System.Windows.Forms.Button'
 		$buttonLeft = New-Object -TypeName 'System.Windows.Forms.Button'
 		$buttonAbort = New-Object -TypeName 'System.Windows.Forms.Button'
+		$flowLayoutPanel = New-Object -TypeName 'System.Windows.Forms.FlowLayoutPanel'
+		$panelButtons = New-Object -TypeName 'System.Windows.Forms.Panel'
 		$InitialFormInstallationPromptWindowState = New-Object -TypeName 'System.Windows.Forms.FormWindowState'
 
 		[scriptblock]$Form_Cleanup_FormClosed = {
@@ -1562,73 +1566,59 @@ Function Show-InstallationPrompt {
 		## Create padding object
 		$paddingNone = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 0,0,0,0
 
+		## Default control size
+		$DefaultControlSize = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 450,0
+
 		## Generic Button properties
-		$buttonSize = New-Object -TypeName 'System.Drawing.Size'
-		$buttonSize.Width = 110
-		$buttonSize.Height = 23
-		$buttonPadding = New-Object -TypeName 'System.Windows.Forms.Padding'
-		$buttonPadding.Top = 0
-		$buttonPadding.Bottom = 5
-		$buttonPadding.Left = 50
-		$buttonPadding.Right = 0
+		$buttonSize = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 110,24
 
 		## Picture Banner
 		$pictureBanner.DataBindings.DefaultDataSourceUpdateMode = 0
 		$pictureBanner.ImageLocation = $appDeployLogoBanner
-		$System_Drawing_Point = New-Object -TypeName 'System.Drawing.Point' -ArgumentList 0,0
-		$pictureBanner.Location = $System_Drawing_Point
-		$pictureBanner.Name = 'pictureBanner'
-		$System_Drawing_Size = New-Object -TypeName 'System.Drawing.Size'
-		$System_Drawing_Size.Height = $appDeployLogoBannerHeight
-		$System_Drawing_Size.Width = 450
-		$pictureBanner.Size = $System_Drawing_Size
+		$pictureBanner.Size = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 450,$appDeployLogoBannerHeight
+        $pictureBanner.MinimumSize = $DefaultControlSize
 		$pictureBanner.SizeMode = 'CenterImage'
 		$pictureBanner.Margin = $paddingNone
 		$pictureBanner.TabIndex = 0
 		$pictureBanner.TabStop = $false
+		$pictureBanner.Location = New-Object -TypeName 'System.Drawing.Point' -ArgumentList 0,0
 
 		## Picture Icon
-		$pictureIcon.DataBindings.DefaultDataSourceUpdateMode = 0
-		If ($icon -ne 'None') { $pictureIcon.Image = ([Drawing.SystemIcons]::$Icon).ToBitmap() }
-		$System_Drawing_Point = New-Object -TypeName 'System.Drawing.Point'
-		$System_Drawing_Point.X = 15
-		$System_Drawing_Point.Y = 105 + $appDeployLogoBannerHeightDifference
-		$pictureIcon.Location = $System_Drawing_Point
-		$pictureIcon.Name = 'pictureIcon'
-		$System_Drawing_Size = New-Object -TypeName 'System.Drawing.Size'
-		$System_Drawing_Size.Height = 32
-		$System_Drawing_Size.Width = 32
-		$pictureIcon.Size = $System_Drawing_Size
-		$pictureIcon.AutoSize = $true
-		$pictureIcon.Margin = $paddingNone
-		$pictureIcon.TabIndex = 0
-		$pictureIcon.TabStop = $false
+		If ($Icon -ne 'None') {
+			$pictureIcon.DataBindings.DefaultDataSourceUpdateMode = 0
+			$pictureIcon.Image = ([Drawing.SystemIcons]::$Icon).ToBitmap()
+			$pictureIcon.Name = 'pictureIcon'
+			$pictureIcon.MinimumSize = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 60,32
+			$pictureIcon.Size = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 60,32
+			$pictureIcon.SizeMode = "CenterImage"
+			$pictureIcon.TabIndex = 0
+			$pictureIcon.TabStop = $false
+			$pictureIcon.Anchor = 'None'
+            $pictureIcon.Margin = $paddingNone
+		}
 
 		## Label Text
 		$labelText.DataBindings.DefaultDataSourceUpdateMode = 0
 		$labelText.Name = 'labelText'
-		$System_Drawing_Size = New-Object -TypeName 'System.Drawing.Size'
-		$System_Drawing_Size.Height = 148
-		$System_Drawing_Size.Width = 385
+		$System_Drawing_Size = New-Object -TypeName 'System.Drawing.Size' 390,0
 		$labelText.Size = $System_Drawing_Size
-		$System_Drawing_Point = New-Object -TypeName 'System.Drawing.Point'
-		$System_Drawing_Point.X = 25
-		$System_Drawing_Point.Y = $appDeployLogoBannerHeight
-		$labelText.Location = $System_Drawing_Point
-		$labelText.Margin = '0,0,0,0'
-		$labelText.Padding = '40,0,20,0'
+		$labelText.MinimumSize = $System_Drawing_Size
+		$labelText.MaximumSize = $System_Drawing_Size
+		$labelText.AutoSize = $true
+		$labelText.Margin = $paddingNone
+		$labelText.Padding = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 0,10,10,10
 		$labelText.TabIndex = 1
 		$labelText.Text = $message
 		$labelText.TextAlign = "Middle$($MessageAlignment)"
-		$labelText.Anchor = 'Top'
+		$labelText.Anchor = 'None'
 		$labelText.add_Click($handler_labelText_Click)
 
-		# Generic Y location for buttons
-		$buttonLocationY = 200 + $appDeployLogoBannerHeightDifference
-
+		If ($Icon -ne 'None') {
+			# Add margin for the icon based on labelText Height so its centered
+			$pictureIcon.Height = $labelText.Height
+		}
 		## Button Left
 		$buttonLeft.DataBindings.DefaultDataSourceUpdateMode = 0
-		$buttonLeft.Location = "15,$buttonLocationY"
 		$buttonLeft.Name = 'buttonLeft'
 		$buttonLeft.Size = $buttonSize
 		$buttonLeft.TabIndex = 5
@@ -1636,11 +1626,11 @@ Function Show-InstallationPrompt {
 		$buttonLeft.DialogResult = 'No'
 		$buttonLeft.AutoSize = $false
 		$buttonLeft.UseVisualStyleBackColor = $true
+		$buttonLeft.Location = "15,5"
 		$buttonLeft.add_Click($buttonLeft_OnClick)
 
 		## Button Middle
 		$buttonMiddle.DataBindings.DefaultDataSourceUpdateMode = 0
-		$buttonMiddle.Location = "170,$buttonLocationY"
 		$buttonMiddle.Name = 'buttonMiddle'
 		$buttonMiddle.Size = $buttonSize
 		$buttonMiddle.TabIndex = 6
@@ -1648,11 +1638,11 @@ Function Show-InstallationPrompt {
 		$buttonMiddle.DialogResult = 'Ignore'
 		$buttonMiddle.AutoSize = $true
 		$buttonMiddle.UseVisualStyleBackColor = $true
+        $buttonMiddle.Location = "170,5"
 		$buttonMiddle.add_Click($buttonMiddle_OnClick)
 
 		## Button Right
 		$buttonRight.DataBindings.DefaultDataSourceUpdateMode = 0
-		$buttonRight.Location = "325,$buttonLocationY"
 		$buttonRight.Name = 'buttonRight'
 		$buttonRight.Size = $buttonSize
 		$buttonRight.TabIndex = 7
@@ -1660,6 +1650,7 @@ Function Show-InstallationPrompt {
 		$buttonRight.DialogResult = 'Yes'
 		$buttonRight.AutoSize = $true
 		$buttonRight.UseVisualStyleBackColor = $true
+		$buttonRight.Location = "325,5"
 		$buttonRight.add_Click($buttonRight_OnClick)
 
 		## Button Abort (Hidden)
@@ -1668,18 +1659,59 @@ Function Show-InstallationPrompt {
 		$buttonAbort.Size = '1,1'
 		$buttonAbort.DialogResult = 'Abort'
 		$buttonAbort.TabStop = $false
+		$buttonAbort.Visible = $false
 		$buttonAbort.UseVisualStyleBackColor = $true
+        $buttonAbort.Location = "0,0"
 		$buttonAbort.add_Click($buttonAbort_OnClick)
 
+		## FlowLayoutPanel
+		$flowLayoutPanel.MinimumSize = $DefaultControlSize
+		$flowLayoutPanel.MaximumSize = $DefaultControlSize
+		$flowLayoutPanel.Size = $DefaultControlSize
+		$flowLayoutPanel.AutoSize = $true
+		$flowLayoutPanel.Anchor = 'Top,Left'
+		$flowLayoutPanel.FlowDirection = 'LeftToRight'
+		$flowLayoutPanel.WrapContents = $true
+        $flowLayoutPanel.Margin = $paddingNone
+		If ($Icon -ne 'None') {
+			$flowLayoutPanel.Controls.Add($pictureIcon)
+		}
+		$flowLayoutPanel.Controls.Add($labelText)
+		$flowLayoutPanel.Location = New-Object -TypeName 'System.Drawing.Point' -ArgumentList 0,$appDeployLogoBannerHeight
+		## Make sure label text is positioned correctly
+		If ($Icon -ne 'None') {
+            $pictureIcon.Location = New-Object -TypeName 'System.Drawing.Point' -ArgumentList 0,0
+			$labelText.Location =  New-Object -TypeName 'System.Drawing.Point' -ArgumentList 60,0
+		} else {
+			$labelText.MinimumSize = $DefaultControlSize
+			$labelText.MaximumSize = $DefaultControlSize
+			$labelText.Size = $DefaultControlSize
+			$labelText.Location =  New-Object -TypeName 'System.Drawing.Point' -ArgumentList 0,0
+		}
+		$flowLayoutPanel.Controls.Add($buttonAbort)
+
+		## ButtonsPanel
+		$panelButtons.MinimumSize = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 450,34
+		$panelButtons.Size = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 450,34
+		$panelButtons.Padding = $paddingNone
+		$panelButtons.Margin = $paddingNone
+		$panelButtons.MaximumSize = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 450,34
+		$panelButtons.AutoSize = $true
+		If ($buttonLeftText) { $panelButtons.Controls.Add($buttonLeft) }
+		If ($buttonMiddleText) { $panelButtons.Controls.Add($buttonMiddle) }
+		If ($buttonRightText) { $panelButtons.Controls.Add($buttonRight) }
+		## Add the ButtonsPanel to the flowLayoutPanel if any buttons are present
+		If ($buttonLeftText -or $buttonMiddleText -or $buttonRightText) {
+			$flowLayoutPanel.Controls.Add($panelButtons)
+		}
+
 		## Form Installation Prompt
-		$System_Drawing_Size = New-Object -TypeName 'System.Drawing.Size'
-		$System_Drawing_Size.Height = 270 + $appDeployLogoBannerHeightDifference
-		$System_Drawing_Size.Width = 450
-		$formInstallationPrompt.Size = $System_Drawing_Size
-		$formInstallationPrompt.Padding = '0,0,0,10'
+		$formInstallationPrompt.MinimumSize = $DefaultControlSize
+        $formInstallationPrompt.Size = $DefaultControlSize
+		$formInstallationPrompt.Padding = $paddingNone
 		$formInstallationPrompt.Margin = $paddingNone
 		$formInstallationPrompt.DataBindings.DefaultDataSourceUpdateMode = 0
-		$formInstallationPrompt.Name = 'WelcomeForm'
+		$formInstallationPrompt.Name = 'InstallPromptForm'
 		$formInstallationPrompt.Text = $title
 		$formInstallationPrompt.StartPosition = 'CenterScreen'
 		$formInstallationPrompt.FormBorderStyle = 'FixedDialog'
@@ -1687,15 +1719,10 @@ Function Show-InstallationPrompt {
 		$formInstallationPrompt.MinimizeBox = $false
 		$formInstallationPrompt.TopMost = $true
 		$formInstallationPrompt.TopLevel = $true
+		$formInstallationPrompt.AutoSize = $true
 		$formInstallationPrompt.Icon = New-Object -TypeName 'System.Drawing.Icon' -ArgumentList $AppDeployLogoIcon
 		$formInstallationPrompt.Controls.Add($pictureBanner)
-		$formInstallationPrompt.Controls.Add($pictureIcon)
-		$formInstallationPrompt.Controls.Add($labelText)
-		$formInstallationPrompt.Controls.Add($buttonAbort)
-		If ($buttonLeftText) { $formInstallationPrompt.Controls.Add($buttonLeft) }
-		If ($buttonMiddleText) { $formInstallationPrompt.Controls.Add($buttonMiddle) }
-		If ($buttonRightText) { $formInstallationPrompt.Controls.Add($buttonRight) }
-
+		$formInstallationPrompt.Controls.Add($flowLayoutPanel)
 		## Timer
 		$timer = New-Object -TypeName 'System.Windows.Forms.Timer'
 		$timer.Interval = ($timeout * 1000)
@@ -6643,12 +6670,12 @@ Function Show-WelcomePrompt {
 		$labelAppName.TabIndex = 1
 
 		## Initial form layout: Close Applications / Allow Deferral
-		$labelAppNameText = "$configDeferPromptWelcomeMessage `n$installTitle"
+		$labelAppNameText = "$configDeferPromptWelcomeMessage`n`n$installTitle"
 		If ($showCloseApps) {
-			$labelAppNameText = "$labelAppNameText `n`n$configClosePromptMessage"
+			$labelAppNameText = "$labelAppNameText`n`n$configClosePromptMessage"
 		}
 		If ($CustomText) {
-			$labelAppNameText = "$labelAppNameText `n`n$configWelcomePromptCustomMessage"
+			$labelAppNameText = "$labelAppNameText`n`n$configWelcomePromptCustomMessage"
 		}
 		$labelAppName.Text = $labelAppNameText
 		$labelAppName.TextAlign = 'MiddleCenter'
@@ -6674,7 +6701,7 @@ Function Show-WelcomePrompt {
 		$labelDefer.MinimumSize = $defaultControlSize
 		$labelDefer.MaximumSize = $defaultControlSize
 		$labelDefer.Margin = $paddingNone
-		$labelDefer.Padding = '0,0,0,0'
+		$labelDefer.Padding = '0,0,0,5'
 		$labelDefer.TabIndex = 4
 		$deferralText = "$configDeferPromptExpiryMessage`n"
 
@@ -6699,7 +6726,7 @@ Function Show-WelcomePrompt {
 		$labelCountdown.Size = $defaultControlSize
 		$labelCountdown.MinimumSize = $defaultControlSize
 		$labelCountdown.MaximumSize = $defaultControlSize
-		$labelCountdown.Margin = "0,5,0,5"
+		$labelCountdown.Margin = "0,0,0,5"
 		$labelCountdown.Padding = $paddingNone
 		$labelCountdown.TabIndex = 4
 		$labelCountdown.Font = New-Object -TypeName "System.Drawing.Font" -ArgumentList $labelCountdown.Font,1
@@ -6711,6 +6738,7 @@ Function Show-WelcomePrompt {
 		## Panel Flow Layout
 		$System_Drawing_Point = New-Object -TypeName 'System.Drawing.Point' -ArgumentList 0,$appDeployLogoBannerHeight
 		$flowLayoutPanel.Location = $System_Drawing_Point
+		$flowLayoutPanel.Margin = $paddingNone
 		$flowLayoutPanel.AutoSize = $true
 		$flowLayoutPanel.Anchor = 'Top'
 		$flowLayoutPanel.FlowDirection = 'TopDown'
@@ -6722,7 +6750,7 @@ Function Show-WelcomePrompt {
 
 		## Button Close For Me
 		$buttonCloseApps.DataBindings.DefaultDataSourceUpdateMode = 0
-		$buttonCloseApps.Location = '15,0'
+		$buttonCloseApps.Location = '15,5'
 		$buttonCloseApps.Name = 'buttonCloseApps'
 		$buttonCloseApps.Size = $buttonSize
 		$buttonCloseApps.TabIndex = 5
@@ -6735,10 +6763,10 @@ Function Show-WelcomePrompt {
 		## Button Defer
 		$buttonDefer.DataBindings.DefaultDataSourceUpdateMode = 0
 		If (-not $showCloseApps) {
-			$buttonDefer.Location = '15,0'
+			$buttonDefer.Location = '15,5'
 		}
 		Else {
-			$buttonDefer.Location = '170,0'
+			$buttonDefer.Location = '170,5'
 		}
 		$buttonDefer.Name = 'buttonDefer'
 		$buttonDefer.Size = $buttonSize
@@ -6751,7 +6779,7 @@ Function Show-WelcomePrompt {
 
 		## Button Continue
 		$buttonContinue.DataBindings.DefaultDataSourceUpdateMode = 0
-		$buttonContinue.Location = '325,0'
+		$buttonContinue.Location = '325,5'
 		$buttonContinue.Name = 'buttonContinue'
 		$buttonContinue.Size = $buttonSize
 		$buttonContinue.TabIndex = 7
@@ -6782,6 +6810,7 @@ Function Show-WelcomePrompt {
 
 		## Form Welcome
 		$formWelcome.Size = $defaultControlSize
+		$formWelcome.MinimumSize = $defaultControlSize
 		$formWelcome.Padding = $paddingNone
 		$formWelcome.Margin = $paddingNone
 		$formWelcome.DataBindings.DefaultDataSourceUpdateMode = 0
@@ -6798,11 +6827,12 @@ Function Show-WelcomePrompt {
 		$formWelcome.Controls.Add($pictureBanner)
 
 		## Panel Button
-		$panelButtons.Size = $defaultControlSize
+		$panelButtons.MinimumSize = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 450,34
+		$panelButtons.Size = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 450,34
+		$panelButtons.MaximumSize = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 450,34
 		$panelButtons.AutoSize = $true
 		$panelButtons.Padding = $paddingNone
 		$panelButtons.Margin = $paddingNone
-		$panelButtons.MaximumSize = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 450,40
 		If ($showCloseApps) { $panelButtons.Controls.Add($buttonCloseApps) }
 		If ($showDefer) { $panelButtons.Controls.Add($buttonDefer) }
 		$panelButtons.Controls.Add($buttonContinue)
@@ -9146,7 +9176,7 @@ Function Test-Battery {
 		}
 		$SystemTypePowerStatus.Add('BatteryLifePercent', $PowerStatus.BatteryLifePercent)
 
-		## The reported approximate number of seconds of battery life remaining. It will report –1 if the remaining life is unknown because the system is on AC power.
+		## The reported approximate number of seconds of battery life remaining. It will report -1 if the remaining life is unknown because the system is on AC power.
 		[int32]$BatteryLifeRemaining = $PowerStatus.BatteryLifeRemaining
 		$SystemTypePowerStatus.Add('BatteryLifeRemaining', $PowerStatus.BatteryLifeRemaining)
 

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1588,8 +1588,9 @@ Function Show-InstallationPrompt {
 			$pictureIcon.DataBindings.DefaultDataSourceUpdateMode = 0
 			$pictureIcon.Image = ([Drawing.SystemIcons]::$Icon).ToBitmap()
 			$pictureIcon.Name = 'pictureIcon'
-			$pictureIcon.MinimumSize = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 60,32
-			$pictureIcon.Size = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 60,32
+			$pictureIcon.MinimumSize = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 64,32
+			$pictureIcon.Size = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 64,32
+			$pictureIcon.Padding = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 24,0,8,0
 			$pictureIcon.SizeMode = "CenterImage"
 			$pictureIcon.TabIndex = 0
 			$pictureIcon.TabStop = $false
@@ -1600,13 +1601,12 @@ Function Show-InstallationPrompt {
 		## Label Text
 		$labelText.DataBindings.DefaultDataSourceUpdateMode = 0
 		$labelText.Name = 'labelText'
-		$System_Drawing_Size = New-Object -TypeName 'System.Drawing.Size' 390,0
+		$System_Drawing_Size = New-Object -TypeName 'System.Drawing.Size' 386,0
 		$labelText.Size = $System_Drawing_Size
 		$labelText.MinimumSize = $System_Drawing_Size
 		$labelText.MaximumSize = $System_Drawing_Size
 		$labelText.AutoSize = $true
 		$labelText.Margin = $paddingNone
-		$labelText.Padding = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 5,5,5,5
 		$labelText.TabIndex = 1
 		$labelText.Text = $message
 		$labelText.TextAlign = "Middle$($MessageAlignment)"
@@ -1677,18 +1677,20 @@ Function Show-InstallationPrompt {
 			$flowLayoutPanel.Controls.Add($pictureIcon)
 		}
 		$flowLayoutPanel.Controls.Add($labelText)
-		$flowLayoutPanel.Location = New-Object -TypeName 'System.Drawing.Point' -ArgumentList 0,$appDeployLogoBannerHeight
 		## Make sure label text is positioned correctly
 		If ($Icon -ne 'None') {
+			$labelText.Padding = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 0,5,10,5
             $pictureIcon.Location = New-Object -TypeName 'System.Drawing.Point' -ArgumentList 0,0
-			$labelText.Location =  New-Object -TypeName 'System.Drawing.Point' -ArgumentList 60,0
+			$labelText.Location =  New-Object -TypeName 'System.Drawing.Point' -ArgumentList 64,0
 		} else {
+			$labelText.Padding = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 10,5,10,5
 			$labelText.MinimumSize = $DefaultControlSize
 			$labelText.MaximumSize = $DefaultControlSize
 			$labelText.Size = $DefaultControlSize
 			$labelText.Location =  New-Object -TypeName 'System.Drawing.Point' -ArgumentList 0,0
 		}
 		$flowLayoutPanel.Controls.Add($buttonAbort)
+		$flowLayoutPanel.Location = New-Object -TypeName 'System.Drawing.Point' -ArgumentList 0,$appDeployLogoBannerHeight
 
 		## ButtonsPanel
 		$panelButtons.MinimumSize = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 450,34
@@ -6642,9 +6644,7 @@ Function Show-WelcomePrompt {
 		$defaultControlSize = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 450,0
 
 		## Generic Button properties
-		$buttonSize = New-Object -TypeName 'System.Drawing.Size'
-		$buttonSize.Width = 110
-		$buttonSize.Height = 24
+		$buttonSize = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 110,24
 
 		## Picture Banner
 		$pictureBanner.DataBindings.DefaultDataSourceUpdateMode = 0
@@ -6665,8 +6665,8 @@ Function Show-WelcomePrompt {
 		$labelAppName.Size = $defaultControlSize
 		$labelAppName.MinimumSize = $defaultControlSize
 		$labelAppName.MaximumSize = $defaultControlSize
-		$labelAppName.Margin = '0,5,0,5'
-		$labelAppName.Padding = $paddingNone
+		$labelAppName.Margin = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 0,5,0,2
+		$labelAppName.Padding = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 10,0,10,0
 		$labelAppName.TabIndex = 1
 
 		## Initial form layout: Close Applications / Allow Deferral
@@ -6690,7 +6690,7 @@ Function Show-WelcomePrompt {
 		$listBoxCloseApps.Name = 'listBoxCloseApps'
 		$System_Drawing_Size = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 400,100
 		$listBoxCloseApps.Size = $System_Drawing_Size
-		$listBoxCloseApps.Margin = '25,0,0,0'
+		$listBoxCloseApps.Margin = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 25,0,0,0
 		$listBoxCloseApps.TabIndex = 3
 		$ProcessDescriptions | ForEach-Object { $null = $listboxCloseApps.Items.Add($_) }
 
@@ -6700,8 +6700,8 @@ Function Show-WelcomePrompt {
 		$labelDefer.Size = $defaultControlSize
 		$labelDefer.MinimumSize = $defaultControlSize
 		$labelDefer.MaximumSize = $defaultControlSize
-		$labelDefer.Margin = $paddingNone
-		$labelDefer.Padding = '0,0,0,5'
+		$labelDefer.Margin = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 0,2,0,5
+		$labelDefer.Padding = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 10,0,10,0
 		$labelDefer.TabIndex = 4
 		$deferralText = "$configDeferPromptExpiryMessage`n"
 
@@ -6726,8 +6726,8 @@ Function Show-WelcomePrompt {
 		$labelCountdown.Size = $defaultControlSize
 		$labelCountdown.MinimumSize = $defaultControlSize
 		$labelCountdown.MaximumSize = $defaultControlSize
-		$labelCountdown.Margin = "0,0,0,5"
-		$labelCountdown.Padding = $paddingNone
+		$labelCountdown.Margin = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 0,0,0,5
+		$labelCountdown.Padding = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 10,0,10,0
 		$labelCountdown.TabIndex = 4
 		$labelCountdown.Font = New-Object -TypeName "System.Drawing.Font" -ArgumentList $labelCountdown.Font,1
 		$labelCountdown.Text = '00:00:00'
@@ -6750,7 +6750,7 @@ Function Show-WelcomePrompt {
 
 		## Button Close For Me
 		$buttonCloseApps.DataBindings.DefaultDataSourceUpdateMode = 0
-		$buttonCloseApps.Location = '15,5'
+		$buttonCloseApps.Location = New-Object -TypeName 'System.Drawing.Point' -ArgumentList 15,5
 		$buttonCloseApps.Name = 'buttonCloseApps'
 		$buttonCloseApps.Size = $buttonSize
 		$buttonCloseApps.TabIndex = 5
@@ -6763,10 +6763,10 @@ Function Show-WelcomePrompt {
 		## Button Defer
 		$buttonDefer.DataBindings.DefaultDataSourceUpdateMode = 0
 		If (-not $showCloseApps) {
-			$buttonDefer.Location = '15,5'
+			$buttonDefer.Location = New-Object -TypeName 'System.Drawing.Point' -ArgumentList 15,5
 		}
 		Else {
-			$buttonDefer.Location = '170,5'
+			$buttonDefer.Location = New-Object -TypeName 'System.Drawing.Point' -ArgumentList 170,5
 		}
 		$buttonDefer.Name = 'buttonDefer'
 		$buttonDefer.Size = $buttonSize
@@ -6779,7 +6779,7 @@ Function Show-WelcomePrompt {
 
 		## Button Continue
 		$buttonContinue.DataBindings.DefaultDataSourceUpdateMode = 0
-		$buttonContinue.Location = '325,5'
+		$buttonContinue.Location = New-Object -TypeName 'System.Drawing.Point' -ArgumentList 325,5
 		$buttonContinue.Name = 'buttonContinue'
 		$buttonContinue.Size = $buttonSize
 		$buttonContinue.TabIndex = 7
@@ -6800,7 +6800,7 @@ Function Show-WelcomePrompt {
 		## Button Abort (Hidden)
 		$buttonAbort.DataBindings.DefaultDataSourceUpdateMode = 0
 		$buttonAbort.Name = 'buttonAbort'
-		$buttonAbort.Size = '1,1'
+		$buttonAbort.Size = New-Object -TypeName 'System.Drawing.Size' -ArgumentList 1,1
 		$buttonAbort.TabStop = $false
 		$buttonAbort.DialogResult = 'Abort'
 		$buttonAbort.TabIndex = 5

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1606,7 +1606,7 @@ Function Show-InstallationPrompt {
 		$labelText.MaximumSize = $System_Drawing_Size
 		$labelText.AutoSize = $true
 		$labelText.Margin = $paddingNone
-		$labelText.Padding = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 0,10,5,10
+		$labelText.Padding = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 5,5,5,5
 		$labelText.TabIndex = 1
 		$labelText.Text = $message
 		$labelText.TextAlign = "Middle$($MessageAlignment)"

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1606,7 +1606,7 @@ Function Show-InstallationPrompt {
 		$labelText.MaximumSize = $System_Drawing_Size
 		$labelText.AutoSize = $true
 		$labelText.Margin = $paddingNone
-		$labelText.Padding = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 0,10,10,10
+		$labelText.Padding = New-Object -TypeName 'System.Windows.Forms.Padding' -ArgumentList 0,10,5,10
 		$labelText.TabIndex = 1
 		$labelText.Text = $message
 		$labelText.TextAlign = "Middle$($MessageAlignment)"


### PR DESCRIPTION
Show-InstallationWelcome was slightly modified:
- separated the Installation Title in the form so its more clear for the user
- modified buttons top and bottom spacing so its consistent with and without countdown
- fixed padding around CloseApps list caused by whitespace inside the xml config

Show-InstallationPrompt was reworked so the window scales with the amount of text entered and removed unused space. If there is no icon specified, the text will scale the entire width too. Buttons now look the same like in Show-InstallationWelcome

![first](https://user-images.githubusercontent.com/20016096/83172207-8bccdc80-a117-11ea-87e5-564586e220ac.png)
![second](https://user-images.githubusercontent.com/20016096/83172210-8c657300-a117-11ea-8e8e-d7daea5ec2a8.png)
![third](https://user-images.githubusercontent.com/20016096/83172211-8cfe0980-a117-11ea-992d-fb87cb796e6d.png)