### PR TITLE
improved Get-UserProfiles function

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -4675,7 +4675,8 @@ Function Get-UserProfiles {
 			ForEach-Object {
 				Get-ItemProperty -LiteralPath $_.PSPath -ErrorAction 'Stop' | Where-Object { ($_.ProfileImagePath) } |
 				Select-Object @{ Label = 'NTAccount'; Expression = { $(ConvertTo-NTAccountOrSID -SID $_.PSChildName).Value } }, @{ Label = 'SID'; Expression = { $_.PSChildName } }, @{ Label = 'ProfilePath'; Expression = { $_.ProfileImagePath } }
-			}
+			} |
+            Where-Object { $_.NTAccount } ## This removes "defaultuser0" account, which is Windows's 10 bug
 			If ($ExcludeSystemProfiles) {
 				[string[]]$SystemProfiles = 'S-1-5-18', 'S-1-5-19', 'S-1-5-20'
 				[psobject[]]$UserProfiles = $UserProfiles | Where-Object { $SystemProfiles -notcontains $_.SID }


### PR DESCRIPTION
Before submitting this PR, I made sure:

- I tested the toolkit with my changes. Made sure it doesn't break other code.

- I updated the documentation with the changes I made.

- The code I changed has comments with explanation.

- The enconding of the file wasn't changed. It is still UTF8 without BOM.


Some of our customers had problems with this function because of following bug:
https://www.kapilarya.com/what-is-defaultuser0-account-in-windows-10-and-how-to-remove-it

So we use `Get-UserProfiles | Where-Object { $_.NTAccount }` every time