### PR TITLE
- Null checks/fixes for `Show-InstallationPrompt`. (Targeted to dev)

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -11060,10 +11060,13 @@ https://psappdeploytoolkit.com
             #  Invoke the progress runspace
             $null = $progressCmd.BeginInvoke()
             #  Allow the thread to be spun up safely before invoking actions against it.
-            Start-Sleep -Seconds 1
-            If ($script:ProgressSyncHash.Error) {
-                Write-Log -Message "Failure while displaying progress dialog. `r`n$(Resolve-Error -ErrorRecord $script:ProgressSyncHash.Error)" -Severity 3 -Source ${CmdletName}
-            }
+            do {
+                $running = $(try {$script:ProgressSyncHash.Window.Dispatcher.Thread.ThreadState -eq 'Running'} catch {$false})
+                If ($script:ProgressSyncHash.ContainsKey('Error')) {
+                    Write-Log -Message "Failure while displaying progress dialog. `r`n$(Resolve-Error -ErrorRecord $script:ProgressSyncHash.Error)" -Severity 3 -Source ${CmdletName}
+                    break
+                }
+            } until ($running)
         }
         ## Check if the progress thread is running before invoking methods on it
         ElseIf ($script:ProgressSyncHash.Window.Dispatcher.Thread.ThreadState -eq 'Running') {

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -10918,7 +10918,7 @@ https://psappdeploytoolkit.com
         }
 
         ## Check if the progress thread is running before invoking methods on it
-        If ($script:ProgressSyncHash.Window.Dispatcher.Thread.ThreadState -ne 'Running') {
+        If (!(Test-Path -LiteralPath 'variable:ProgressRunspace') -or !(Test-Path -LiteralPath 'variable:ProgressSyncHash') -or !$script:ProgressSyncHash.ContainsKey('Window') -or ($script:ProgressSyncHash.Window.Dispatcher.Thread.ThreadState -ne 'Running')) {
             #  Notify user that the software installation has started
             $balloonText = "$deploymentTypeName $configBalloonTextStart"
             Show-BalloonTip -BalloonTipIcon 'Info' -BalloonTipText $balloonText


### PR DESCRIPTION
- Repair `Start-Sleep -Seconds 1` setup in `Show-InstallationPrompt`.
  * I had a situation where 1 second wasn't enough before I was trying to pump another installation prompt message through.
  * This loop will spin until the ThreadState is truly running, which means it might be done in less than a second, or longer if it needs to.
  * Check is done within a sub-expressed try/catch block as under strict compliance mode, directly attempting to access ThreadState might not be possible until the dispatcher has set it up enough to be available.
  * The repositioned error check now safely checks that there's indeed an error before attempting to access `$ProgressSyncHash`'s key value.

- Add extra safety to the process thread checks in `Show-InstallationProgress`.
  * Directly attempting to access `$ProgressSyncHash` was resulting in an attempt to check a non-existent variable.

Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.
