### PR TITLE
- Fix setup to `$envOffice` variables. (Targeted to dev)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@
 - Improved Execute-ProcessAsUser and how it parses and executes commandline arguments. #794 #894 #782 #762 #851
 - Improve $envOffice variable setup by reducing the number of Get-ItemProperty calls.
 - Factor in GPO-configured UpdateChannel property vs. CDNBaseURL property for $envOfficeChannel. #837
+- Add "monthly enterprise" UUID to $envOfficeChannel setup.
 
 **Version 3.9.3 [01/05/2023]**
 - Improved accuracy of Intune Provisioning/ESP detection #779 #801

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@
 - Improved Get-HardwarePlatform to add support for detecting Parallels virtual machines #838
 - Improved Execute-ProcessAsUser and how it parses and executes commandline arguments. #794 #894 #782 #762 #851
 - Improve $envOffice variable setup by reducing the number of Get-ItemProperty calls.
+- Factor in GPO-configured UpdateChannel property vs. CDNBaseURL property for $envOfficeChannel. #837
 
 **Version 3.9.3 [01/05/2023]**
 - Improved accuracy of Intune Provisioning/ESP detection #779 #801

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@
 - Improved Execute-MSI so that all repetitive references to .log or .txt file extension in $LogName variable are all removed #759
 - Improved Get-HardwarePlatform to add support for detecting Parallels virtual machines #838
 - Improved Execute-ProcessAsUser and how it parses and executes commandline arguments. #794 #894 #782 #762 #851
+- Improve $envOffice variable setup by reducing the number of Get-ItemProperty calls.
 
 **Version 3.9.3 [01/05/2023]**
 - Improved accuracy of Intune Provisioning/ESP detection #779 #801

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -296,8 +296,14 @@ Else {
 [String]$envOfficeBitness = If ($envOfficeVars | Select-Object -ExpandProperty Platform -ErrorAction SilentlyContinue) {
     $envOfficeVars.Platform
 }
-[String]$envOfficeChannel = If ($envOfficeVars | Select-Object -ExpandProperty CDNBaseURL -ErrorAction SilentlyContinue) {
-    Switch -regex ($envOfficeVars.CDNBaseURL) {
+[String]$envOfficeChannelProperty = If ($envOfficeVars | Select-Object -ExpandProperty UpdateChannel -ErrorAction SilentlyContinue) {
+    $envOfficeVars.UpdateChannel
+}
+ElseIf ($envOfficeVars | Select-Object -ExpandProperty CDNBaseURL -ErrorAction SilentlyContinue) {
+    $envOfficeVars.CDNBaseURL
+}
+[String]$envOfficeChannel = If ($envOfficeChannelProperty) {
+    Switch -regex ($envOfficeChannelProperty) {
         "492350f6-3a01-4f97-b9c0-c7c6ddf67d60" {"monthly"}
         "7ffbc6bf-bc32-4f92-8982-f9dd17fd3114" {"semi-annual"}
         "64256afe-f5d9-4f86-8936-8840a6a4f5be" {"monthly targeted"}

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -289,19 +289,19 @@ Else {
 }
 
 ## Variables: Office C2R version, bitness and channel
-If ((Get-ItemProperty -LiteralPath 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Office\ClickToRun\Configuration' -ErrorAction 'SilentlyContinue').PSObject.Properties.Name -contains 'VersionToReport') {
-    [String]$envOfficeVersion = (Get-ItemProperty -LiteralPath 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Office\ClickToRun\Configuration' -Name 'VersionToReport' -ErrorAction 'SilentlyContinue').VersionToReport
+[PSObject]$envOfficeVars = Get-ItemProperty -LiteralPath 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Office\ClickToRun\Configuration' -ErrorAction 'SilentlyContinue'
+[String]$envOfficeVersion = If ($envOfficeVars | Select-Object -ExpandProperty VersionToReport -ErrorAction SilentlyContinue) {
+    $envOfficeVars.VersionToReport
 }
-If ((Get-ItemProperty -LiteralPath 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Office\ClickToRun\Configuration' -ErrorAction 'SilentlyContinue').PSObject.Properties.Name -contains 'Platform') {
-    [String]$envOfficeBitness = (Get-ItemProperty -LiteralPath 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Office\ClickToRun\Configuration' -Name 'Platform' -ErrorAction 'SilentlyContinue').Platform
+[String]$envOfficeBitness = If ($envOfficeVars | Select-Object -ExpandProperty Platform -ErrorAction SilentlyContinue) {
+    $envOfficeVars.Platform
 }
-If ((Get-ItemProperty -LiteralPath 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Office\ClickToRun\Configuration' -ErrorAction 'SilentlyContinue').PSObject.Properties.Name -contains 'CDNBaseURL') {
-    [String]$envOfficeCDNBaseURL = (Get-ItemProperty -LiteralPath 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Office\ClickToRun\Configuration' -Name 'CDNBaseURL' -ErrorAction 'SilentlyContinue').CDNBaseURL
-    Switch -regex ([String]$envofficeCDNBaseURL) {
-        "492350f6-3a01-4f97-b9c0-c7c6ddf67d60" {$envOfficeChannel = "monthly"}
-        "7ffbc6bf-bc32-4f92-8982-f9dd17fd3114" {$envOfficeChannel = "semi-annual"}
-        "64256afe-f5d9-4f86-8936-8840a6a4f5be" {$envOfficeChannel = "monthly targeted"}
-        "b8f9b850-328d-4355-9145-c59439a0c4cf" {$envOfficeChannel = "semi-annual targeted"}
+[String]$envOfficeChannel = If ($envOfficeVars | Select-Object -ExpandProperty CDNBaseURL -ErrorAction SilentlyContinue) {
+    Switch -regex ($envOfficeVars.CDNBaseURL) {
+        "492350f6-3a01-4f97-b9c0-c7c6ddf67d60" {"monthly"}
+        "7ffbc6bf-bc32-4f92-8982-f9dd17fd3114" {"semi-annual"}
+        "64256afe-f5d9-4f86-8936-8840a6a4f5be" {"monthly targeted"}
+        "b8f9b850-328d-4355-9145-c59439a0c4cf" {"semi-annual targeted"}
     }
 }
 

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -308,6 +308,7 @@ ElseIf ($envOfficeVars | Select-Object -ExpandProperty CDNBaseURL -ErrorAction S
         "7ffbc6bf-bc32-4f92-8982-f9dd17fd3114" {"semi-annual"}
         "64256afe-f5d9-4f86-8936-8840a6a4f5be" {"monthly targeted"}
         "b8f9b850-328d-4355-9145-c59439a0c4cf" {"semi-annual targeted"}
+        "55336b82-a18d-4dd6-b5f6-9e5095c314a6" {"monthly enterprise"}
     }
 }
 


### PR DESCRIPTION
Supersedes #873.

* When having variables optionally defined within a branch, they're not available thereafter.
* Such setups breaks PowerShell when running strict compliance mode, such as `Set-StrictMode -Version Latest`.
* There's also no need to set a variable within an if statement, switch, or foreach loop, constructs like `$var = if ($true) {'value'}` are perfectly legal, and preferred as at least you always have a variable which is null if the condition isn't met.

Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.
