### PR TITLE
Execute-ProcessAsUser VBScript that will start PowerShell fix

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -7481,6 +7481,8 @@ https://psappdeploytoolkit.com
             $executeProcessAsUserScript | Out-File -FilePath "$executeAsUserTempPath\$($schTaskName).vbs" -Force -Encoding 'Default' -ErrorAction 'SilentlyContinue'
             $Path = "$envWinDir\System32\wscript.exe"
             $Parameters = "`"$executeAsUserTempPath\$($schTaskName).vbs`""
+            $EscapedPath = $Path
+            $EscapedParameters = $Parameters
 
             Try {
                 Set-ItemPermission -Path "$executeAsUserTempPath\$schTaskName.vbs" -User $UserName -Permission 'Read'


### PR DESCRIPTION
Be sure to also set EscapedPath and EscapedParameters in the code branch that creates a .vbs in the event you are trying to run PowerShell as $RunAsActiveUser - as these newer variables are referenced further down during scheduled task creatiion

Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.
