### PR TITLE
Remove backslashes at the start of $envLogonServer

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -35,6 +35,7 @@
   - Function Show-BalloonTip now logs when it is being bypassed
   - Added parameter -NoWait for asynchronous execution
   - The icon tooltip now contains Title - Text
+- Fixed an issue where $envLogonServer would start with backslashes
 
 **Version 3.8.3 [01/10/2020]**
 - Added function Set-ItemPermission that allows you to easily change permissions on files or folders.

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -148,6 +148,10 @@ If ($IsMachinePartOfDomain) {
 	Catch { }
 	# If running in system context or if GetHostEntry fails, fall back on the logonserver value stored in the registry
 	If (-not $envLogonServer) { [string]$envLogonServer = (Get-ItemProperty -LiteralPath 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Group Policy\History' -ErrorAction 'SilentlyContinue').DCName }
+	## Remove backslashes at the beginning
+	while ($envLogonServer.StartsWith('\')) {
+		$envLogonServer = $envLogonServer.Substring(1)
+	}
 
 	try {
 		[string]$MachineDomainController = [DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain().FindDomainController().Name


### PR DESCRIPTION
Removes backslashes at the start of $envLogonServer 
Fixes #155

Before submitting this PR, I made sure:

- [X] I tested the toolkit with my changes. Made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 without BOM.
