### PR TITLE
Change Un/Block-AppExecution so it doesn't run without admin rights

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitConfig.xml
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitConfig.xml
@@ -17,7 +17,7 @@
 		<Toolkit_RequireAdmin>True</Toolkit_RequireAdmin>
 		<!-- Specify if Administrator Rights are required. NB: Some functions won't work if this is set to false, such as deferral, blockexecution, file & registry RW access and potentially logging. -->
 		<Toolkit_TempPath>$envTemp</Toolkit_TempPath>
-		<!-- Path used to store temporary Toolkit files (with PSAppDeployToolkit as subdirectory), e.g. cache toolkit for cleaning up blocked apps. Normally you don't want this set to a path that is writable by regular users, this might lead to a security vulnerability. The default Temp variable for the LocalSystem account is C:\ProgramData. -->
+		<!-- Path used to store temporary Toolkit files (with PSAppDeployToolkit as subdirectory), e.g. cache toolkit for cleaning up blocked apps. Normally you don't want this set to a path that is writable by regular users, this might lead to a security vulnerability. The default Temp variable for the LocalSystem account is C:\Windows\Temp. -->
 		<Toolkit_RegPath>HKLM:\SOFTWARE</Toolkit_RegPath>
 		<!-- Registry key used to store toolkit information (with PSAppDeployToolkit as child registry key), e.g. deferral history. -->
 		<Toolkit_LogPath>$envWinDir\Logs\Software</Toolkit_LogPath>
@@ -26,7 +26,7 @@
 		<!-- Same as TempPath but used when RequireAdmin is False. -->
 		<Toolkit_RegPathNoAdminRights>HKCU:\SOFTWARE</Toolkit_RegPathNoAdminRights>
 		<!-- Same as RegPath but used when RequireAdmin is False. Bear in mind that since this Registry Key should be writable without admin permission, regular users can modify it also. -->
-		<Toolkit_LogPathNoAdminRights>$envTemp\Logs\Software</Toolkit_LogPathNoAdminRights>
+		<Toolkit_LogPathNoAdminRights>$envProgramData\Logs\Software</Toolkit_LogPathNoAdminRights>
 		<!-- Same as LogPath but used when RequireAdmin is False. -->
 		<Toolkit_CompressLogs>False</Toolkit_CompressLogs>
 		<!-- Specify if the log files should be bundled together in a compressed zip file -->

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitConfig.xml
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitConfig.xml
@@ -16,7 +16,7 @@
 	<Toolkit_Options>
 		<Toolkit_RequireAdmin>True</Toolkit_RequireAdmin>
 		<!-- Specify if Administrator Rights are required. NB: Some functions won't work if this is set to false, such as deferral, blockexecution, file & registry RW access and potentially logging. -->
-		<Toolkit_TempPath>$envProgramData</Toolkit_TempPath>
+		<Toolkit_TempPath>$envCommonProgramFiles</Toolkit_TempPath>
 		<!-- Path used to store temporary Toolkit files (with PSAppDeployToolkit as subdirectory), e.g. cache toolkit for cleaning up blocked apps. Normally you don't want this set to a path that is writable by regular users, this might lead to a security vulnerability. The default Temp variable for the LocalSystem account is C:\ProgramData. -->
 		<Toolkit_RegPath>HKLM:\SOFTWARE</Toolkit_RegPath>
 		<!-- Registry key used to store toolkit information (with PSAppDeployToolkit as child registry key), e.g. deferral history. -->

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitConfig.xml
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitConfig.xml
@@ -16,17 +16,17 @@
 	<Toolkit_Options>
 		<Toolkit_RequireAdmin>True</Toolkit_RequireAdmin>
 		<!-- Specify if Administrator Rights are required. NB: Some functions won't work if this is set to false, such as deferral, blockexecution, file & registry RW access and potentially logging. -->
-		<Toolkit_TempPath>$envTemp</Toolkit_TempPath>
-		<!-- Path used to store temporary Toolkit files (with PSAppDeployToolkit as subdirectory), e.g. cache toolkit for cleaning up blocked apps. Normally you don't want this set to a path that is writable by regular users, this might lead to a security vulnerability. The default Temp variable for the LocalSystem account is C:\Windows\Temp. -->
-		<Toolkit_RegPath>HKLM:SOFTWARE</Toolkit_RegPath>
+		<Toolkit_TempPath>$envProgramData</Toolkit_TempPath>
+		<!-- Path used to store temporary Toolkit files (with PSAppDeployToolkit as subdirectory), e.g. cache toolkit for cleaning up blocked apps. Normally you don't want this set to a path that is writable by regular users, this might lead to a security vulnerability. The default Temp variable for the LocalSystem account is C:\ProgramData. -->
+		<Toolkit_RegPath>HKLM:\SOFTWARE</Toolkit_RegPath>
 		<!-- Registry key used to store toolkit information (with PSAppDeployToolkit as child registry key), e.g. deferral history. -->
 		<Toolkit_LogPath>$envWinDir\Logs\Software</Toolkit_LogPath>
 		<!-- Log path used for Toolkit logging. -->
-		<Toolkit_TempPathNoAdminRights>$envTemp</Toolkit_TempPathNoAdminRights>
+		<Toolkit_TempPathNoAdminRights>$envLocalAppData</Toolkit_TempPathNoAdminRights>
 		<!-- Same as TempPath but used when RequireAdmin is False. -->
-		<Toolkit_RegPathNoAdminRights>HKCU:SOFTWARE</Toolkit_RegPathNoAdminRights>
+		<Toolkit_RegPathNoAdminRights>HKCU:\SOFTWARE</Toolkit_RegPathNoAdminRights>
 		<!-- Same as RegPath but used when RequireAdmin is False. Bear in mind that since this Registry Key should be writable without admin permission, regular users can modify it also. -->
-		<Toolkit_LogPathNoAdminRights>$envProgramData\Logs\Software</Toolkit_LogPathNoAdminRights>
+		<Toolkit_LogPathNoAdminRights>$envLocalAppData\Logs\Software</Toolkit_LogPathNoAdminRights>
 		<!-- Same as LogPath but used when RequireAdmin is False. -->
 		<Toolkit_CompressLogs>False</Toolkit_CompressLogs>
 		<!-- Specify if the log files should be bundled together in a compressed zip file -->

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitConfig.xml
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitConfig.xml
@@ -16,17 +16,17 @@
 	<Toolkit_Options>
 		<Toolkit_RequireAdmin>True</Toolkit_RequireAdmin>
 		<!-- Specify if Administrator Rights are required. NB: Some functions won't work if this is set to false, such as deferral, blockexecution, file & registry RW access and potentially logging. -->
-		<Toolkit_TempPath>$envCommonProgramFiles</Toolkit_TempPath>
+		<Toolkit_TempPath>$envTemp</Toolkit_TempPath>
 		<!-- Path used to store temporary Toolkit files (with PSAppDeployToolkit as subdirectory), e.g. cache toolkit for cleaning up blocked apps. Normally you don't want this set to a path that is writable by regular users, this might lead to a security vulnerability. The default Temp variable for the LocalSystem account is C:\ProgramData. -->
 		<Toolkit_RegPath>HKLM:\SOFTWARE</Toolkit_RegPath>
 		<!-- Registry key used to store toolkit information (with PSAppDeployToolkit as child registry key), e.g. deferral history. -->
 		<Toolkit_LogPath>$envWinDir\Logs\Software</Toolkit_LogPath>
 		<!-- Log path used for Toolkit logging. -->
-		<Toolkit_TempPathNoAdminRights>$envLocalAppData</Toolkit_TempPathNoAdminRights>
+		<Toolkit_TempPathNoAdminRights>$envTemp</Toolkit_TempPathNoAdminRights>
 		<!-- Same as TempPath but used when RequireAdmin is False. -->
 		<Toolkit_RegPathNoAdminRights>HKCU:\SOFTWARE</Toolkit_RegPathNoAdminRights>
 		<!-- Same as RegPath but used when RequireAdmin is False. Bear in mind that since this Registry Key should be writable without admin permission, regular users can modify it also. -->
-		<Toolkit_LogPathNoAdminRights>$envLocalAppData\Logs\Software</Toolkit_LogPathNoAdminRights>
+		<Toolkit_LogPathNoAdminRights>$envTemp\Logs\Software</Toolkit_LogPathNoAdminRights>
 		<!-- Same as LogPath but used when RequireAdmin is False. -->
 		<Toolkit_CompressLogs>False</Toolkit_CompressLogs>
 		<!-- Specify if the log files should be bundled together in a compressed zip file -->

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5538,9 +5538,14 @@ Function Block-AppExecution {
 "@
 	}
 	Process {
+		## Bypass if no Admin rights
+		If ($configToolkitRequireAdmin -eq $false) {
+			Write-Log -Message "Bypassing Function [${CmdletName}], because [Require Admin: $configToolkitRequireAdmin]." -Source ${CmdletName}
+			Return
+		}
 		## Bypass if in NonInteractive mode
 		If ($deployModeNonInteractive) {
-			Write-Log -Message "Bypassing Function [${CmdletName}] [Mode: $deployMode]." -Source ${CmdletName}
+			Write-Log -Message "Bypassing Function [${CmdletName}], because [Mode: $deployMode]." -Source ${CmdletName}
 			Return
 		}
 
@@ -5632,9 +5637,14 @@ Function Unblock-AppExecution {
 		Write-FunctionHeaderOrFooter -CmdletName ${CmdletName} -CmdletBoundParameters $PSBoundParameters -Header
 	}
 	Process {
+		## Bypass if no Admin rights
+		If ($configToolkitRequireAdmin -eq $false) {
+			Write-Log -Message "Bypassing Function [${CmdletName}], because [Require Admin: $configToolkitRequireAdmin]." -Source ${CmdletName}
+			Return
+		}
 		## Bypass if in NonInteractive mode
 		If ($deployModeNonInteractive) {
-			Write-Log -Message "Bypassing Function [${CmdletName}] [Mode: $deployMode]." -Source ${CmdletName}
+			Write-Log -Message "Bypassing Function [${CmdletName}], because [Mode: $deployMode]." -Source ${CmdletName}
 			Return
 		}
 


### PR DESCRIPTION
Since $envTemp points to c:\windows\temp and the folder has limited permissions for Administrators by default, it has to be changed again. ProgramData seems like the best option other than ProgramFiles which is used for programs themselves. ProgramData is also hidden by default.

ProgramData is read only to users by default so we need to change the no admin rights log dir to a user writable location for when the toolkit runs without admin rights. Not many such folders exist. One of the best locations is LocalAppData since those folders dont get erased without reason and are user writable.

Also modifies Block and Unblock AppExecution functions so they get bypassed if admin rights are not requested because the functions require elevated permissions to function.

Fixes #526