### PR TITLE
- Null checks for `Get-InstalledApplication`. (Targeted to dev)

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -3078,10 +3078,6 @@ https://psappdeploytoolkit.com
         [PSObject[]]$installedApplication = @()
         ForEach ($regKeyApp in $regKeyApplication) {
             Try {
-                [String]$appDisplayName = ''
-                [String]$appDisplayVersion = ''
-                [String]$appPublisher = ''
-
                 ## Bypass any updates or hotfixes
                 If ((-not $IncludeUpdatesAndHotfixes) -and (($regKeyApp.DisplayName -match '(?i)kb\d+') -or ($regKeyApp.DisplayName -match 'Cumulative Update') -or ($regKeyApp.DisplayName -match 'Security Update') -or ($regKeyApp.DisplayName -match 'Hotfix'))) {
                     $UpdatesSkippedCounter += 1
@@ -3089,9 +3085,9 @@ https://psappdeploytoolkit.com
                 }
 
                 ## Remove any control characters which may interfere with logging and creating file path names from these variables
-                $appDisplayName = $regKeyApp.DisplayName -replace '[^\p{L}\p{Nd}\p{Z}\p{P}]', ''
-                $appDisplayVersion = $regKeyApp.DisplayVersion -replace '[^\p{L}\p{Nd}\p{Z}\p{P}]', ''
-                $appPublisher = $regKeyApp.Publisher -replace '[^\p{L}\p{Nd}\p{Z}\p{P}]', ''
+                [String]$appDisplayName = $regKeyApp.DisplayName -replace '[^\p{L}\p{Nd}\p{Z}\p{P}]', ''
+                [String]$appDisplayVersion = ($regKeyApp | Select-Object -ExpandProperty DisplayVersion -ErrorAction SilentlyContinue) -replace '[^\p{L}\p{Nd}\p{Z}\p{P}]', ''
+                [String]$appPublisher = ($regKeyApp | Select-Object -ExpandProperty Publisher -ErrorAction SilentlyContinue) -replace '[^\p{L}\p{Nd}\p{Z}\p{P}]', ''
 
 
                 ## Determine if application is a 64-bit application

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -3052,15 +3052,14 @@ https://psappdeploytoolkit.com
         }
 
         ## Enumerate the installed applications from the registry for applications that have the "DisplayName" property
-        [PSObject[]]$regKeyApplication = @()
-        ForEach ($regKey in $regKeyApplications) {
+        [PSObject[]]$regKeyApplication = ForEach ($regKey in $regKeyApplications) {
             If (Test-Path -LiteralPath $regKey -ErrorAction 'SilentlyContinue' -ErrorVariable '+ErrorUninstallKeyPath') {
                 [PSObject[]]$UninstallKeyApps = Get-ChildItem -LiteralPath $regKey -ErrorAction 'SilentlyContinue' -ErrorVariable '+ErrorUninstallKeyPath'
                 ForEach ($UninstallKeyApp in $UninstallKeyApps) {
                     Try {
                         [PSObject]$regKeyApplicationProps = Get-ItemProperty -LiteralPath $UninstallKeyApp.PSPath -ErrorAction 'Stop'
-                        If ($regKeyApplicationProps.DisplayName) {
-                            [PSObject[]]$regKeyApplication += $regKeyApplicationProps
+                        If ($regKeyApplicationProps | Select-Object -ExpandProperty DisplayName -ErrorAction Ignore) {
+                            $regKeyApplicationProps
                         }
                     }
                     Catch {


### PR DESCRIPTION
- Only add apps to `$regKeyApplication` if the app has a DisplayName.
  * Prevents bad accesses later on under strict mode.
  * If the app doesn't have a DisplayName, what are we really checking anyway?
  * Remove setup where we += on an array, this destroys and re-creates the array every time and is a top performance killer.

- Repair some null property accesses in `Get-InstalledApplication`.
  * Not everything has a `DisplayVersion` or `Publisher` value, so this is safer under strict compliance modes.
  * Deliberately uses `-ErrorAction SilentlyContinue` as PowerShell 2.x compatibility seems to be valued within this project still 😕.


Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.
