### PR TITLE
- Allow `Write-Log` calls with `-Severity 0` to indicate success. (Targeted to dev)

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1069,7 +1069,7 @@ https://psappdeploytoolkit.com
         [Alias('Text')]
         [String[]]$Message,
         [Parameter(Mandatory = $false, Position = 1)]
-        [ValidateRange(1, 3)]
+        [ValidateRange(0, 3)]
         [Int16]$Severity = 1,
         [Parameter(Mandatory = $false, Position = 2)]
         [ValidateNotNull()]
@@ -1177,6 +1177,9 @@ https://psappdeploytoolkit.com
                         1 {
                             Write-Host -Object $lTextLogLine
                         }
+                        0 {
+                            Write-Host -Object $lTextLogLine -ForegroundColor 'Green' -BackgroundColor 'Black'
+                        }
                     }
                 }
                 #  If executing "powershell.exe -File <filename>.ps1 > log.txt", then all the Write-Host calls are converted to Write-Output calls so that they are included in the text log.
@@ -1274,6 +1277,9 @@ https://psappdeploytoolkit.com
                         1 {
                             [String]$LegacyTextLogLine = "$LegacyMsg [$Source] [Info] :: $Msg"
                         }
+                        0 {
+                            [String]$LegacyTextLogLine = "$LegacyMsg [$Source] [Success] :: $Msg"
+                        }
                     }
                 }
                 Else {
@@ -1287,6 +1293,9 @@ https://psappdeploytoolkit.com
                         }
                         1 {
                             [String]$LegacyTextLogLine = "$LegacyMsg [Info] :: $Msg"
+                        }
+                        0 {
+                            [String]$LegacyTextLogLine = "$LegacyMsg [Success] :: $Msg"
                         }
                     }
                 }


### PR DESCRIPTION
* Surprisingly to me, OneTrace picked this straight up as an indication of success. I thought for sure I'd have to clamp off the value.
* Fixes #821.

Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.
