### PR TITLE
- Dot-source `AppDeployToolkitExtensions.ps1` slightly earlier. (Targeted to dev)

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -16114,6 +16114,23 @@ If (-not ([Management.Automation.PSTypeName]'PSADT.UiAutomation').Type) {
 ## Disable logging until log file details are available
 . $DisableScriptLogging
 
+## Dot source ScriptBlock to get a list of all users logged on to the system (both local and RDP users), and discover session details for account executing script
+. $GetLoggedOnUserDetails
+
+## Dot source ScriptBlock to create temporary directory of logged on user
+. $GetLoggedOnUserTempPath
+
+## Dot source ScriptBlock to load localized UI messages from config XML
+. $xmlLoadLocalizedUIMessages
+
+## Dot source ScriptBlock to get system DPI scale factor
+. $GetDisplayScaleFactor
+
+## Dot Source script extensions
+If (Test-Path -LiteralPath "$scriptRoot\$appDeployToolkitDotSourceExtensions" -PathType 'Leaf') {
+    . "$scriptRoot\$appDeployToolkitDotSourceExtensions"
+}
+
 ## If the default Deploy-Application.ps1 hasn't been modified, and the main script was not called by a referring script, check for MSI / MST and modify the install accordingly
 If ((-not $appName) -and (-not $ReferredInstallName)) {
     # Build properly formatted Architecture String
@@ -16312,11 +16329,6 @@ Else {
     Write-Log -Message "Script [$scriptPath] invoked directly" -Source $appDeployToolkitName
 }
 
-## Dot Source script extensions
-If (Test-Path -LiteralPath "$scriptRoot\$appDeployToolkitDotSourceExtensions" -PathType 'Leaf') {
-    . "$scriptRoot\$appDeployToolkitDotSourceExtensions"
-}
-
 ## Evaluate non-default parameters passed to the scripts
 If ($deployAppScriptParameters) {
     [String]$deployAppScriptParameters = ($deployAppScriptParameters.GetEnumerator() | ForEach-Object { & $ResolveParameters $_ }) -join ' '
@@ -16380,24 +16392,6 @@ Write-Log -Message "PowerShell Host is [$($envHost.Name)] with version [$($envHo
 Write-Log -Message "PowerShell Version is [$envPSVersion $psArchitecture]" -Source $appDeployToolkitName
 Write-Log -Message "PowerShell CLR (.NET) version is [$envCLRVersion]" -Source $appDeployToolkitName
 Write-Log -Message $scriptSeparator -Source $appDeployToolkitName
-
-## Disable logging
-. $DisableScriptLogging
-
-## Dot source ScriptBlock to get a list of all users logged on to the system (both local and RDP users), and discover session details for account executing script
-. $GetLoggedOnUserDetails
-
-## Dot source ScriptBlock to create temporary directory of logged on user
-. $GetLoggedOnUserTempPath
-
-## Dot source ScriptBlock to load localized UI messages from config XML
-. $xmlLoadLocalizedUIMessages
-
-## Dot source ScriptBlock to get system DPI scale factor
-. $GetDisplayScaleFactor
-
-## Revert script logging to original setting
-. $RevertScriptLogging
 
 ## Set the install phase to asynchronous if the script was not dot sourced, i.e. called with parameters
 If ($AsyncToolkitLaunch) {


### PR DESCRIPTION
* Can allow for some very specific setups whereby a caller might be downloading an MSI on demand and wants it available prior to running the Zero-Config MSI code, but wants `Show-InstallationProgress` to be callable/accessible (niche requirement, I know).

Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.
