### PR TITLE
Replace recent append functionality with full log rotation

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitConfig.xml
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitConfig.xml
@@ -44,12 +44,14 @@
         <!-- Specify if log file should be a CMTrace compatible log file or a Legacy text log file. -->
         <Toolkit_LogDebugMessage>False</Toolkit_LogDebugMessage>
         <!-- Specify if debug messages such as bound parameters passed to a function should be logged. -->
-        <Toolkit_LogMaxSize>10</Toolkit_LogMaxSize>
-        <!-- Specify maximum file size limit for log file in megabytes (MB). -->
         <Toolkit_LogWriteToHost>True</Toolkit_LogWriteToHost>
         <!-- Specify if log messages should be written to the console. -->
-        <Toolkit_LogDoNotAppend>False</Toolkit_LogDoNotAppend>
-        <!-- Specify if an existing log file should not be appended to. -->
+        <Toolkit_LogAppend>True</Toolkit_LogAppend>
+        <!-- Specify if an existing log file should be appended to. -->
+        <Toolkit_LogMaxSize>10</Toolkit_LogMaxSize>
+        <!-- Specify maximum file size limit for log file in megabytes (MB). -->
+        <Toolkit_LogMaxHistory>10</Toolkit_LogMaxHistory>
+        <!-- Specify maximum number of previous log files to retain. -->
         <Toolkit_UseRobocopy>True</Toolkit_UseRobocopy>
         <!-- Specify if Robocopy should be used with the Copy-File function. -->
         <Toolkit_CachePath>$envProgramData\SoftwareCache</Toolkit_CachePath>

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1231,33 +1231,33 @@ https://psappdeploytoolkit.com
 
         if (Test-Path -Path $LogFilePath -PathType Leaf) {
             Try {
-                $ExistingLogFile = Get-Item $LogFilePath
-                [Decimal]$ExistingLogFileSizeMB = $ExistingLogFile.Length / 1MB
+                $LogFile = Get-Item $LogFilePath
+                [Decimal]$LogFileSizeMB = $LogFile.Length / 1MB
 
                 # Check if log file needs to be rotated
-                if ((!$script:LogFileInitialized -and !$AppendToLogFile) -or ($MaxLogFileSizeMB -gt 0 -and $ExistingLogFileSizeMB -gt $MaxLogFileSizeMB)) {
+                if ((!$script:LogFileInitialized -and !$AppendToLogFile) -or ($MaxLogFileSizeMB -gt 0 -and $LogFileSizeMB -gt $MaxLogFileSizeMB)) {
 
                     # Get new log file path
                     $LogFileNameWithoutExtension = [IO.Path]::GetFileNameWithoutExtension($LogFileName)
                     $LogFileExtension = [IO.Path]::GetExtension($LogFileName)
-                    $Timestamp = Get-Date -Format 'yyyy-MM-dd-HH-mm-ss'
-                    $ArchivedLogFileName = "{0}_{1}{2}" -f $LogFileNameWithoutExtension, $Timestamp, $LogFileExtension
-                    [String]$ArchivedLogFilePath = Join-Path -Path $LogFileDirectory -ChildPath $ArchivedLogFileName
+                    $Timestamp = $LogFile.LastWriteTime.ToString('yyyy-MM-dd-HH-mm-ss')
+                    $ArchiveLogFileName = "{0}_{1}{2}" -f $LogFileNameWithoutExtension, $Timestamp, $LogFileExtension
+                    [String]$ArchiveLogFilePath = Join-Path -Path $LogFileDirectory -ChildPath $ArchiveLogFileName
 
-                    if ($MaxLogFileSizeMB -gt 0 -and $ExistingLogFileSizeMB -gt $MaxLogFileSizeMB) {
+                    if ($MaxLogFileSizeMB -gt 0 -and $LogFileSizeMB -gt $MaxLogFileSizeMB) {
                         [Hashtable]$ArchiveLogParams = @{ ScriptSection = $ScriptSection; Source = ${CmdletName}; Severity = 2; LogFileDirectory = $LogFileDirectory; LogFileName = $LogFileName; LogType = $LogType; MaxLogFileSizeMB = 0; AppendToLogFile = $true; WriteHost = $WriteHost; ContinueOnError = $ContinueOnError; PassThru = $false }
 
                         ## Log message about archiving the log file
-                        $ArchiveLogMessage = "Maximum log file size [$MaxLogFileSizeMB MB] reached. Rename log file to [$ArchivedLogFileName]."
+                        $ArchiveLogMessage = "Maximum log file size [$MaxLogFileSizeMB MB] reached. Rename log file to [$ArchiveLogFileName]."
                         Write-Log -Message $ArchiveLogMessage @ArchiveLogParams
                     }
 
                     # Rename the file
-                    Move-Item -Path $LogFilePath -Destination $ArchivedLogFilePath -Force -ErrorAction 'Stop'
+                    Move-Item -Path $LogFilePath -Destination $ArchiveLogFilePath -Force -ErrorAction 'Stop'
 
-                    if ($MaxLogFileSizeMB -gt 0 -and $ExistingLogFileSizeMB -gt $MaxLogFileSizeMB) {
+                    if ($MaxLogFileSizeMB -gt 0 -and $LogFileSizeMB -gt $MaxLogFileSizeMB) {
                         ## Start new log file and Log message about archiving the old log file
-                        $NewLogMessage = "Previous log file was renamed to [$ArchivedLogFileName] because maximum log file size of [$MaxLogFileSizeMB MB] was reached."
+                        $NewLogMessage = "Previous log file was renamed to [$ArchiveLogFileName] because maximum log file size of [$MaxLogFileSizeMB MB] was reached."
                         Write-Log -Message $NewLogMessage @ArchiveLogParams
                     }
 


### PR DESCRIPTION
Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made. (only help inside function updated - main docs and site still to do)

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.

I branched off of Master rather than Dev, since that's where the recent commits were made for the 'DoNotAppend' funcionality.
Order of a few params in Write-Log have changed (just for aesthetics) that might technically be a breaking change, although very unlikely people would be using 10+ positional parameters.

- Default is <Toolkit_LogAppend>True</Toolkit_LogAppend> (which behaves the same as 3.9.3)
- Turn that to false and you have managed log rotation. 
- Handling is combined with the max log size routine, which has now moved from the End to the Begin block of Write-Log
- Max history set by <Toolkit_LogMaxHistory>; if set to 0 it will just retain the latest log only.
- Kept the -AppendToLogFile parameter in the function - turns out this is required so that we can force enable append when writing to the end of a log that has reached max size.
- Naming convention to append datetime matches that used by the zip files, with .log extension.
- Previous naming convention to rename to .lo_ when max size reach is also included in the files checked for deletion.
- Same history count is applied to zip files if compression is enabled.