### PR TITLE
- Remove dead event handler setups from `Show-InstallationPrompt`. (Targeted to dev)

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -2245,12 +2245,6 @@ https://psappdeploytoolkit.com
         [ScriptBlock]$Install_Prompt_Form_Cleanup_FormClosed = {
             ## Remove all event handlers from the controls
             Try {
-                $labelText.remove_Click($handler_labelText_Click)
-                $buttonLeft.remove_Click($buttonLeft_OnClick)
-                $buttonRight.remove_Click($buttonRight_OnClick)
-                $buttonMiddle.remove_Click($buttonMiddle_OnClick)
-                $buttonAbort.remove_Click($buttonAbort_OnClick)
-                $installPromptTimer.remove_Tick($installPromptTimer_Tick)
                 $installPromptTimer.Dispose()
                 $installPromptTimer = $null
                 $installPromptTimerPersist.remove_Tick($installPromptTimerPersist_Tick)
@@ -2346,7 +2340,6 @@ https://psappdeploytoolkit.com
         $labelText.TextAlign = "Middle$($MessageAlignment)"
         $labelText.Anchor = 'None'
         $labelText.AutoSize = $true
-        $labelText.add_Click($handler_labelText_Click)
 
         If ($Icon -ne 'None') {
             # Add margin for the icon based on labelText Height so its centered
@@ -2367,7 +2360,6 @@ https://psappdeploytoolkit.com
         $buttonLeft.Padding = $paddingNone
         $buttonLeft.UseVisualStyleBackColor = $true
         $buttonLeft.Location = '14,4'
-        $buttonLeft.add_Click($buttonLeft_OnClick)
 
         ## Button Middle
         $buttonMiddle.DataBindings.DefaultDataSourceUpdateMode = 0
@@ -2384,7 +2376,6 @@ https://psappdeploytoolkit.com
         $buttonMiddle.Padding = $paddingNone
         $buttonMiddle.UseVisualStyleBackColor = $true
         $buttonMiddle.Location = '160,4'
-        $buttonMiddle.add_Click($buttonMiddle_OnClick)
 
         ## Button Right
         $buttonRight.DataBindings.DefaultDataSourceUpdateMode = 0
@@ -2401,7 +2392,6 @@ https://psappdeploytoolkit.com
         $buttonRight.Padding = $paddingNone
         $buttonRight.UseVisualStyleBackColor = $true
         $buttonRight.Location = '306,4'
-        $buttonRight.add_Click($buttonRight_OnClick)
 
         ## Button Abort (Hidden)
         $buttonAbort.DataBindings.DefaultDataSourceUpdateMode = 0
@@ -2422,7 +2412,6 @@ https://psappdeploytoolkit.com
         $buttonAbort.Margin = $paddingNone
         $buttonAbort.Padding = $paddingNone
         $buttonAbort.UseVisualStyleBackColor = $true
-        $buttonAbort.add_Click($buttonAbort_OnClick)
 
         ## FlowLayoutPanel
         $flowLayoutPanel.MinimumSize = $DefaultControlSize


### PR DESCRIPTION
Supersedes #876.

* This was also breaking strict compliance mode. Remnants from the past that weren't ever cleaned up properly?

Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.
