### PR TITLE
Fix for tempory folder issue for blocked execution

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,4 +6,4 @@ Before submitting this PR, I made sure:
 
 - [X] The code I changed has comments with explanation.
 
-- [X] The enconding of the file wasn't changed. It is still UTF8 without BOM.
+- [X] The encoding of the file wasn't changed. It is still UTF8 without BOM.

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5601,7 +5601,7 @@ Function Block-AppExecution {
 		$Users = New-Object System.Security.Principal.NTAccount($UsersAccountName)
 		
 		## Sets read permissions on the files needed for the scheduled task
-		Set-Permissions -Path $blockExecutionTempPath -User $Users -Permission 'Read' -Recurse
+		Set-Permission -Path $blockExecutionTempPath -User $Users -Permission 'Read' -Recurse
 		
 		## Create a scheduled task to run on startup to call this script and clean up blocked applications in case the installation is interrupted, e.g. user shuts down during installation"
 		Write-Log -Message 'Create scheduled task to cleanup blocked applications in case installation is interrupted.' -Source ${CmdletName}

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5565,6 +5565,8 @@ Function Block-AppExecution {
 		$debuggerBlockScript | Out-File -FilePath "$dirAppDeployTemp\AppDeployToolkit_BlockAppExecutionMessage.vbs" -Force -Encoding 'default' -ErrorAction 'SilentlyContinue'
 		[string]$debuggerBlockValue = "$envWinDir\System32\wscript.exe `"$dirAppDeployTemp\AppDeployToolkit_BlockAppExecutionMessage.vbs`""
 
+		Set-Permission -Path $dirAppDeployTemp -User "BUILTIN\Users" -Permission Read -Recurse
+
 		## Create a scheduled task to run on startup to call this script and clean up blocked applications in case the installation is interrupted, e.g. user shuts down during installation"
 		Write-Log -Message 'Create scheduled task to cleanup blocked applications in case installation is interrupted.' -Source ${CmdletName}
 		If (Get-ScheduledTask -ContinueOnError $true | Select-Object -Property 'TaskName' | Where-Object { $_.TaskName -eq "\$schTaskBlockedAppsName" }) {
@@ -10753,6 +10755,154 @@ Function Get-PendingReboot {
 }
 #endregion
 
+#region Function Set-Permission
+Function Set-Permission {
+
+    <#
+    .SYNOPSYS
+        Allow you to easily change permissions on files or folders
+    .PARAMETER Path
+        Path to the folder or file you want to modify (ex: C:\Temp)
+    .PARAMETER User
+        One or more user names (ex: BUILTIN\Users, DOMAIN\Admin)
+    .PARAMETER Permission
+        To remove permission use: None, to see all the possible permissions go to 'http://technet.microsoft.com/fr-fr/library/ff730951.aspx'
+    .PARAMETER Recurse
+        If you use this switch, permissions will be recursive on folder and file children
+    .EXAMPLE
+        Will grant FullControl permissions to 'John' and 'Users' on 'C:\Temp' and it's files and folders children.
+        PS C:\>Set-Permission -Path "C:\Temp" -User "DOMAIN\John", "BUILTIN\Utilisateurs" -Permission FullControl -Recurse
+    .EXAMPLE
+        Will grant Read permissions to 'John' on 'C:\Temp\pic.png'
+        PS C:\>Set-Permission -Path "C:\Temp\pic.png" -User "DOMAIN\John" -Permission Read
+    .EXAMPLE
+        Will remove all permissions to 'John' on 'C:\Temp\Private'
+        PS C:\>Set-Permission -Path "C:\Temp\Private" -User "DOMAIN\John" -Permission None
+
+        Conditions : John need to have explicit existing permissions on the Path or File
+    .NOTE
+        Original Author : Julian DA CUNHA - dacunha.julian@gmail.com, used with permission
+    #>
+
+    [CmdletBinding()]
+    Param (
+        [Parameter( Mandatory=$True, 
+                    Position=0,
+                    HelpMessage = "Path to the folder or file you want to modify (ex: C:\Temp)" )]
+        [ValidateScript({Test-Path $_})]
+        [Alias('File', 'Folder')]
+        [String] $Path,
+
+        [Parameter( Mandatory=$True, 
+                    Position=1,
+                    HelpMessage = "One or more user names (ex: BUILTIN\Users, DOMAIN\Admin)" )]
+        [Alias('Username', 'Users')]
+        [String[]] $User,
+
+        [Parameter( Mandatory=$True,
+                    Position=2,
+                    HelpMessage = "To remove permission use: None, to see all the possible permissions go to 'http://technet.microsoft.com/fr-fr/library/ff730951.aspx'")]
+        [Alias('Acl', 'Grant')]
+        [ValidateSet("AppendData", "ChangePermissions", "CreateDirectories", "CreateFiles", "Delete", `
+                     "DeleteSubdirectoriesAndFiles", "ExecuteFile", "FullControl", "ListDirectory", "Modify",`
+                     "Read", "ReadAndExecute", "ReadAttributes", "ReadData", "ReadExtendedAttributes", "ReadPermissions",`
+                     "Synchronize", "TakeOwnership", "Traverse", "Write", "WriteAttributes", "WriteData", "WriteExtendedAttributes", "None")]
+        [String] $Permission,
+
+        [Parameter( Mandatory=$False, 
+                    HelpMessage = "If you use this switch, permissions will be recursive on folder and file children" )]
+        [Switch] $Recurse
+    )
+
+    Begin {
+
+        # Test run as Administrator
+        If (!$IsAdmin){
+            Write-Log -Message "Unable to use the function, Set-Permissions. Please run elevated." -Source ${CmdletName}
+            Return
+        }
+
+        # Set permissions
+        If ($Permission -ne "None"){
+            $Permission = [System.Security.AccessControl.FileSystemRights]$Permission
+        }
+
+        # Enable recursive permissions
+        If ($Recurse){
+            $InheritanceFlag = [System.Security.AccessControl.InheritanceFlags]
+            $InheritanceFlag = [System.Security.AccessControl.InheritanceFlags]($InheritanceFlag::ContainerInherit -bor $InheritanceFlag::ObjectInherit)
+        } Else { 
+            $InheritanceFlag = [System.Security.AccessControl.InheritanceFlags]::None
+        }
+
+        # Set Propagation
+        $PropagationFlag = [System.Security.AccessControl.PropagationFlags]::None
+
+        # Allow Object access
+        $Allow = [System.Security.AccessControl.AccessControlType]::Allow
+
+        # Set permissions for special accounts
+        $ObjSID = New-Object System.Security.Principal.SecurityIdentifier("S-1-5-32-544")
+        $AdminsSID = $ObjSID.Translate( [System.Security.Principal.NTAccount])
+        $AdminsAccountName = $AdminsSID.Value
+
+        $ObjSID = New-Object System.Security.Principal.SecurityIdentifier("S-1-5-18")
+        $SystemSID = $ObjSID.Translate( [System.Security.Principal.NTAccount])
+        $SystemAccountName = $SystemSID.Value
+        
+        $Admin = New-Object System.Security.Principal.NTAccount($AdminsAccountName)
+        $System = New-Object System.Security.Principal.NTAccount($SystemAccountName)
+    }
+
+    Process {
+
+        # Get object acls
+        $Acl = Get-Acl $Path
+        # Disable inherance, Preserve inherited permissions
+        $Acl.SetAccessRuleProtection($True, $False)
+
+        # Set Permissions for Administrators and System
+        $SpecialPermission = [System.Security.AccessControl.FileSystemRights]::FullControl
+        $Rule = New-Object System.Security.AccessControl.FileSystemAccessRule($Admin, $SpecialPermission, $InheritanceFlag, $PropagationFlag, $Allow)
+        $Acl.AddAccessRule($Rule)
+        $Rule = New-Object System.Security.AccessControl.FileSystemAccessRule($System, $SpecialPermission, $InheritanceFlag, $PropagationFlag, $Allow)
+        $Acl.AddAccessRule($Rule)
+        $null = Set-Acl -Path $Path -AclObject $Acl
+
+        # Apply permissions on Users
+        Foreach ($U in $User){
+
+            # Set Username
+            $Username = New-Object System.Security.Principal.NTAccount($U)
+
+            # Set or Remove permissions
+            If ($Permission -ne "None"){
+
+                $Rule = New-Object System.Security.AccessControl.FileSystemAccessRule($Username, $Permission, $InheritanceFlag, $PropagationFlag, $Allow)
+                $Acl.AddAccessRule($Rule)
+                Write-Log -Message "ACL - Add($Username, $Permission, $InheritanceFlag, $PropagationFlag, $Allow)" -Source ${CmdletName}
+
+            } Else {
+
+                # Check If user is in security descriptor
+                $Remove = $Acl.Access | Where { $_.IdentityReference -eq $U }
+
+                If ($Remove){
+
+                    $RemoveRule = New-Object System.Security.AccessControl.FileSystemAccessRule($Remove.IdentityReference, $Remove.FileSystemRights, $Remove.InheritanceFlags, $Remove.PropagationFlags, $Remove.AccessControlType)
+                    $Acl.RemoveAccessRuleAll($RemoveRule)
+                    Write-Loge -Message "ACL - RemoveAll($($Remove.IdentityReference), $($Remove.FileSystemRights), $($Remove.InheritanceFlags), $($Remove.PropagationFlags), $($Remove.AccessControlType))" -Source ${CmdletName}
+
+                }
+            }
+        }
+    }
+
+    End {
+        $null = Set-Acl -Path $Path -AclObject $Acl
+    }
+}
+#endregion
 
 #endregion
 ##*=============================================

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5597,7 +5597,7 @@ Function Block-AppExecution {
 		
 		$blockExecutionTempFiles = Get-ChildItem -Path $blockExecutionTempPath
 		foreach ($item in $blockExecutionTempFiles) {
-			Set-Permission -Path $item.FullName -User $Users -Permission 'ReadAndExecute'
+			Set-Permission -Path $item.FullName -User $Users -Permission 'Read'
 		}
 		
 		## Create a scheduled task to run on startup to call this script and clean up blocked applications in case the installation is interrupted, e.g. user shuts down during installation"
@@ -5708,7 +5708,7 @@ Function Unblock-AppExecution {
 
 		## Remove BlockAppExection Temporary directory
 		[string]$blockExecutionTempPath = Join-Path -Path $dirAppDeployTemp -ChildPath 'BlockExecution'
-		If (Test-Path -LiteralPath $blockExecutionTempPath -PathType 'Container' -ErrorAction 'SilentyContinue') {
+		If (Test-Path -LiteralPath $blockExecutionTempPath -PathType 'Container') {
 			Remove-Folder -Path $blockExecutionTempPath
 		}
 	}
@@ -10926,7 +10926,7 @@ Function Set-Permission {
 
                 $Rule = New-Object System.Security.AccessControl.FileSystemAccessRule($Username, $Permission, $InheritanceFlag, $PropagationFlag, $Allow)
                 $Acl.AddAccessRule($Rule)
-                Write-Log -Message "ACL - Add($Username, $Permission, $InheritanceFlag, $PropagationFlag, $Allow)" -Source ${CmdletName}
+                Write-Log -Message "[$path] ACL - Add($Username, $Permission, $InheritanceFlag, $PropagationFlag, $Allow)" -Source ${CmdletName}
 
             } Else {
 
@@ -10937,7 +10937,7 @@ Function Set-Permission {
 
                     $RemoveRule = New-Object System.Security.AccessControl.FileSystemAccessRule($Remove.IdentityReference, $Remove.FileSystemRights, $Remove.InheritanceFlags, $Remove.PropagationFlags, $Remove.AccessControlType)
                     $Acl.RemoveAccessRuleAll($RemoveRule)
-                    Write-Loge -Message "ACL - RemoveAll($($Remove.IdentityReference), $($Remove.FileSystemRights), $($Remove.InheritanceFlags), $($Remove.PropagationFlags), $($Remove.AccessControlType))" -Source ${CmdletName}
+                    Write-Loge -Message "[$path] ACL - RemoveAll($($Remove.IdentityReference), $($Remove.FileSystemRights), $($Remove.InheritanceFlags), $($Remove.PropagationFlags), $($Remove.AccessControlType))" -Source ${CmdletName}
 
                 }
             }


### PR DESCRIPTION
Set READ permissions to BUITLTIN\Users so they can get the popup message
Added Set-Permission function to make it easier to set permissions

Before submitting this PR, I made sure:

- [X] I tested the toolkit with my changes. Made sure it doesn't break other code.

- [TODO] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 without BOM.
