### PR TITLE
Mask Passwords in logs: AppDeployToolkitMain.ps1

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -16050,18 +16050,36 @@ If ($deployAppScriptFriendlyName) {
     Write-Log -Message "[$deployAppScriptFriendlyName] script version is [$deployAppScriptVersion]" -Source $appDeployToolkitName
 }
 If ($deployAppScriptParameters) {
+	$CommandLinePasswords = $deployAppScriptParameters | Select-String -Pattern "-(Password|Pwd|Passwords|Pwds):'([\w\d*.!@#$%^&(){}\[\]:"";'<>,.?/~`_+-=|\\]+)'[\s]?" -AllMatches | ForEach-Object { $_.Matches }
+
+	foreach ($CommandLinePassword in $CommandLinePasswords) {
+		$deployAppScriptParameters = $deployAppScriptParameters.replace($CommandLinePassword.groups[2].Value, "*******")
+	}
+
     Write-Log -Message "The following non-default parameters were passed to [$deployAppScriptFriendlyName]: [$deployAppScriptParameters]" -Source $appDeployToolkitName
 }
 If ($appDeployMainScriptFriendlyName) {
     Write-Log -Message "[$appDeployMainScriptFriendlyName] script version is [$appDeployMainScriptVersion]" -Source $appDeployToolkitName
 }
 If ($appDeployMainScriptParameters) {
+	$CommandLinePasswords = $appDeployMainScriptParameters | Select-String -Pattern "-(Password|Pwd|Passwords|Pwds):'([\w\d*.!@#$%^&(){}\[\]:"";'<>,.?/~`_+-=|\\]+)'[\s]?" -AllMatches | ForEach-Object { $_.Matches }
+
+	foreach ($CommandLinePassword in $CommandLinePasswords) {
+		$appDeployMainScriptParameters = $appDeployMainScriptParameters.replace($CommandLinePassword.groups[2].Value, "*******")
+	}
+
     Write-Log -Message "The following non-default parameters were passed to [$appDeployMainScriptFriendlyName]: [$appDeployMainScriptParameters]" -Source $appDeployToolkitName
 }
 If ($appDeployExtScriptFriendlyName) {
     Write-Log -Message "[$appDeployExtScriptFriendlyName] version is [$appDeployExtScriptVersion]" -Source $appDeployToolkitName
 }
 If ($appDeployExtScriptParameters) {
+	$CommandLinePasswordss = $appDeployExtScriptParameters | Select-String -Pattern "-(Password|Pwd|Passwords|Pwds):'([\w\d*.!@#$%^&(){}\[\]:"";'<>,.?/~`_+-=|\\]+)'[\s]?" -AllMatches | ForEach-Object { $_.Matches }
+
+	foreach ($CommandLinePassword in $CommandLinePasswords) {
+		$appDeployExtScriptParameters = $appDeployExtScriptParameters.replace($CommandLinePassword.groups[2].Value, "*******")
+	}
+
     Write-Log -Message "The following non-default parameters were passed to [$appDeployExtScriptFriendlyName]: [$appDeployExtScriptParameters]" -Source $appDeployToolkitName
 }
 Write-Log -Message "Computer Name is [$envComputerNameFQDN]" -Source $appDeployToolkitName


### PR DESCRIPTION
Mask passwords showed as command line in logs.
Parameters triggered : 
-Password
-Pwd
-Passwords
-Pwds

Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.
