### PR TITLE
Fix Show-InstallationProgress window not being centered

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -7670,7 +7670,7 @@ Function Show-InstallationProgress {
 				#  Grey out the X button
 				$script:ProgressSyncHash.Window.add_Loaded({
 					#  Calculate the position on the screen where the progress dialog should be placed
-					#  We have to use PrimaryScreenWidth/PrimaryScreenHeight instead of WorkArea because WorkArea does not get updated when the screensize changes on virtual machines
+					#  We have to use PrimaryScreenWidth/PrimaryScreenHeight instead of WorkArea because WorkArea does not get updated when the screen size changes in virtual machines
 					[int32]$screenWidth = [System.Windows.SystemParameters]::PrimaryScreenWidth
 					[int32]$screenHeight = [System.Windows.SystemParameters]::PrimaryScreenHeight
 					[int32]$screenCenterWidth = $screenWidth - $script:ProgressSyncHash.Window.ActualWidth

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -7670,10 +7670,10 @@ Function Show-InstallationProgress {
 				#  Grey out the X button
 				$script:ProgressSyncHash.Window.add_Loaded({
 					#  Calculate the position on the screen where the progress dialog should be placed
-					[int32]$screenWidth = [System.Windows.SystemParameters]::WorkArea.Width
-					[int32]$screenHeight = [System.Windows.SystemParameters]::WorkArea.Height
-					[int32]$screenCenterWidth = $screenWidth - $script:ProgressSyncHash.Window.Width
-					[int32]$screenCenterHeight = $screenHeight - $script:ProgressSyncHash.Window.Height
+					[int32]$screenWidth = [System.Windows.SystemParameters]::PrimaryScreenWidth
+					[int32]$screenHeight = [System.Windows.SystemParameters]::PrimaryScreenHeight
+					[int32]$screenCenterWidth = $screenWidth - $script:ProgressSyncHash.Window.ActualWidth
+					[int32]$screenCenterHeight = $screenHeight - $script:ProgressSyncHash.Window.ActualHeight
 					#  Set the start position of the Window based on the screen size
 					If ($windowLocation -eq 'BottomRight') {
 						#  Put the window in the corner

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -7670,6 +7670,7 @@ Function Show-InstallationProgress {
 				#  Grey out the X button
 				$script:ProgressSyncHash.Window.add_Loaded({
 					#  Calculate the position on the screen where the progress dialog should be placed
+					#  We have to use PrimaryScreenWidth/PrimaryScreenHeight instead of WorkArea because WorkArea does not get updated when the screensize changes on virtual machines
 					[int32]$screenWidth = [System.Windows.SystemParameters]::PrimaryScreenWidth
 					[int32]$screenHeight = [System.Windows.SystemParameters]::PrimaryScreenHeight
 					[int32]$screenCenterWidth = $screenWidth - $script:ProgressSyncHash.Window.ActualWidth

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -7670,9 +7670,8 @@ Function Show-InstallationProgress {
 				#  Grey out the X button
 				$script:ProgressSyncHash.Window.add_Loaded({
 					#  Calculate the position on the screen where the progress dialog should be placed
-					#  We have to use PrimaryScreenWidth/PrimaryScreenHeight instead of WorkArea because WorkArea does not get updated when the screen size changes in virtual machines
-					[int32]$screenWidth = [System.Windows.SystemParameters]::PrimaryScreenWidth
-					[int32]$screenHeight = [System.Windows.SystemParameters]::PrimaryScreenHeight
+					[int32]$screenWidth = [System.Windows.SystemParameters]::WorkArea.Width
+					[int32]$screenHeight = [System.Windows.SystemParameters]::WorkArea.Height
 					[int32]$screenCenterWidth = $screenWidth - $script:ProgressSyncHash.Window.ActualWidth
 					[int32]$screenCenterHeight = $screenHeight - $script:ProgressSyncHash.Window.ActualHeight
 					#  Set the start position of the Window based on the screen size


### PR DESCRIPTION
On win7 Show-InstallationProgress is not centered. This fixes it.
