### PR TITLE
- Null checks for `Get-RunningProcesses`. (Targeted to dev)

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -8734,18 +8734,21 @@ https://psappdeploytoolkit.com
             [ScriptBlock]$whereObjectFilter = {
                 ForEach ($processObject in $processObjects) {
                     If ($_.ProcessName -ieq $processObject.ProcessName) {
-                        If ($processObject.ProcessDescription) {
-                            #  The description of the process provided as a Parameter to the function, e.g. -ProcessName "winword=Microsoft Office Word".
-                            Add-Member -InputObject $_ -MemberType 'NoteProperty' -Name 'ProcessDescription' -Value $processObject.ProcessDescription -Force -PassThru -ErrorAction 'SilentlyContinue'
-                        }
-                        ElseIf ($_.Description) {
-                            #  If the process already has a description field specified, then use it
-                            Add-Member -InputObject $_ -MemberType 'NoteProperty' -Name 'ProcessDescription' -Value $_.Description -Force -PassThru -ErrorAction 'SilentlyContinue'
-                        }
-                        Else {
-                            #  Fall back on the process name if no description is provided by the process or as a parameter to the function
-                            Add-Member -InputObject $_ -MemberType 'NoteProperty' -Name 'ProcessDescription' -Value $_.ProcessName -Force -PassThru -ErrorAction 'SilentlyContinue'
-                        }
+                        Add-Member -InputObject $_ -MemberType NoteProperty -Name ProcessDescription -Force -PassThru -Value $(
+                            If ($processObject.ProcessDescription) {
+                                #  The description of the process provided as a Parameter to the function, e.g. -ProcessName "winword=Microsoft Office Word".
+                                $processObject.ProcessDescription
+                            }
+                            ElseIf ($_.Description) {
+                                #  If the process already has a description field specified, then use it
+                                $_.Description
+                            }
+                            Else {
+                                #  Fall back on the process name if no description is provided by the process or as a parameter to the function
+                                $_.ProcessName
+                            }
+                        )
+
                         Write-Output -InputObject ($true)
                         Return
                     }

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -9177,6 +9177,7 @@ https://psappdeploytoolkit.com
                 [Boolean]$forceCountdown = $true
             }
             Set-Variable -Name 'closeAppsCountdownGlobal' -Value $closeAppsCountdown -Scope 'Script'
+            $promptResult = $null
 
             While ((Get-RunningProcesses -ProcessObjects $processObjects -OutVariable 'runningProcesses') -or (($promptResult -ne 'Defer') -and ($promptResult -ne 'Close'))) {
                 [String]$runningProcessDescriptions = ($runningProcesses | Where-Object { $_.ProcessDescription } | Select-Object -ExpandProperty 'ProcessDescription' | Sort-Object -Unique) -join ','


### PR DESCRIPTION
- Repair setup in `Get-RunningProcesses` whereby `PSNoteProperty` of `ProcessDescription` was being conditionally added.
  * It's so important to have a consistent API with objects in an array, and this was resulting in some objects having the member and others were not.
  * This fixes such a setup so that there's always a `ProcessDescription` member, which will be null when conditions aren't met.
  * This also repairs throws under strict compliance mode by ensuring there's never an access to a non-existent object member.

- Ensure `$promptResult` is available in `Get-RunningProcesses` before attempting to access the variable.
  * As it was not available on the stack before attempting to access it in the upcoming while loop, this resulted in a throw when using strict compliance mode.

Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.
