### PR TITLE
Clear a couple of global variables on exit

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -36,6 +36,9 @@
   - Added parameter -NoWait for asynchronous execution
   - The icon tooltip now contains Title - Text
 - Fixed an issue where $envLogonServer would start with backslashes
+- Fixed an issue where some global variable did not get cleared on exit
+  - This caused an issue if you ran multiple toolkits in the same powershell session. It would use the same log file for all toolkits.
+  - This only occured if you used the .ps1 files directly. Deploy-Application.exe opens a new session each time.
 
 **Version 3.8.3 [01/10/2020]**
 - Added function Set-ItemPermission that allows you to easily change permissions on files or folders.

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1267,6 +1267,11 @@ Function Exit-Script {
 	If ($script:notifyIcon) { Try { $script:notifyIcon.Dispose() } Catch {} }
 	## Reset powershell window title to its previous title
 	$Host.UI.RawUI.WindowTitle = $oldPSWindowTitle
+	## Reset variables in case another toolkit is being run in the same session
+	$global:logName = $null
+	$global:installTitle = $null
+	$global:installName = $null
+	$global:appName = $null
 	## Exit the script, returning the exit code to SCCM
 	If (Test-Path -LiteralPath 'variable:HostInvocation') { $script:ExitCode = $exitCode; Exit } Else { Exit $exitCode }
 }


### PR DESCRIPTION
If you run multiple toolkits in the same powershell session, these variable do not get reinitialized because they are not empty. This causes bugs, for example the log file is the same even though the toolkit is not. This PR resolves it but not if the script is exited without Exit-Script.

Fixes #567

Before submitting this PR, I made sure:

- [X] I tested the toolkit with my changes. Made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 without BOM.
