### PR TITLE
- Miscellaneous fixes that I've lumped together. (Targeted to dev)

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1790,7 +1790,7 @@ https://psappdeploytoolkit.com
         New-ZipFile -DestinationArchiveDirectoryPath $configToolkitLogDir -DestinationArchiveFileName $DestinationArchiveFileName -SourceDirectory $logTempFolder -RemoveSourceAfterArchiving
     }
 
-    If ($script:notifyIcon) {
+    If (Test-Path -LiteralPath 'variable:notifyIcon') {
         Try {
             $script:notifyIcon.Dispose()
         }
@@ -10640,7 +10640,7 @@ https://psappdeploytoolkit.com
             Return
         }
         ## Dispose of previous balloon
-        If ($script:notifyIcon) {
+        If (Test-Path -LiteralPath 'variable:notifyIcon') {
             Try {
                 $script:notifyIcon.Dispose()
             }

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1134,6 +1134,9 @@ https://psappdeploytoolkit.com
         If (-not (Test-Path -LiteralPath 'variable:DisableLogging')) {
             $DisableLogging = $false
         }
+        If ([System.String]::IsNullOrWhiteSpace($LogFileName)) {
+            $DisableLogging = $true
+        }
         #  Check if the script section is defined
         [Boolean]$ScriptSectionDefined = [Boolean](-not [String]::IsNullOrEmpty($ScriptSection))
         #  Get the file name of the source script

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -12261,9 +12261,7 @@ https://psappdeploytoolkit.com
             ## Create a Windows Installer object
             [__ComObject]$Installer = New-Object -ComObject 'WindowsInstaller.Installer' -ErrorAction 'Stop'
             ## Determine if the database file is a patch (.msp) or not
-            If ([IO.Path]::GetExtension($Path) -eq '.msp') {
-                [Boolean]$IsMspFile = $true
-            }
+            [Boolean]$IsMspFile = [IO.Path]::GetExtension($Path) -eq '.msp'
             ## Define properties for how the MSI database is opened
             [Int32]$msiOpenDatabaseModeReadOnly = 0
             [Int32]$msiSuppressApplyTransformErrors = 63

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -482,6 +482,7 @@ If ($configToolkitRequireAdmin -eq $false) {
     #  If a user is logged on, then get primary UI language for logged on user (even if running in session 0)
     If ($RunAsActiveUser) {
         #  Read language defined by Group Policy
+        [String[]]$HKULanguages = $null
         If (-not $HKULanguages) {
             [String[]]$HKULanguages = Get-RegistryKey -Key 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\MUI\Settings' -Value 'PreferredUILanguages'
         }

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -4228,6 +4228,7 @@ https://psappdeploytoolkit.com
     Process {
         Try {
             $private:returnCode = $null
+            $stdOut = $stdErr = $null
 
             ## Validate and find the fully qualified path for the $Path variable.
             If (([IO.Path]::IsPathRooted($Path)) -and ([IO.Path]::HasExtension($Path))) {

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1698,11 +1698,6 @@ https://psappdeploytoolkit.com
     ## Get the name of this function
     [String]${CmdletName} = $PSCmdlet.MyInvocation.MyCommand.Name
 
-    ## Stop the Close Program Dialog if running
-    If ($formCloseApps) {
-        $formCloseApps.Close
-    }
-
     ## Close the Installation Progress Dialog if running
     Close-InstallationProgress
 

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -11887,7 +11887,7 @@ https://psappdeploytoolkit.com
         If (-not $DLLAction) {
             Throw 'Parameter validation failed. Please specify the [-DLLAction] parameter to determine whether to register or unregister the DLL.'
         }
-        [String]$DLLAction = ((Get-Culture).TextInfo).ToTitleCase($DLLAction.ToLower())
+        [String]$DLLAction = $culture.TextInfo.ToTitleCase($DLLAction.ToLower())
         Switch ($DLLAction) {
             'Register' {
                 [String]$DLLActionParameters = "/s `"$FilePath`""

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -414,7 +414,7 @@ If (-not (Test-Path -LiteralPath $appDeployCustomTypesSourceCode -PathType 'Leaf
 
 # Get Toast Notification Options
 [Xml.XmlElement]$xmlToastOptions = $xmlConfig.Toast_Options
-[String]$configToastDisable = $xmlToastOptions.Toast_Disable
+[Boolean]$configToastDisable = [Boolean]::Parse($xmlToastOptions.Toast_Disable)
 [String]$configToastAppName = $xmlToastOptions.Toast_AppName
 
 [String]$appDeployLogoIcon = Join-Path -Path $scriptRoot -ChildPath $configBannerIconFileName


### PR DESCRIPTION
Most of these are bad variable accesses while running under `Set-StrictMode -Version Latest`. I'd implore you to consider enabling this mode within your module by default to allow stricter checks against undefined behaviour.

- `$configToastDisable` should be a bool and not a string.
- Ensure `$HKULanguages` is defined before attempting to access the variable.
  * Such setups breaks PowerShell when running strict compliance mode, such as `Set-StrictMode -Version Latest`.
- Set `$DisableLogging` to `$true` in `Write-Log` if `$LogFileName` is null/hasn't been set up yet.
  * Was flagging either under PowerShell 7, or when strict mode was on as the call to `Out-File` later on was firing before the `$logFile` global was initialised.
- Remove dead code relating to `$formCloseApps`.
  * Variable seems to be a remnant from a previous setup.
  * The remains of this was causing the script to throw under strict compliance mode.
- Repair `$script:notifyIcon` tests.
  * This was throwing under strict compliance mode as the variable is not guaranteed to be there. This check is safer under such situations.
- Ensure `$stdOut` and `$stdErr` are always available on the stack in `Execute-Process`.
  * These variables were only being defined deep within a branch, then the resulting attempt to access was against variables that possibly didn't exist.
- Leverage pre-existing `$culture` global inside `Invoke-RegisterOrUnregisterDLL`.
- Repair bad `$IsMspFile` setup that caused the upcoming branch to fail in strict compliance mode.

 
Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.
