### PR TITLE
Added function Get-shortcut

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,9 +40,10 @@
   - This caused an issue if you ran multiple toolkits in the same powershell session. It would use the same log file for all toolkits.
   - This only occured if you used the .ps1 files directly. Deploy-Application.exe opens a new session each time.
 - Added function Set-Shortcut that allows you to change existing shortcuts
+- Added function Get-Shortcut to retrieve information from a shortcut
 - Changed New-Shortcut:
   - BREAKING CHANGE: IconIndex parameter is now an Integer. It was previously incorrectly specified as a String.
-  - Reworked the way this functions sets shortcut to run as admin
+  - Reworked the way this function sets shortcut to run as admin
   - Added additional checks for the input Path in order to provide better log messages and better handling of relative paths
   - Improved function help text
 

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5081,7 +5081,7 @@ Function Set-Shortcut {
 	Modifies a shortcut - .lnk or .url file, with configurable options. 
 	Only specify the parameters that you want to change.
 .PARAMETER Path
-	Path to the shortcut to change
+	Path to the shortcut to be changed
 .PARAMETER TargetPath
 	Changes target path or URL that the shortcut launches
 .PARAMETER Arguments
@@ -5273,9 +5273,9 @@ Function Get-Shortcut {
 .SYNOPSIS
 	Get information from a new .lnk or .url type shortcut
 .DESCRIPTION
-	Get information from a new .lnk or .url type shortcut. Returns as a hashtable.
+	Get information from a new .lnk or .url type shortcut. Returns a hashtable.
 .PARAMETER Path
-	Path to the shortcut to read
+	Path to the shortcut to get information from
 .PARAMETER ContinueOnError
 	Continue if an error is encountered. Default is: $true.
 .EXAMPLE
@@ -5358,7 +5358,7 @@ Function Get-Shortcut {
 				$Output.IconIndex = $Split[1]
 				## Drop the changes
 				$shortcut = $null
-
+				## Run as admin
 				[byte[]]$filebytes = [IO.FIle]::ReadAllBytes($FullPath)
 				if ($filebytes[21] -band 32) {
 					$Output.RunAsAdmin = $true

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5022,15 +5022,6 @@ Function New-Shortcut {
 
 			Write-Log -Message "Creating shortcut [$FullPath]." -Source ${CmdletName}
 			If ($extension -eq '.url') {
-				# if the icon path includes the index, split them
-				If ($IconLocation) {
-					[string[]]$Split = $IconLocation.Split(',')
-					$IconLocation = $Split[0]
-					# only use the index if the iconindex parameter is not used
-					if (-not $IconIndex) {
-						$IconIndex = $Split[1]
-					}
-				}
 				[string[]]$URLFile = '[InternetShortcut]'
 				$URLFile += "URL=$targetPath"
 				If ($IconIndex -ne $null) { $URLFile += "IconIndex=$IconIndex" }
@@ -5057,13 +5048,10 @@ Function New-Shortcut {
 				## Hotkey
 				If ($hotkey) { $shortcut.Hotkey = $hotkey }
 				## Icon
-				If (-not $IconIndex) {
+				If ($IconIndex -eq $null) {
 					$IconIndex = 0
 				}
-				If ($IconLocation -and (-not ($IconLocation.Contains(',')))) {
-					$IconLocation = $IconLocation + ",$IconIndex"
-				}
-				If ($IconLocation) { $shortcut.IconLocation = $IconLocation }
+				If ($IconLocation) { $shortcut.IconLocation = $IconLocation + ",$IconIndex" }
 				## Save the changes
 				$shortcut.Save()
 
@@ -5373,7 +5361,7 @@ Function Get-Shortcut {
 				[string[]]$Split = $shortcut.IconLocation.Split(',')
 				$Output.IconLocation = $Split[0]
 				$Output.IconIndex = $Split[1]
-				## Drop the changes
+				## Remove the variable
 				$shortcut = $null
 				## Run as admin
 				[byte[]]$filebytes = [IO.FIle]::ReadAllBytes($FullPath)

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5015,6 +5015,11 @@ Function New-Shortcut {
 				Throw
 			}
 
+			If (Test-Path -Path $FullPath -PathType Leaf) {
+				Write-Log -Message "The shortcut [$FullPath] already exists. Deleting the file..." -Source ${CmdletName}
+				Remove-File -Path $FullPath
+			}
+
 			Write-Log -Message "Creating shortcut [$FullPath]." -Source ${CmdletName}
 			If ($extension -eq '.url') {
 				# if the icon path includes the index, split them

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -4904,7 +4904,7 @@ Function New-Shortcut {
 .PARAMETER Arguments
 	Arguments to be passed to the target path
 .PARAMETER IconLocation
-	Location of the icon used for the shortcut
+	Location of the icon used for the shortcut. Can include icon index: <icon path>,<icon index>
 .PARAMETER IconIndex
 	Executables, DLLs, ICO files with multiple icons need the icon index to be specified. Integer.
 .PARAMETER Description
@@ -5087,7 +5087,7 @@ Function Set-Shortcut {
 .PARAMETER Arguments
 	Changes Arguments to be passed to the target path
 .PARAMETER IconLocation
-	Changes location of the icon used for the shortcut
+	Changes location of the icon used for the shortcut. Can include icon index: <icon path>,<icon index>
 .PARAMETER IconIndex
 	Executables, DLLs, ICO files with multiple icons need the icon index to be specified. Integer. Don't specify the parameter to keep the previous value.
 .PARAMETER Description

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5014,6 +5014,15 @@ Function New-Shortcut {
 
 			Write-Log -Message "Creating shortcut [$FullPath]." -Source ${CmdletName}
 			If ($extension -eq '.url') {
+				# if the icon path includes the index, split them
+				If ($IconLocation -and $iconLocation.Contains(',')) {
+					[string[]]$Split = $IconLocation.Split(',')
+					$iconLocation = $Split[0]
+					# only use the index if the iconindex parameter is not used
+					if (-not $iconIndex) {
+						$iconIndex = $Split[1]
+					}
+				}
 				[string[]]$URLFile = '[InternetShortcut]'
 				$URLFile += "URL=$targetPath"
 				If ($iconIndex) { $URLFile += "IconIndex=$iconIndex" }
@@ -5179,6 +5188,15 @@ Function Set-Shortcut {
 			Write-Log -Message "Changing shortcut [$Path]." -Source ${CmdletName}
 			If ($extension -eq '.url') {
 				[string[]]$URLFile = [IO.File]::ReadAllLines($Path)
+				# if the icon path includes the index, split them
+				If ($IconLocation -and $iconLocation.Contains(',')) {
+					[string[]]$Split = $IconLocation.Split(',')
+					$iconLocation = $Split[0]
+					# only use the index if the iconindex parameter is not used
+					if (-not $iconIndex) {
+						$iconIndex = $Split[1]
+					}
+				}
 				for($i = 0; $i -lt $URLFile.Length; $i++) {
 					$URLFile[$i] = $URLFile[$i].TrimStart()
 					if($URLFile[$i].StartsWith('URL=') -and $targetPath) { $URLFile[$i] = "URL=$targetPath" }
@@ -5329,9 +5347,9 @@ Function Get-Shortcut {
 				[string[]]$URLFile = [IO.File]::ReadAllLines($Path)
 				for($i = 0; $i -lt $URLFile.Length; $i++) {
 					$URLFile[$i] = $URLFile[$i].TrimStart()
-					if($URLFile[$i].StartsWith('URL=')) { $Output.TargetPath = $URLFile[$i] }
-					elseif($URLFile[$i].StartsWith('IconIndex=')) { $Output.IconIndex = $URLFile[$i] }
-					elseif($URLFile[$i].StartsWith('IconFile=')) { $Output.IconLocation = $URLFile[$i] }
+					if($URLFile[$i].StartsWith('URL=')) { $Output.TargetPath = $URLFile[$i].Replace('URL=','') }
+					elseif($URLFile[$i].StartsWith('IconIndex=')) { $Output.IconIndex = $URLFile[$i].Replace('IconIndex=','') }
+					elseif($URLFile[$i].StartsWith('IconFile=')) { $Output.IconLocation = $URLFile[$i].Replace('IconFile=','') }
 				}
 			} Else {
 				$shortcut = $shell.CreateShortcut($FullPath)

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5023,18 +5023,18 @@ Function New-Shortcut {
 			Write-Log -Message "Creating shortcut [$FullPath]." -Source ${CmdletName}
 			If ($extension -eq '.url') {
 				# if the icon path includes the index, split them
-				If ($IconLocation -and $iconLocation.Contains(',')) {
+				If ($IconLocation -and $IconLocation.Contains(',')) {
 					[string[]]$Split = $IconLocation.Split(',')
-					$iconLocation = $Split[0]
+					$IconLocation = $Split[0]
 					# only use the index if the iconindex parameter is not used
-					if (-not $iconIndex) {
-						$iconIndex = $Split[1]
+					if (-not $IconIndex) {
+						$IconIndex = $Split[1]
 					}
 				}
 				[string[]]$URLFile = '[InternetShortcut]'
 				$URLFile += "URL=$targetPath"
-				If ($iconIndex) { $URLFile += "IconIndex=$iconIndex" }
-				If ($IconLocation) { $URLFile += "IconFile=$iconLocation" }
+				If ($IconIndex) { $URLFile += "IconIndex=$IconIndex" }
+				If ($IconLocation) { $URLFile += "IconFile=$IconLocation" }
 				[IO.File]::WriteAllLines($FullPath,$URLFile,(new-object -TypeName Text.UTF8Encoding -ArgumentList $false))
 			} Else {
 				$shortcut = $shell.CreateShortcut($FullPath)
@@ -5057,13 +5057,13 @@ Function New-Shortcut {
 				## Hotkey
 				If ($hotkey) { $shortcut.Hotkey = $hotkey }
 				## Icon
-				If (-not $iconIndex) {
-					$iconIndex = 0
+				If (-not $IconIndex) {
+					$IconIndex = 0
 				}
-				If ($iconLocation -and (-not ($iconLocation.Contains(',')))) {
-					$iconLocation = $iconLocation + ",$iconIndex"
+				If ($IconLocation -and (-not ($IconLocation.Contains(',')))) {
+					$IconLocation = $IconLocation + ",$IconIndex"
 				}
-				If ($iconLocation) { $shortcut.IconLocation = $iconLocation }
+				If ($IconLocation) { $shortcut.IconLocation = $IconLocation }
 				## Save the changes
 				$shortcut.Save()
 
@@ -5199,19 +5199,19 @@ Function Set-Shortcut {
 			If ($extension -eq '.url') {
 				[string[]]$URLFile = [IO.File]::ReadAllLines($Path)
 				# if the icon path includes the index, split them
-				If ($IconLocation -and $iconLocation.Contains(',')) {
+				If ($IconLocation -and $IconLocation.Contains(',')) {
 					[string[]]$Split = $IconLocation.Split(',')
-					$iconLocation = $Split[0]
+					$IconLocation = $Split[0]
 					# only use the index if the iconindex parameter is not used
-					if (-not $iconIndex) {
-						$iconIndex = $Split[1]
+					if (-not $IconIndex) {
+						$IconIndex = $Split[1]
 					}
 				}
 				for($i = 0; $i -lt $URLFile.Length; $i++) {
 					$URLFile[$i] = $URLFile[$i].TrimStart()
 					if($URLFile[$i].StartsWith('URL=') -and $targetPath) { $URLFile[$i] = "URL=$targetPath" }
-					elseif($URLFile[$i].StartsWith('IconIndex=') -and $iconIndex) { $URLFile[$i] = "IconIndex=$iconIndex" }
-					elseif($URLFile[$i].StartsWith('IconFile=') -and $IconLocation) { $URLFile[$i] = "IconFile=$iconLocation" }
+					elseif($URLFile[$i].StartsWith('IconIndex=') -and $IconIndex) { $URLFile[$i] = "IconIndex=$IconIndex" }
+					elseif($URLFile[$i].StartsWith('IconFile=') -and $IconLocation) { $URLFile[$i] = "IconFile=$IconLocation" }
 				}
 				[IO.File]::WriteAllLines($Path,$URLFile,(new-object -TypeName Text.UTF8Encoding -ArgumentList $false))
 			} Else {
@@ -5243,28 +5243,28 @@ Function Set-Shortcut {
 				$TempIconLocation = $Split[0]
 				$TempIconIndex = $Split[1]
 				# Check whether a new icon path was specified
-				If ($iconLocation) {
+				If ($IconLocation) {
 					# New icon path was specified. Check whether new icon index was also specified
-					If ($iconIndex) {
+					If ($IconIndex) {
 						# Create new icon path from new icon path and new icon index
-						$iconLocation = $iconLocation + ",$iconIndex"
+						$IconLocation = $IconLocation + ",$IconIndex"
 					} else {
 						# No new icon index was specified as a parameter. Check whether it wasnt supplied as a part of the Path
-						If (-not ($iconLocation.Contains(','))) {
+						If (-not ($IconLocation.Contains(','))) {
 							# New icon index was not specified as a part of the Path, use the index from the shortcut
-							$iconLocation = $iconLocation + ",$TempIconIndex"
+							$IconLocation = $IconLocation + ",$TempIconIndex"
 						}
 						# The new path was specified and the icon index is a part of the path
 					}
 				} else {
 					# New icon path was not specified. Check whether new icon index was specified
-					If ($iconIndex) {
+					If ($IconIndex) {
 						# New icon index was specified, append it to the icon path from the shortcut
-						$iconLocation = $TempIconLocation + ",$iconIndex"
+						$IconLocation = $TempIconLocation + ",$IconIndex"
 					}
 					# New icon index was not specified neither was the icon path
 				}
-				If ($iconLocation) { $shortcut.IconLocation = $iconLocation }
+				If ($IconLocation) { $shortcut.IconLocation = $IconLocation }
 				## Save the changes
 				$shortcut.Save()
 

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5231,13 +5231,9 @@ Function Set-Shortcut {
 						# No new icon index was specified as a parameter. We will keep the old one
 						$IconLocation = $IconLocation + ",$TempIconIndex"
 					}
-				} else {
-					# New icon path was not specified. Check whether new icon index was specified
-					If ($IconIndex -ne $null) {
-						# New icon index was specified, append it to the icon path from the shortcut
-						$IconLocation = $TempIconLocation + ",$IconIndex"
-					}
-					# New icon index was not specified neither was the icon path
+				} elseif ($IconIndex -ne $null) {
+					# New icon index was specified, but not the icon location. Append it to the icon path from the shortcut
+					$IconLocation = $TempIconLocation + ",$IconIndex"
 				}
 				If ($IconLocation) { $shortcut.IconLocation = $IconLocation }
 				## Save the changes

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -4980,6 +4980,9 @@ Function New-Shortcut {
 				return
 			}
 			Try {
+				# Make sure Net framework current dir is synced with powershell cwd
+				[IO.Directory]::SetCurrentDirectory((Get-Location))
+				# Get full path
 				[string]$FullPath = [IO.Path]::GetFullPath($Path)
 			}
 			Catch {
@@ -5185,6 +5188,8 @@ Function Set-Shortcut {
 				}
 				return
 			}
+			# Make sure Net framework current dir is synced with powershell cwd
+			[IO.Directory]::SetCurrentDirectory((Get-Location))
 			Write-Log -Message "Changing shortcut [$Path]." -Source ${CmdletName}
 			If ($extension -eq '.url') {
 				[string[]]$URLFile = [IO.File]::ReadAllLines($Path)
@@ -5331,6 +5336,9 @@ Function Get-Shortcut {
 				return
 			}
 			Try {
+				# Make sure Net framework current dir is synced with powershell cwd
+				[IO.Directory]::SetCurrentDirectory((Get-Location))
+				# Get full path
 				[string]$FullPath = [IO.Path]::GetFullPath($Path)
 			}
 			Catch {
@@ -5342,7 +5350,6 @@ Function Get-Shortcut {
 			}
 
 			$Output = @{ Path = $FullPath }
-			Write-Log -Message "Reading shortcut [$FullPath]." -Source ${CmdletName}
 			If ($extension -eq '.url') {
 				[string[]]$URLFile = [IO.File]::ReadAllLines($Path)
 				for($i = 0; $i -lt $URLFile.Length; $i++) {


### PR DESCRIPTION
Adds function Get-Shortcut
Removes undocumented ability for parameter -IconLocation to accept <icon path>,<icon index> since we have -IconIndex
Fixed IconIndex 0 not being passed correctly

Before submitting this PR, I made sure:

- [X] I tested the toolkit with my changes. Made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 without BOM.
