### PR TITLE
Changed Close-InstallationProgress to allow 0 for the -WaitingTime parameter

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@
   - Changed the function so it doesn't prepare the window when -NoWait is specified. This also fixes a bug where the timers kept running in the background and were never stopped when -NoWait was specified.
   - The titlebar close button is now disabled.
   - Added -TopMost parameter
+  - Changed Close-InstallationProgress waiting time to 0 in the function so the user does not have to wait 5s if there is no progress dialog to close
 - Changed Show-InstallationWelcome
   - The titlebar close button is now disabled.
   - If CloseApps timer is enabled, but none of the processes are running, the countdown message will now be the same as the one when only the Countdown is enabled without CloseApps.
@@ -43,6 +44,7 @@
 - Fixed New-Shortcut, Set-Shortcut and Get-Shortcut not handling UNC paths
 - Changed $installPhase at the end of the Main script
   - This does not change anything if you run Deploy-Application.ps1, but if you dot source Main.ps1, this will make it so you're not stuck in Initialization
+- Changed Close-InstallationProgress to allow 0 for the -WaitingTime parameter
 
 **Version 3.8.4 [26/01/2021]**
 - Fixed Boolean parameters not being passed to Execute-Process

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1877,7 +1877,7 @@ Function Show-InstallationPrompt {
 
 		if (-not $AsyncToolkitLaunch) {
 			## Close the Installation Progress Dialog if running
-			Close-InstallationProgress
+			Close-InstallationProgress -WaitingTime 1
 		}
 
 		[string]$installPromptLoggedParameters = ($installPromptParameters.GetEnumerator() | ForEach-Object $ResolveParameters) -join ' '


### PR DESCRIPTION
Also changes Show-InstallationPrompt's use of Close-InstallationProgress so the user does not have to wait 5s if there is no progress dialog to close.

Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.
