### PR TITLE
- Better setup for `$ScriptSource` setup in `Write-Log`.

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1136,16 +1136,11 @@ https://psappdeploytoolkit.com
         #  Check if the script section is defined
         [Boolean]$ScriptSectionDefined = [Boolean](-not [String]::IsNullOrEmpty($ScriptSection))
         #  Get the file name of the source script
-        Try {
-            If ($script:MyInvocation.Value.ScriptName) {
-                [String]$ScriptSource = Split-Path -Path $script:MyInvocation.Value.ScriptName -Leaf -ErrorAction 'Stop'
-            }
-            Else {
-                [String]$ScriptSource = Split-Path -Path $script:MyInvocation.MyCommand.Definition -Leaf -ErrorAction 'Stop'
-            }
+        $ScriptSource = If (![System.String]::IsNullOrWhiteSpace($script:MyInvocation.ScriptName)) {
+            Split-Path -Path $script:MyInvocation.ScriptName -Leaf -ErrorAction SilentlyContinue
         }
-        Catch {
-            $ScriptSource = ''
+        Else {
+            Split-Path -Path $script:MyInvocation.MyCommand.Definition -Leaf -ErrorAction SilentlyContinue
         }
 
         ## Create script block for generating CMTrace.exe compatible log entry


### PR DESCRIPTION
* Repairs bad access to `$MyInvocation`, which has no `Value` member.
* Avoids all the try/catch block malarkey by using ErrorAction on the `Split-Path` calls.
* Deliberately uses `-ErrorAction SilentlyContinue` as PowerShell 2.x compatibility seems to be valued within this project still 😕.

Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.
