### PR TITLE
Exclude defaultuser0 from Get-UserProfiles

### DIFF
--- a/Sources/BetaToolkit/AppDeployToolkitMain.ps1
+++ b/Sources/BetaToolkit/AppDeployToolkitMain.ps1
@@ -3516,7 +3516,8 @@ Function Get-UserProfiles {
 			ForEach-Object {
 				Get-ItemProperty -LiteralPath $_.PSPath -ErrorAction 'Stop' | Where-Object { ($_.ProfileImagePath) } |
 				Select-Object @{ Label = 'NTAccount'; Expression = { $(ConvertTo-NTAccountOrSID -SID $_.PSChildName).Value } }, @{ Label = 'SID'; Expression = { $_.PSChildName } }, @{ Label = 'ProfilePath'; Expression = { $_.ProfileImagePath } }
-			}
+			} |
+			Where-Object { $_.NTAccount -notmatch 'defaultuser0$'} # This excludes the "defaultuser0" account used by CloudExperienceHostBroker.exe
 			If ($ExcludeSystemProfiles) {
 				[string[]]$SystemProfiles = 'S-1-5-18', 'S-1-5-19', 'S-1-5-20'
 				[psobject[]]$UserProfiles = $UserProfiles | Where-Object { $SystemProfiles -notcontains $_.SID }

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -6480,7 +6480,7 @@ https://psappdeploytoolkit.com
                     Get-ItemProperty -LiteralPath $_.PSPath -ErrorAction 'Stop' | Where-Object { ($_.ProfileImagePath) } |
                         Select-Object @{ Label = 'NTAccount'; Expression = { $(ConvertTo-NTAccountOrSID -SID $_.PSChildName).Value } }, @{ Label = 'SID'; Expression = { $_.PSChildName } }, @{ Label = 'ProfilePath'; Expression = { $_.ProfileImagePath } }
                     } |
-                    Where-Object { $_.NTAccount } # This removes the "defaultuser0" account, which is a Windows 10 bug
+                    Where-Object { $_.NTAccount -notmatch 'defaultuser0$'} # This excludes the "defaultuser0" account used by CloudExperienceHostBroker.exe
             If ($ExcludeSystemProfiles) {
                 [String[]]$SystemProfiles = 'S-1-5-18', 'S-1-5-19', 'S-1-5-20'
                 [PSObject[]]$UserProfiles = $UserProfiles | Where-Object { $SystemProfiles -notcontains $_.SID }


### PR DESCRIPTION
Invoke-HKCURegistrySettingsForAllUsers called Get-UserProfiles and it returned defaultuser0. It 'interacted' with the defaultuser0 profile during a SCCM OSD task sequence in Post-Installation steps. It unloaded the defaultuser0 profile which caused CloudExperienceHostBroker.exe to reset OOBE and reboot.

[Post-Installation] :: Load the User [COMPUTERNAME\defaultuser0] registry hive in path [HKEY_USERS\S-1-5-21...
[Post-Installation] :: Unload the User [COMPUTERNAME\defaultuser0] registry hive in path [HKEY_USERS\S-1-5-21...

Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.
