### PR TITLE
- Null checks for `Execute-MSI`. (Targeted to dev)

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -3621,29 +3621,18 @@ https://psappdeploytoolkit.com
         }
 
         ## Check if the MSI is already installed. If no valid ProductCode to check, then continue with requested MSI action.
-        If ($MSIProductCode) {
-            If ($SkipMSIAlreadyInstalledCheck) {
-                [Boolean]$IsMsiInstalled = $false
-            }
-            Else {
+        [Boolean]$IsMsiInstalled = If ($MSIProductCode) {
+            If (!$SkipMSIAlreadyInstalledCheck) {
                 If ($IncludeUpdatesAndHotfixes) {
-                    [PSObject]$MsiInstalled = Get-InstalledApplication -ProductCode $MSIProductCode -IncludeUpdatesAndHotfixes
+                    !!(Get-InstalledApplication -ProductCode $MSIProductCode -IncludeUpdatesAndHotfixes)
                 }
                 Else {
-                    [PSObject]$MsiInstalled = Get-InstalledApplication -ProductCode $MSIProductCode
-                }
-                If ($MsiInstalled) {
-                    [Boolean]$IsMsiInstalled = $true
+                    !!(Get-InstalledApplication -ProductCode $MSIProductCode)
                 }
             }
         }
         Else {
-            If ($Action -eq 'Install') {
-                [Boolean]$IsMsiInstalled = $false
-            }
-            Else {
-                [Boolean]$IsMsiInstalled = $true
-            }
+            $Action -ne 'Install'
         }
 
         If (($IsMsiInstalled) -and ($Action -eq 'Install')) {

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -3426,6 +3426,7 @@ https://psappdeploytoolkit.com
     Process {
         ## Initialize variable indicating whether $Path variable is a Product Code or not
         [Boolean]$PathIsProductCode = $false
+        [String[]]$transforms = $null
 
         ## If the path matches a product code
         If ($Path -match $MSIProductCodeRegExPattern) {

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -3568,8 +3568,8 @@ https://psappdeploytoolkit.com
         }
 
         ## Get the ProductCode of the MSI
-        If ($PathIsProductCode) {
-            [String]$MSIProductCode = $path
+        [String]$MSIProductCode = If ($PathIsProductCode) {
+            $path
         }
         ElseIf ([IO.Path]::GetExtension($msiFile) -eq '.msi') {
             Try {
@@ -3577,7 +3577,7 @@ https://psappdeploytoolkit.com
                 If ($transforms) {
                     $GetMsiTablePropertySplat.Add( 'TransformPath', $transforms )
                 }
-                [String]$MSIProductCode = Get-MsiTableProperty @GetMsiTablePropertySplat | Select-Object -ExpandProperty 'ProductCode' -ErrorAction 'Stop'
+                Get-MsiTableProperty @GetMsiTablePropertySplat | Select-Object -ExpandProperty 'ProductCode' -ErrorAction 'Stop'
             }
             Catch {
                 Write-Log -Message "Failed to get the ProductCode from the MSI file. Continue with requested action [$Action]..." -Source ${CmdletName}


### PR DESCRIPTION
- Repair `$MSIProductCode` setup in `Execute-MSI`.
  * Because `$MSIProductCode` was being set in an if/elseif branch setup without an else branch, the variable was not guaranteed to be available on the stack.
  * Replacement setup guarantees variable is always available and works in strict compliance modes.

- Repair `$MsiInstalled` setup in `Execute-MSI`.
  * Original setup was more complicated than it needed to be and was resulting in boolean checks against psobject types.
  * The new setup is less lines and works properly in strict compliance mode.

Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.
