### PR TITLE
Improved the computing of $dpiScale

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -531,13 +531,7 @@ If (Test-Path -LiteralPath 'variable:deferDays') { Remove-Variable -Name 'deferD
 		[int32]$dpiPixels = Get-RegistryKey -Key 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontDPI' -Value 'LogPixels'
 		[boolean]$UserDisplayScaleFactor = $false
 	}
-	Switch ($dpiPixels) {
-		96 { [int32]$dpiScale = 100 }
-		120 { [int32]$dpiScale = 125 }
-		144 { [int32]$dpiScale = 150 }
-		192 { [int32]$dpiScale = 200 }
-		Default { [int32]$dpiScale = 100 }
-	}
+	[int32]$dpiScale = [math]::Round( ($dpiPixels / 25), 0, 'AwayFromZero' ) * 25		# closest multiple of 25:  100, 125,150,175,200, ...,500.
 }
 #endregion
 ##*=============================================


### PR DESCRIPTION
Improved the computing of $dpiScale in the scriptblok $GetDisplayScaleFactor in AppDeployToolkitMain.ps1

Now $dpiScale is more accurate: any value of scaling will be taken into account, included 175% or 300% that will no longer default to 100.
Examples:
- For a user having set a scaling to 175%, $dpiPixels is 168. The computed $dpiScale is now 175 instead of 100.
- For a 4K big screen $dpiPixels is 288 when the scaling is set to "300% (Recommended)". The computed $dpiScale is now 300 instead of 100.

Before submitting this PR, I made sure:

- [X] I tested the toolkit with my changes. Made sure it doesn't break other code.

- [  ] I did not update the documentation with the changes I made because $dpiScale is not in the doc, it is only written to the log.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 without BOM.
