### PR TITLE
Add process object to Get-WindowTitle

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -8993,6 +8993,7 @@ Function Get-WindowTitle {
 							ParentProcess= $Process.Name
 							ParentProcessMainWindowHandle = $Process.MainWindowHandle
 							ParentProcessId = $Process.Id
+							ParentProcessObj = $Process
 						}
 
 						## Only save/return the window and process details which match the search criteria


### PR DESCRIPTION
It is useful to have the full object returned for builtin functions such
as CloseMainWindow()

Before submitting this PR, I made sure:

- [X] I tested the toolkit with my changes. Made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The enconding of the file wasn't changed. It is still UTF8 without BOM.
