### PR TITLE
- Better setup for `$ResolveParameters`. (Targeted to dev)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@
 - Improved Execute-MSI so that all repetitive references to .log or .txt file extension in $LogName variable are all removed #759
 - Improved Get-HardwarePlatform to add support for detecting Parallels virtual machines #838
 - Improved Execute-ProcessAsUser and how it parses and executes commandline arguments. #794 #894 #782 #762 #851
+- Improved setup for $ResolveParameters (uses proper filter and piping, supports arrays and dictionaries) #874
 
 **Version 3.9.3 [01/05/2023]**
 - Improved accuracy of Intune Provisioning/ESP detection #779 #801


### PR DESCRIPTION
Supersedes #874.

* Use a proper filter instead of a scriptblock.
* Directly pipe into filter instead of having the overhead of `ForEach-Object` and a scriptblock invocation on every loop.
* Add support for arrays.
* Add support for other dictionaries, recursively processing their values.

Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.
