### PR TITLE
Multiple fixes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,4 @@
-**Version 3.8.4 [??/??/2020]**
+**Version 3.8.4 [??/??/2021]**
 - Fix Boolean parameters not being passed to Execute-Process
 - Changed Show-InstallationWelcome:
   - The buttons are now wider
@@ -16,12 +16,19 @@
   - Reworked the window to look consistent with Show-InstallationWelcome
 - Changed Show-InstallationProgress:
   - Reworked the window to look consistent with Show-InstallationWelcome
-- Fixed Set-ActiveSetup adding executed active setup registry key when -ExecuteForCurrentUser $false was specified
+  - Function now logs when it is being bypassed due to Deploy Mode
+- Changed Set-ActiveSetup:
+  - Fixed an issue where the function was adding executed active setup registry key when -ExecuteForCurrentUser $false was specified
+  - The function now checks the Active Setup registry key to evaluate whether to execute the StubPath based on the IsInstalled property
 - Fixed typo in Stop-ServiceAndDependencies saying "start" instead of "stop"
 - Fixed the toolkit checking task scheduler services twice
 - Fixed the toolkit not creating $app variables if they are not created in Deploy-Application.ps1
 - Reworked Close-InstallationProgress so it waits a couple of seconds in case the window is not opened yet
   - This fixes an issue where the Show-InstallationProgress dialog would not get closed on slower machines where Close-InstallationProgress was called right after Show-InstallationProgress
+  - Function now gets bypassed due to Silent Deploy Mode
+- Changed Execute-ProcessAsUser:
+  - The function now escapes invalid xml characters prior to using them in a xml file
+- Fixed signatures for a couple of functions inside AppDeployToolkitMain.cs based on official documentation - No breaking changes
 
 **Version 3.8.3 [01/10/2020]**
 - Added function Set-ItemPermission that allows you to easily change permissions on files or folders.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,7 +5,7 @@
   - The listbox is also wider so it is aligned with buttons
   - The countdown is now bigger and in bold
   - The appname is now in bold to be more visible
-  - The function now closes processes by name not by ID
+  - The function now internally closes processes by name not by ID
   - Fixed the hidden abort button not working on toolkit timeout
   - Performance improvements
 - Changed Show-InstallationPrompt:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -30,6 +30,7 @@
   - The function now escapes invalid xml characters prior to using them in a xml file
 - Fixed signatures for a couple of functions inside AppDeployToolkitMain.cs based on official documentation - No breaking changes
 - Performance improvements across the toolkit
+- Fixed a bug in Set-ItemPermission where SID translation did not work correctly
 
 **Version 3.8.3 [01/10/2020]**
 - Added function Set-ItemPermission that allows you to easily change permissions on files or folders.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,16 +1,16 @@
 **Version 3.8.4 [??/??/2021]**
 - Fix Boolean parameters not being passed to Execute-Process
 - Changed Show-InstallationWelcome:
-  - The buttons are now wider
-  - The listbox is also wider so it is aligned with buttons
-  - The countdown is now bigger and in bold
-  - The appname is now in bold to be more visible
-  - The function now internally closes processes by name not by ID
+  - Buttons are now wider
+  - Listbox is also wider so it is aligned with buttons
+  - Countdown is now bigger and in bold
+  - Appname is now in bold to be more visible
+  - Function now internally closes processes by name not by ID
   - Fixed the hidden abort button not working on toolkit timeout
   - Performance improvements
 - Changed Show-InstallationPrompt:
   - Fixed the hidden abort button not working on toolkit timeout
-  - The buttons are now identical in size and position to the ones in Show-InstallationWelcome
+  - Buttons are now identical in size and position to the ones in Show-InstallationWelcome
   - Increased the gap between the banner and the text when the message is too short
 - Changed Show-InstallationRestartPrompt:
   - Reworked the window to look consistent with Show-InstallationWelcome
@@ -19,13 +19,13 @@
   - Function now logs when it is being bypassed due to Deploy Mode
 - Changed Set-ActiveSetup:
   - Fixed an issue where the function was adding executed active setup registry key when -ExecuteForCurrentUser $false was specified
-  - The function now checks the Active Setup registry key to evaluate whether to execute the StubPath based on the IsInstalled property
+  - Function now checks the Active Setup registry key to evaluate whether to execute the StubPath based on the IsInstalled property
 - Fixed typo in Stop-ServiceAndDependencies saying "start" instead of "stop"
 - Fixed the toolkit checking task scheduler services twice
 - Fixed the toolkit not creating $app variables if they are not created in Deploy-Application.ps1
 - Reworked Close-InstallationProgress so it waits a couple of seconds in case the window is not opened yet
   - This fixes an issue where the Show-InstallationProgress dialog would not get closed on slower machines where Close-InstallationProgress was called right after Show-InstallationProgress
-  - Function now gets bypassed due to Silent Deploy Mode
+  - Function now gets bypassed in Silent Deploy Mode
 - Changed Execute-ProcessAsUser:
   - The function now escapes invalid xml characters prior to using them in a xml file
 - Fixed signatures for a couple of functions inside AppDeployToolkitMain.cs based on official documentation - No breaking changes

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,8 @@
 - Changed Execute-ProcessAsUser:
   - The function now escapes invalid xml characters prior to using them in a xml file
 - Fixed signatures for a couple of functions inside AppDeployToolkitMain.cs based on official documentation - No breaking changes
+- Performance improvements across the toolkit
+- Changed default baloontip time in Show-BalloonTip from 10s to 12s
 
 **Version 3.8.3 [01/10/2020]**
 - Added function Set-ItemPermission that allows you to easily change permissions on files or folders.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,6 +34,7 @@
 - Changed Show-BalloonTip:
   - Function Show-BalloonTip now logs when it is being bypassed
   - Added parameter -NoWait for asynchronous execution
+  - The icon tooltip now contains Title - Text
 
 **Version 3.8.3 [01/10/2020]**
 - Added function Set-ItemPermission that allows you to easily change permissions on files or folders.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,5 @@
 **Version 3.8.4 [??/??/2021]**
-- Fix Boolean parameters not being passed to Execute-Process
+- Fixed Boolean parameters not being passed to Execute-Process
 - Changed Show-InstallationWelcome:
   - Buttons are now wider
   - Listbox is also wider so it is aligned with buttons
@@ -30,7 +30,6 @@
   - The function now escapes invalid xml characters prior to using them in a xml file
 - Fixed signatures for a couple of functions inside AppDeployToolkitMain.cs based on official documentation - No breaking changes
 - Performance improvements across the toolkit
-- Changed default baloontip time in Show-BalloonTip from 10s to 12s
 
 **Version 3.8.3 [01/10/2020]**
 - Added function Set-ItemPermission that allows you to easily change permissions on files or folders.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,7 +31,9 @@
 - Fixed signatures for a couple of functions inside AppDeployToolkitMain.cs based on official documentation - No breaking changes
 - Performance improvements across the toolkit
 - Fixed a bug in Set-ItemPermission where SID translation did not work correctly
-- Function Show-BalloonTip now logs when it is being bypassed
+- Changed Show-BalloonTip:
+  - Function Show-BalloonTip now logs when it is being bypassed
+  - Added parameter -NoWait for asynchronous execution
 
 **Version 3.8.3 [01/10/2020]**
 - Added function Set-ItemPermission that allows you to easily change permissions on files or folders.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,6 +31,7 @@
 - Fixed signatures for a couple of functions inside AppDeployToolkitMain.cs based on official documentation - No breaking changes
 - Performance improvements across the toolkit
 - Fixed a bug in Set-ItemPermission where SID translation did not work correctly
+- Function Show-BalloonTip now logs when it is being bypassed
 
 **Version 3.8.3 [01/10/2020]**
 - Added function Set-ItemPermission that allows you to easily change permissions on files or folders.

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.cs
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.cs
@@ -38,7 +38,8 @@ namespace PSADT
 			IntPtr hModuleInstance = LoadLibraryEx("msimsg.dll", IntPtr.Zero, LoadLibraryFlags.LOAD_LIBRARY_AS_DATAFILE);
 
 			StringBuilder sb = new StringBuilder(255);
-			LoadString(hModuleInstance, errCode, sb, sb.Capacity + 1);
+			uint u = Convert.ToUInt32(errCode);
+			LoadString(hModuleInstance, u, sb, sb.Capacity + 1);
 
 			return sb.ToString();
 		}
@@ -82,8 +83,8 @@ namespace PSADT
 			IntPtr hShell32 = LoadLibrary("shell32.dll");
 			const int nChars  = 255;
 			StringBuilder Buff = new StringBuilder("", nChars);
-
-			LoadString(hShell32, VerbId, Buff, Buff.Capacity);
+			uint u = Convert.ToUInt32(VerbId);
+			LoadString(hShell32, u, Buff, Buff.Capacity);
 			return Buff.ToString();
 		}
 	}

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.cs
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.cs
@@ -30,7 +30,7 @@ namespace PSADT
 		static extern IntPtr LoadLibraryEx(string lpFileName, IntPtr hFile, LoadLibraryFlags dwFlags);
 
 		[DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = false)]
-		static extern int LoadString(IntPtr hInstance, int uID, StringBuilder lpBuffer, int nBufferMax);
+		static extern int LoadString(IntPtr hInstance, uint uID, StringBuilder lpBuffer, int nBufferMax);
 
 		// Get MSI exit code message from msimsg.dll resource dll
 		public static string GetMessageFromMsiExitCode(int errCode)
@@ -54,10 +54,10 @@ namespace PSADT
 		static extern bool SendNotifyMessage(IntPtr hWnd, int Msg, IntPtr wParam, IntPtr lParam);
 
 		[DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = false)]
-		private static extern IntPtr SendMessageTimeout(IntPtr hWnd, int Msg, IntPtr wParam, string lParam, int fuFlags, int uTimeout, IntPtr lpdwResult);
+		private static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, IntPtr wParam, string lParam, uint fuFlags, uint uTimeout, IntPtr lpdwResult);
 
 		[DllImport("shell32.dll", CharSet = CharSet.Auto, SetLastError = false)]
-		private static extern int SHChangeNotify(int eventId, int flags, IntPtr item1, IntPtr item2);
+		private static extern void SHChangeNotify(long eventId, uint flags, IntPtr item1, IntPtr item2);
 
 		public static void RefreshDesktopAndEnvironmentVariables()
 		{
@@ -72,7 +72,7 @@ namespace PSADT
 	public sealed class FileVerb
 	{
 		[DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = false)]
-		public static extern int LoadString(IntPtr h, int id, StringBuilder sb, int maxBuffer);
+		public static extern int LoadString(IntPtr h, uint id, StringBuilder sb, int maxBuffer);
 
 		[DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = false)]
 		public static extern IntPtr LoadLibrary(string s);

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -7591,7 +7591,7 @@ Function Show-BalloonTip {
 .PARAMETER BalloonTipIcon
 	Icon to be used. Options: 'Error', 'Info', 'None', 'Warning'. Default is: Info.
 .PARAMETER BalloonTipTime
-	Time in milliseconds to display the balloon tip. Default: 12000.
+	Time in milliseconds to display the balloon tip. Default: 10000.
 .EXAMPLE
 	Show-BalloonTip -BalloonTipText 'Installation Started' -BalloonTipTitle 'Application Name'
 .EXAMPLE
@@ -7613,7 +7613,7 @@ Function Show-BalloonTip {
 		[Windows.Forms.ToolTipIcon]$BalloonTipIcon = 'Info',
 		[Parameter(Mandatory=$false,Position=3)]
 		[ValidateNotNullorEmpty()]
-		[int32]$BalloonTipTime = 12000
+		[int32]$BalloonTipTime = 10000
 	)
 
 	Begin {

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -7625,11 +7625,6 @@ Function Show-BalloonTip {
 
 		## Dispose of previous balloon
 		If ($script:notifyIcon) { Try { $script:notifyIcon.Dispose() } Catch {} }
-		## Prepare Text - Cut it if longer than 63 chars
-		$BalloonTipIconText = $BalloonTipTitle + " - " + $BalloonTipText
-		if ($BalloonTipIconText.Length -gt 63) {
-			$BalloonTipIconText = $BalloonTipIconText.Substring(0,60) + "..."
-		}
 		## NoWait - Create the balloontip icon asynchronously
 		If ($NoWait) {
 			Write-Log -Message "Display balloon tip notification asynchronously with message [$BalloonTipText]." -Source ${CmdletName}
@@ -7655,6 +7650,12 @@ Function Show-BalloonTip {
 
 				## Load assembly containing class System.Windows.Forms and System.Drawing	
 				Add-Type -AssemblyName 'System.Windows.Forms','System.Drawing' -ErrorAction 'Stop'
+
+				## Prepare Text - Cut it if longer than 63 chars
+				$BalloonTipIconText = [String]::Concat($BalloonTipTitle,' - ',$BalloonTipText)
+				if ($BalloonTipIconText.Length -gt 63) {
+					$BalloonTipIconText = [String]::Concat($BalloonTipIconText.Substring(0,60),'...')
+				}
 
 				[Windows.Forms.ToolTipIcon]$BalloonTipIcon = $BalloonTipIcon
 				$script:notifyIcon = New-Object -TypeName 'System.Windows.Forms.NotifyIcon' -Property @{
@@ -7683,6 +7684,12 @@ Function Show-BalloonTip {
 		## Otherwise create the balloontip icon synchronously
 		Else {
 			Write-Log -Message "Display balloon tip notification with message [$BalloonTipText]." -Source ${CmdletName}
+
+			## Prepare Text - Cut it if longer than 63 chars
+			$BalloonTipIconText = $BalloonTipTitle + ' - ' + $BalloonTipText
+			if ($BalloonTipIconText.Length -gt 63) {
+				$BalloonTipIconText = $BalloonTipIconText.Substring(0,60) + '...'
+			}
 			[Windows.Forms.ToolTipIcon]$BalloonTipIcon = $BalloonTipIcon
 			$script:notifyIcon = New-Object -TypeName 'System.Windows.Forms.NotifyIcon' -Property @{
 				BalloonTipIcon = $BalloonTipIcon

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -7613,7 +7613,11 @@ Function Show-BalloonTip {
 	}
 	Process {
 		## Skip balloon if in silent mode
-		If (($deployModeSilent) -or (-not $configShowBalloonNotifications) -or (Test-PowerPoint)) { Return }
+		$presentationDetected = Test-PowerPoint
+		If (($deployModeSilent) -or (-not $configShowBalloonNotifications) -or $presentationDetected) { 
+			Write-Log -Message "Bypassing Show-BalloonTip [Mode: $deployMode, Config Show Balloon Notifications:$configShowBalloonNotifications, Presentation Detected:$presentationDetected]. BalloonTipText:$BalloonTipText" -Source ${CmdletName}
+			Return 
+		}
 
 		## Dispose of previous balloon
 		If ($script:notifyIcon) { Try { $script:notifyIcon.Dispose() } Catch {} }

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -6383,6 +6383,7 @@ Function Show-InstallationWelcome {
 						Write-Log -Message 'Specified [-PromptToSave] option will not be available because current process is running in session zero and is not interactive.' -Severity 2 -Source ${CmdletName}
 					}
 
+					Get-RunningProcesses -ProcessObjects $processObjects -OutVariable 'runningProcesses'
 					ForEach ($runningProcess in $runningProcesses) {
 						[psobject[]]$AllOpenWindowsForRunningProcess = Get-WindowTitle -GetAllWindowTitles -DisableFunctionLogging | Where-Object { $_.ParentProcess -eq $runningProcess.ProcessName }
 						#  If the PromptToSave parameter was specified and the process has a window open, then prompt the user to save work if there is work to be saved when closing window
@@ -10407,7 +10408,7 @@ Function Set-ActiveSetup {
 				}
 				Else {
 					# Skip if Active Setup reg key is present and IsInstalled is 1
-					If ((Get-RegistryKey -Key $HKCUActiveSetupKey -SID $UserProfile.SID -Value "IsInstalled" -ContinueOnError $true) -ne 1) {
+					If ((Get-RegistryKey -Key $HKCUActiveSetupKey -Value "IsInstalled" -ContinueOnError $true) -ne 1) {
 						Write-Log -Message 'Executing Active Setup StubPath file for the current user.' -Source ${CmdletName}
 						If ($CUArguments) {
 							$ExecuteResults = Execute-Process -FilePath $CUStubExePath -Parameters $CUArguments -PassThru -ExitOnProcessFailure $false

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -11317,7 +11317,7 @@ Function Set-ItemPermission {
 				$U = $U.remove(0,1)
 				try {
 					# Translate the SID
-					$Username = ConvertTo-NTAccountOrSID -SID $U
+					$UsersAccountName = ConvertTo-NTAccountOrSID -SID $U
 				}
 				catch {
 					Write-Log "Failed to translate SID [$U]. Skipping..." -Source ${CmdletName} -Severity 2

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -6384,7 +6384,7 @@ Function Show-InstallationWelcome {
 					}
 					# Update the process list right before closing, in case it changed
 					$runningProcesses = Get-RunningProcesses -ProcessObjects $processObjects
-					[string]$runningProcessDescriptions = ($runningProcesses.ProcessDescription | Sort-Object -Unique) -join ','
+					# Close running processes
 					ForEach ($runningProcess in $runningProcesses) {
 						[psobject[]]$AllOpenWindowsForRunningProcess = Get-WindowTitle -GetAllWindowTitles -DisableFunctionLogging | Where-Object { $_.ParentProcess -eq $runningProcess.ProcessName }
 						#  If the PromptToSave parameter was specified and the process has a window open, then prompt the user to save work if there is work to be saved when closing window
@@ -6430,7 +6430,12 @@ Function Show-InstallationWelcome {
 							Stop-Process -Name $runningProcess.ProcessName -Force -ErrorAction 'SilentlyContinue'
 						}
 					}
-					Start-Sleep -Seconds 2
+
+					if ($runningProcesses = Get-RunningProcesses -ProcessObjects $processObjects -DisableLogging) {
+						# Apps are still running, give them 2s to close. If they are still running, the Welcome Window will be displayed again
+						Write-Log -Message 'Sleeping for 2 seconds because the processes are still not closed...' -Source ${CmdletName}
+						Start-Sleep -Seconds 2
+					}
 				}
 				#  Stop the script (if not actioned before the timeout value)
 				ElseIf ($promptResult -eq 'Timeout') {


### PR DESCRIPTION
A lot of performance improvements in this one.

Changed some function signatures to the ones specified in the official documentation.

Removed some redundant code.

Only loading assemblies once.

Execute-ProcessAsUser now escapes XML characters prior to creating an xml file.

Added log messages to some Show- functions when the function is being bypassed due to deploy mode.

Set-ActiveSetup now doesn't execute the StubPath if the registry key for it exists in the CU hive with IsInstalled set to 1.

Show-InstallationWelcome now closes processes correctly if the user has reopened them while the window was running.

Fixes a couple of typos.

Fixes an issue with Set-ItemPermission where SID translation did not work correctly #598 