### PR TITLE
Fix Boolean parameters not being passed to Execute-Process

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,5 @@
 **Version 3.8.4 [??/??/2020]**
+- Fix Boolean parameters not being passed to Execute-Process
 - Changed Show-InstallationWelcome:
   - The buttons are now wider
   - The listbox is also wider so it is aligned with buttons

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -2652,13 +2652,13 @@ Function Execute-MSI {
 												  Parameters = $argsMSI
 												  WindowStyle = 'Normal' }
 			If ($WorkingDirectory) { $ExecuteProcessSplat.Add( 'WorkingDirectory', $WorkingDirectory) }
-			If ($ContinueOnError) { $ExecuteProcessSplat.Add( 'ContinueOnError', $ContinueOnError) }
+			If ($PSBoundParameters.ContainsKey("ContinueOnError")) { $ExecuteProcessSplat.Add( 'ContinueOnError', $ContinueOnError) }
 			If ($SecureParameters) { $ExecuteProcessSplat.Add( 'SecureParameters', $SecureParameters) }
-			If ($PassThru) { $ExecuteProcessSplat.Add( 'PassThru', $PassThru) }
+			If ($PSBoundParameters.ContainsKey("PassThru")) { $ExecuteProcessSplat.Add( 'PassThru', $PassThru) }
 			If ($IgnoreExitCodes) {  $ExecuteProcessSplat.Add( 'IgnoreExitCodes', $IgnoreExitCodes) }
 			If ($PriorityClass) {  $ExecuteProcessSplat.Add( 'PriorityClass', $PriorityClass) }
-			If ($ExitOnProcessFailure) {  $ExecuteProcessSplat.Add( 'ExitOnProcessFailure', $ExitOnProcessFailure) }
-			If ($NoWait) { $ExecuteProcessSplat.Add( 'NoWait', $NoWait) }
+			If ($PSBoundParameters.ContainsKey("ExitOnProcessFailure")) {  $ExecuteProcessSplat.Add( 'ExitOnProcessFailure', $ExitOnProcessFailure) }
+			If ($PSBoundParameters.ContainsKey("NoWait")) { $ExecuteProcessSplat.Add( 'NoWait', $NoWait) }
 			#  Call the Execute-Process function
 			If ($PassThru) {
 				[psobject]$ExecuteResults = Execute-Process @ExecuteProcessSplat
@@ -2883,13 +2883,13 @@ Function Remove-MSIApplications {
 
 		## Build the hashtable with the options that will be passed to Execute-MSI using splatting
 		[hashtable]$ExecuteMSISplat =  @{ Action = 'Uninstall'; Path = '' }
-		If ($ContinueOnError) { $ExecuteMSISplat.Add( 'ContinueOnError', $ContinueOnError) }
+		If ($PSBoundParameters.ContainsKey("ContinueOnError")) { $ExecuteMSISplat.Add( 'ContinueOnError', $ContinueOnError) }
 		If ($Parameters) { $ExecuteMSISplat.Add( 'Parameters', $Parameters) }
 		ElseIf ($AddParameters) { $ExecuteMSISplat.Add( 'AddParameters', $AddParameters) }
 		If ($LoggingOptions) { $ExecuteMSISplat.Add( 'LoggingOptions', $LoggingOptions) }
 		If ($LogName) { $ExecuteMSISplat.Add( 'LogName', $LogName) }
-		If ($PassThru) { $ExecuteMSISplat.Add( 'PassThru', $PassThru) }
-		If ($IncludeUpdatesAndHotfixes) { $ExecuteMSISplat.Add( 'IncludeUpdatesAndHotfixes', $IncludeUpdatesAndHotfixes) }
+		If ($PSBoundParameters.ContainsKey("PassThru")) { $ExecuteMSISplat.Add( 'PassThru', $PassThru) }
+		If ($PSBoundParameters.ContainsKey("IncludeUpdatesAndHotfixes")) { $ExecuteMSISplat.Add( 'IncludeUpdatesAndHotfixes', $IncludeUpdatesAndHotfixes) }
 
 		If (($null -ne $removeMSIApplications) -and ($removeMSIApplications.Count)) {
 			ForEach ($removeMSIApplication in $removeMSIApplications) {

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -2652,15 +2652,15 @@ Function Execute-MSI {
 				Path = $exeMsiexec
 				Parameters = $argsMSI
 				WindowStyle = 'Normal'
-				SecureParameters = $SecureParameters
 				ExitOnProcessFailure = $ExitOnProcessFailure
 				ContinueOnError = $ContinueOnError
-				NoWait = $NoWait
-				PassThru = $PassThru
 			}
 			If ($WorkingDirectory) { $ExecuteProcessSplat.Add( 'WorkingDirectory', $WorkingDirectory) }
+			If ($SecureParameters) { $ExecuteProcessSplat.Add( 'SecureParameters', $SecureParameters) }
+			If ($PassThru) { $ExecuteProcessSplat.Add( 'PassThru', $PassThru) }
 			If ($IgnoreExitCodes) {  $ExecuteProcessSplat.Add( 'IgnoreExitCodes', $IgnoreExitCodes) }
 			If ($PriorityClass) {  $ExecuteProcessSplat.Add( 'PriorityClass', $PriorityClass) }
+			If ($NoWait) { $ExecuteProcessSplat.Add( 'NoWait', $NoWait) }
 
 			#  Call the Execute-Process function
 			If ($PassThru) {
@@ -2888,14 +2888,14 @@ Function Remove-MSIApplications {
 		[hashtable]$ExecuteMSISplat =  @{
 			Action = 'Uninstall'
 			Path = ''
-			PassThru = $PassThru
 			ContinueOnError = $ContinueOnError
-			IncludeUpdatesAndHotfixes = $IncludeUpdatesAndHotfixes
 		}
 		If ($Parameters) { $ExecuteMSISplat.Add( 'Parameters', $Parameters) }
 		ElseIf ($AddParameters) { $ExecuteMSISplat.Add( 'AddParameters', $AddParameters) }
 		If ($LoggingOptions) { $ExecuteMSISplat.Add( 'LoggingOptions', $LoggingOptions) }
 		If ($LogName) { $ExecuteMSISplat.Add( 'LogName', $LogName) }
+		If ($PassThru) { $ExecuteMSISplat.Add( 'PassThru', $PassThru) }
+		If ($IncludeUpdatesAndHotfixes) { $ExecuteMSISplat.Add( 'IncludeUpdatesAndHotfixes', $IncludeUpdatesAndHotfixes) }
 
 		If (($null -ne $removeMSIApplications) -and ($removeMSIApplications.Count)) {
 			ForEach ($removeMSIApplication in $removeMSIApplications) {

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -2648,17 +2648,20 @@ Function Execute-MSI {
 		ElseIf (((-not $IsMsiInstalled) -and ($Action -eq 'Install')) -or ($IsMsiInstalled)) {
 			Write-Log -Message "Executing MSI action [$Action]..." -Source ${CmdletName}
 			#  Build the hashtable with the options that will be passed to Execute-Process using splatting
-			[hashtable]$ExecuteProcessSplat =  @{ Path = $exeMsiexec
-												  Parameters = $argsMSI
-												  WindowStyle = 'Normal' }
+			[hashtable]$ExecuteProcessSplat =  @{
+				Path = $exeMsiexec
+				Parameters = $argsMSI
+				WindowStyle = 'Normal'
+				SecureParameters = $SecureParameters
+				ExitOnProcessFailure = $ExitOnProcessFailure
+				ContinueOnError = $ContinueOnError
+				NoWait = $NoWait
+				PassThru = $PassThru
+			}
 			If ($WorkingDirectory) { $ExecuteProcessSplat.Add( 'WorkingDirectory', $WorkingDirectory) }
-			If ($PSBoundParameters.ContainsKey("ContinueOnError")) { $ExecuteProcessSplat.Add( 'ContinueOnError', $ContinueOnError) }
-			If ($SecureParameters) { $ExecuteProcessSplat.Add( 'SecureParameters', $SecureParameters) }
-			If ($PSBoundParameters.ContainsKey("PassThru")) { $ExecuteProcessSplat.Add( 'PassThru', $PassThru) }
 			If ($IgnoreExitCodes) {  $ExecuteProcessSplat.Add( 'IgnoreExitCodes', $IgnoreExitCodes) }
 			If ($PriorityClass) {  $ExecuteProcessSplat.Add( 'PriorityClass', $PriorityClass) }
-			If ($PSBoundParameters.ContainsKey("ExitOnProcessFailure")) {  $ExecuteProcessSplat.Add( 'ExitOnProcessFailure', $ExitOnProcessFailure) }
-			If ($PSBoundParameters.ContainsKey("NoWait")) { $ExecuteProcessSplat.Add( 'NoWait', $NoWait) }
+
 			#  Call the Execute-Process function
 			If ($PassThru) {
 				[psobject]$ExecuteResults = Execute-Process @ExecuteProcessSplat
@@ -2882,14 +2885,17 @@ Function Remove-MSIApplications {
 		}
 
 		## Build the hashtable with the options that will be passed to Execute-MSI using splatting
-		[hashtable]$ExecuteMSISplat =  @{ Action = 'Uninstall'; Path = '' }
-		If ($PSBoundParameters.ContainsKey("ContinueOnError")) { $ExecuteMSISplat.Add( 'ContinueOnError', $ContinueOnError) }
+		[hashtable]$ExecuteMSISplat =  @{
+			Action = 'Uninstall'
+			Path = ''
+			PassThru = $PassThru
+			ContinueOnError = $ContinueOnError
+			IncludeUpdatesAndHotfixes = $IncludeUpdatesAndHotfixes
+		}
 		If ($Parameters) { $ExecuteMSISplat.Add( 'Parameters', $Parameters) }
 		ElseIf ($AddParameters) { $ExecuteMSISplat.Add( 'AddParameters', $AddParameters) }
 		If ($LoggingOptions) { $ExecuteMSISplat.Add( 'LoggingOptions', $LoggingOptions) }
 		If ($LogName) { $ExecuteMSISplat.Add( 'LogName', $LogName) }
-		If ($PSBoundParameters.ContainsKey("PassThru")) { $ExecuteMSISplat.Add( 'PassThru', $PassThru) }
-		If ($PSBoundParameters.ContainsKey("IncludeUpdatesAndHotfixes")) { $ExecuteMSISplat.Add( 'IncludeUpdatesAndHotfixes', $IncludeUpdatesAndHotfixes) }
 
 		If (($null -ne $removeMSIApplications) -and ($removeMSIApplications.Count)) {
 			ForEach ($removeMSIApplication in $removeMSIApplications) {


### PR DESCRIPTION
Change the behavior of the function Execute-Process and Execute-Msi to check boolean and switch parameters with $PSBoundParameters.ContainsKey()

Fix for #580