### PR TITLE
Close-InstallationProgress fix

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,8 @@
   - Reworked the window to look consistent with Show-InstallationWelcome
 - Fixed Set-ActiveSetup adding executed active setup registry key when -ExecuteForCurrentUser $false was specified
 - Fixed typo in Stop-ServiceAndDependencies saying "start" instead of "stop"
+- Fixed the toolkit checking task scheduler services twice
+- Fixed the toolkit not creating $app variables if they are not created in Deploy-Application.ps1
 
 **Version 3.8.3 [01/10/2020]**
 - Added function Set-ItemPermission that allows you to easily change permissions on files or folders.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,8 @@
 - Fixed typo in Stop-ServiceAndDependencies saying "start" instead of "stop"
 - Fixed the toolkit checking task scheduler services twice
 - Fixed the toolkit not creating $app variables if they are not created in Deploy-Application.ps1
+- Reworked Close-InstallationProgress so it waits a couple of seconds in case the window is not opened yet
+  - This fixes an issue where the Show-InstallationProgress dialog would not get closed on slower machines where Close-InstallationProgress was called right after Show-InstallationProgress
 
 **Version 3.8.3 [01/10/2020]**
 - Added function Set-ItemPermission that allows you to easily change permissions on files or folders.

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -7950,31 +7950,31 @@ Function Close-InstallationProgress {
 		[int]$Timeout = $WaitingTime
 		while ((-not $script:ProgressSyncHash.Window.IsInitialized) -and ($Timeout -gt 0)) {
 			if ($Timeout -eq $WaitingTime) {
-				Write-Log -Message "The window for installation progress dialog does not exist. Waiting for up to $WaitingTime seconds..." -Source ${CmdletName}
+				Write-Log -Message "The installation progress dialog does not exist. Waiting up to $WaitingTime seconds..." -Source ${CmdletName}
 			}
 			$Timeout -= 1
 			Start-Sleep -Seconds 1
 		}
 		# Return if we still have no window
 		if (-not $script:ProgressSyncHash.Window.IsInitialized) {
-			Write-Log -Message "The window for installation progress dialog was not created within $WaitingTime seconds." -Source ${CmdletName} -Severity 2
+			Write-Log -Message "The installation progress dialog was not created within $WaitingTime seconds." -Source ${CmdletName} -Severity 2
 			return
 		}
 		# If the thread is suspended, resume it
 		if ($script:ProgressSyncHash.Window.Dispatcher.Thread.ThreadState -band [system.threading.threadstate]::Suspended) {
-			Write-Log -Message 'The thread for installation progress dialog is suspended. Resuming...' -Source ${CmdletName}
+			Write-Log -Message 'The thread for the installation progress dialog is suspended. Resuming the thread.' -Source ${CmdletName}
 			try {
 				$script:ProgressSyncHash.Window.Dispatcher.Thread.Resume()
 			}
 			catch {
-				Write-Log -Message 'Failed to resume the thread for installation progress dialog.' -Source ${CmdletName} -Severity 2
+				Write-Log -Message 'Failed to resume the thread for the installation progress dialog.' -Source ${CmdletName} -Severity 2
 			}
 		}
 		# If the thread is changing its state, wait
 		[int]$Timeout = 0
-		while ((($script:ProgressSyncHash.Window.Dispatcher.Thread.ThreadState -band [system.threading.threadstate]::Aborted) -or ($script:ProgressSyncHash.Window.Dispatcher.Thread.ThreadState -band [system.threading.threadstate]::AbortRequested) -or ($script:ProgressSyncHash.Window.Dispatcher.Thread.ThreadState -band [system.threading.threadstate]::StopRequested) -or ($script:ProgressSyncHash.Window.Dispatcher.Thread.ThreadState -band [system.threading.threadstate]::Unstarted) -or ($script:ProgressSyncHash.Window.Dispatcher.Thread.ThreadState -band [system.threading.threadstate]::WaitSleepJoin)) -and ($Timeout -le $configInstallationUITimeout)) {
+		while ((($script:ProgressSyncHash.Window.Dispatcher.Thread.ThreadState -band [system.threading.threadstate]::Aborted) -or ($script:ProgressSyncHash.Window.Dispatcher.Thread.ThreadState -band [system.threading.threadstate]::AbortRequested) -or ($script:ProgressSyncHash.Window.Dispatcher.Thread.ThreadState -band [system.threading.threadstate]::StopRequested) -or ($script:ProgressSyncHash.Window.Dispatcher.Thread.ThreadState -band [system.threading.threadstate]::Unstarted) -or ($script:ProgressSyncHash.Window.Dispatcher.Thread.ThreadState -band [system.threading.threadstate]::WaitSleepJoin)) -and ($Timeout -le $WaitingTime)) {
 			if (-not $Timeout) {
-				Write-Log -Message 'The thread for installation progress dialog is changing its state. Waiting...' -Source ${CmdletName} -Severity 2
+				Write-Log -Message "The thread for the installation progress dialog is changing its state. Waiting up to $WaitingTime seconds..." -Source ${CmdletName} -Severity 2
 			}
 			$Timeout += 1
 			Start-Sleep -Seconds 1
@@ -7988,9 +7988,9 @@ Function Close-InstallationProgress {
 		if ($script:ProgressRunspace) {
 			# If the runspace is still opening, wait
 			[int]$Timeout = 0
-			while ((($script:ProgressRunspace.RunspaceStateInfo.State -eq [system.management.automation.runspaces.runspacestate]::Opening) -or ($script:ProgressRunspace.RunspaceStateInfo.State -eq [system.management.automation.runspaces.runspacestate]::BeforeOpen)) -and ($Timeout -le $configInstallationUITimeout)) {
+			while ((($script:ProgressRunspace.RunspaceStateInfo.State -eq [system.management.automation.runspaces.runspacestate]::Opening) -or ($script:ProgressRunspace.RunspaceStateInfo.State -eq [system.management.automation.runspaces.runspacestate]::BeforeOpen)) -and ($Timeout -le $WaitingTime)) {
 				if (-not $Timeout) {
-					Write-Log -Message 'The runspace for installation progress dialog is still opening. Waiting...' -Source ${CmdletName} -Severity 2
+					Write-Log -Message "The runspace for the installation progress dialog is still opening. Waiting up to $WaitingTime seconds..." -Source ${CmdletName} -Severity 2
 				}
 				$Timeout += 1
 				Start-Sleep -Seconds 1
@@ -8001,7 +8001,7 @@ Function Close-InstallationProgress {
 				$script:ProgressRunspace.Close()
 			}
 		} else {
-			Write-Log -Message 'The runspace for installation progress dialog is already closed...' -Source ${CmdletName} -Severity 2
+			Write-Log -Message 'The runspace for the installation progress dialog is already closed.' -Source ${CmdletName} -Severity 2
 		}
 
 		if ($script:ProgressSyncHash) {


### PR DESCRIPTION
- Fixed the toolkit checking task scheduler services twice
- Fixed the toolkit not creating $app variables if they are not created in Deploy-Application.ps1
- Reworked Close-InstallationProgress so it waits a couple of seconds in case the window is not opened yet
  - This fixes an issue where the Show-InstallationProgress dialog would not get closed on slower machines where Close-InstallationProgress was called right after Show-InstallationProgress

This patch also gets rid of sub functions inside Show-WelcomePrompt. Also fixes a couple of minor issues.

#532 #448 