### PR TITLE
Consistent use of two number signs for comments

### DIFF
--- a/Toolkit/Deploy-Application.ps1
+++ b/Toolkit/Deploy-Application.ps1
@@ -176,7 +176,7 @@ Try {
 			Execute-MSI @ExecuteDefaultMSISplat
 		}
 
-		# <Perform Uninstallation tasks here>
+		## <Perform Uninstallation tasks here>
 
 
 		##*===============================================
@@ -213,7 +213,7 @@ Try {
 			[hashtable]$ExecuteDefaultMSISplat =  @{ Action = 'Repair'; Path = $defaultMsiFile; }; If ($defaultMstFile) { $ExecuteDefaultMSISplat.Add('Transform', $defaultMstFile) }
 			Execute-MSI @ExecuteDefaultMSISplat
 		}
-		# <Perform Repair tasks here>
+		## <Perform Repair tasks here>
 
 		##*===============================================
 		##* POST-REPAIR


### PR DESCRIPTION
Making the "Perform X Tasks Here" comments consistently use two number signs.

Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [ ] I updated the documentation with the changes I made.
-- N/A

- [ ] The code I changed has comments with explanation.
-- N/A

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.
