### PR TITLE
Add $IsMultiSessionOS Toolkit Variable

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -190,6 +190,7 @@ If ($envOSVersionRevision) { [string]$envOSVersion = "$($envOSVersion.ToString()
 [boolean]$IsServerOS = [boolean]($envOSProductType -eq 3)
 [boolean]$IsDomainControllerOS = [boolean]($envOSProductType -eq 2)
 [boolean]$IsWorkStationOS = [boolean]($envOSProductType -eq 1)
+[boolean]$IsMultiSessionOS = [boolean]($envOSName -match '^Microsoft Windows \d+ Enterprise for Virtual Desktops$')
 Switch ($envOSProductType) {
 	3 { [string]$envOSProductTypeName = 'Server' }
 	2 { [string]$envOSProductTypeName = 'Domain Controller' }

--- a/wiki/Toolkit-Variables.md
+++ b/wiki/Toolkit-Variables.md
@@ -99,6 +99,7 @@ The toolkit has a number of internal variables which can be used in your script.
 | $IsServerOS                              | Is server OS? (e.g. $true/$false)                                                             |
 | $IsDomainControllerOS                    | Is domain controller OS? (e.g. $true/$false)                                                  |
 | $IsWorkStationOS                         | Is workstation OS? (e.g. $true/$false)                                                        |
+| $IsMultiSessionOS                         | Is Multi-Session OS? (e.g. $true/$false)                                                    |
 | $envOSProductTypeName                    | OS product type name (e.g. Server/Domain Controller/Workstation/Unknown)                      |
 | $Is64Bit                                 | Is this a 64-bit OS? (e.g. $true/$false)                                                      |
 | $envOSArchitecture                       | Represents the OS architecture (e.g. 32-Bit/64-Bit)                                           |


### PR DESCRIPTION
Before submitting this Pull Request, I made sure:

* [x] I tested the toolkit with my changes and made sure it doesn't break other code.
* [x] I updated the documentation with the changes I made.
* [x] The code I changed has comments with explanation.
* [x] The encoding of the file wasn't changed. It is still UTF8 with BOM.

Add $IsMultiSessionOS Toolkit Variable. This allows users to easily check if the current operating system is Windows Multi-Session or not. Keying off of $envOSName at guidance from a coworker and Microsoft.

PS Sorry for PR #695.