### PR TITLE
Change PSAppDeployToolkitAdminGuide.docx reference to PSAppDeployToolkit.pdf

### DIFF
--- a/Examples/AdobeReader/Readme.txt
+++ b/Examples/AdobeReader/Readme.txt
@@ -1,1 +1,1 @@
-Instructions for using this script are included in the PSAppDeployToolkitAdminGuide.docx document in the root of this project.
+Instructions for using this script are included in the PSAppDeployToolkit.pdf document in the root of this project.

--- a/Examples/Office2013/Readme.txt
+++ b/Examples/Office2013/Readme.txt
@@ -1,1 +1,1 @@
-Instructions for using this script are included in the PSAppDeployToolkitAdminGuide.docx document in the root of this project.
+Instructions for using this script are included in the PSAppDeployToolkit.pdf document in the root of this project.


### PR DESCRIPTION
Follow-up to de7fa6394aa6d4b69cb65874b2c1865e88488b3b that renamed the former `PSAppDeployToolkitAdminGuide.docx` document to `PSAppDeployToolkit.pdf`.