### PR TITLE
Add log rotation to replace 'DoNotAppend' changes

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitConfig.xml
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitConfig.xml
@@ -44,17 +44,19 @@
         <!-- Specify if log file should be a CMTrace compatible log file or a Legacy text log file. -->
         <Toolkit_LogDebugMessage>False</Toolkit_LogDebugMessage>
         <!-- Specify if debug messages such as bound parameters passed to a function should be logged. -->
-        <Toolkit_LogMaxSize>10</Toolkit_LogMaxSize>
-        <!-- Specify maximum file size limit for log file in megabytes (MB). -->
         <Toolkit_LogWriteToHost>True</Toolkit_LogWriteToHost>
         <!-- Specify if log messages should be written to the console. -->
-        <Toolkit_LogDoNotAppend>True</Toolkit_LogDoNotAppend>
-		<!-- Specify if an existing log file should not be appended to. -->
+        <Toolkit_LogAppend>True</Toolkit_LogAppend>
+        <!-- Specify if an existing log file should be appended to. -->
+        <Toolkit_LogMaxSize>10</Toolkit_LogMaxSize>
+        <!-- Specify maximum file size limit for log file in megabytes (MB). -->
+        <Toolkit_LogMaxHistory>10</Toolkit_LogMaxHistory>
+        <!-- Specify maximum number of previous log files to retain. -->
         <Toolkit_UseRobocopy>True</Toolkit_UseRobocopy>
-		<!-- Specify if Robocopy should be used with the Copy-File function. -->
+        <!-- Specify if Robocopy should be used with the Copy-File function. -->
         <Toolkit_CachePath>$envProgramData\SoftwareCache</Toolkit_CachePath>
-		<!-- Specify the path for the cache folder --> 
-	</Toolkit_Options>
+        <!-- Specify the path for the cache folder --> 
+    </Toolkit_Options>
     <!--Toolkit Options-->
 
     <!--Toast Notification Options-->

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -388,8 +388,6 @@ Else {
     #  If this script was not invoked by another script, fall back to the directory one level above this script
     [String]$scriptParentPath = (Get-Item -LiteralPath $scriptRoot).Parent.FullName
 }
-# Reset the check for existing log files on each script run
-[Boolean]$script:LogFileExistsCheck = $false
 
 ## Variables: App Deploy Script Dependency Files
 [String]$appDeployConfigFile = Join-Path -Path $scriptRoot -ChildPath 'AppDeployToolkitConfig.xml'
@@ -444,10 +442,11 @@ If (-not (Test-Path -LiteralPath $appDeployLogoBanner -PathType 'Leaf')) {
 [String]$configToolkitLogDir = $ExecutionContext.InvokeCommand.ExpandString($xmlToolkitOptions.Toolkit_LogPath)
 [Boolean]$configToolkitCompressLogs = [Boolean]::Parse($xmlToolkitOptions.Toolkit_CompressLogs)
 [String]$configToolkitLogStyle = $xmlToolkitOptions.Toolkit_LogStyle
-[Double]$configToolkitLogMaxSize = $xmlToolkitOptions.Toolkit_LogMaxSize
 [Boolean]$configToolkitLogWriteToHost = [Boolean]::Parse($xmlToolkitOptions.Toolkit_LogWriteToHost)
 [Boolean]$configToolkitLogDebugMessage = [Boolean]::Parse($xmlToolkitOptions.Toolkit_LogDebugMessage)
-[Boolean]$configToolkitLogDoNotAppend = [Boolean]::Parse($xmlToolkitOptions.Toolkit_LogDoNotAppend)
+[Boolean]$configToolkitLogAppend = [Boolean]::Parse($xmlToolkitOptions.Toolkit_LogAppend)
+[Double]$configToolkitLogMaxSize = $xmlToolkitOptions.Toolkit_LogMaxSize
+[Int]$configToolkitLogMaxHistory = $xmlToolkitOptions.Toolkit_LogMaxHistory
 [Boolean]$configToolkitUseRobocopy = [Boolean]::Parse($xmlToolkitOptions.Toolkit_UseRobocopy)
 [String]$configToolkitCachePath = $ExecutionContext.InvokeCommand.ExpandString($xmlToolkitOptions.Toolkit_CachePath)
 #  Get MSI Options
@@ -636,6 +635,7 @@ Else {
 [Boolean]$BlockExecution = $false
 [Boolean]$installationStarted = $false
 [Boolean]$runningTaskSequence = $false
+[Boolean]$LogFileInitialized = $false
 If (Test-Path -LiteralPath 'variable:welcomeTimer') {
     Remove-Variable -Name 'welcomeTimer' -Scope 'Script'
 }
@@ -1034,21 +1034,25 @@ Set the directory where the log file will be saved.
 
 Set the name of the log file.
 
+.PARAMETER AppendToLogFile
+
+Append to existing log file rather than creating a new one upon toolkit initialization. Default value is defined in AppDeployToolkitConfig.xml.
+
+.PARAMETER MaxLogHistory
+
+Maximum number of previous log files to retain. Default value is defined in AppDeployToolkitConfig.xml.
+
 .PARAMETER MaxLogFileSizeMB
 
-Maximum file size limit for log file in megabytes (MB). Default is 10 MB.
-
-.PARAMETER WriteHost
-
-Write the log message to the console.
-
-.PARAMETER DoNotAppendToLogFile
-
-Create a new log file, do not append to existing log file. Default is: $false.	
+Maximum file size limit for log file in megabytes (MB). Default value is defined in AppDeployToolkitConfig.xml.
 
 .PARAMETER ContinueOnError
 
 Suppress writing log message to console on failure to write message to log file. Default is: $true.
+
+.PARAMETER WriteHost
+
+Write the log message to the console.
 
 .PARAMETER PassThru
 
@@ -1125,22 +1129,26 @@ https://psappdeploytoolkit.com
         [Parameter(Mandatory = $false, Position = 6)]
         [ValidateNotNullorEmpty()]
         [String]$LogFileName = $logName,
-        [Parameter(Mandatory = $false, Position = 7)]
+        [Parameter(Mandatory=$false,Position=7)]
+        [ValidateNotNullorEmpty()]
+        [Boolean]$AppendToLogFile = $configToolkitLogAppend,
+        [Parameter(Mandatory=$false,Position=8)]
+        [ValidateNotNullorEmpty()]
+        [Int]$MaxLogHistory = $configToolkitLogMaxHistory,
+        [Parameter(Mandatory = $false, Position = 9)]
         [ValidateNotNullorEmpty()]
         [Decimal]$MaxLogFileSizeMB = $configToolkitLogMaxSize,
-        [Parameter(Mandatory = $false, Position = 8)]
-        [ValidateNotNullorEmpty()]
-        [Boolean]$WriteHost = $configToolkitLogWriteToHost,
-        [Parameter(Mandatory=$false,Position=9)]
-        [Switch]$DoNotAppendToLogFile = $configToolkitLogDoNotAppend,
-        [Parameter(Mandatory=$false,Position=10)]
+	    [Parameter(Mandatory=$false,Position=10)]
         [ValidateNotNullorEmpty()]
         [Boolean]$ContinueOnError = $true,
-	    [Parameter(Mandatory=$false,Position=11)]
+        [Parameter(Mandatory = $false, Position = 11)]
+        [ValidateNotNullorEmpty()]
+        [Boolean]$WriteHost = $configToolkitLogWriteToHost,
+        [Parameter(Mandatory=$false,Position=12)]
         [Switch]$PassThru = $false,
-	    [Parameter(Mandatory=$false,Position=12)]
-        [Switch]$DebugMessage = $false,
 	    [Parameter(Mandatory=$false,Position=13)]
+        [Switch]$DebugMessage = $false,
+	    [Parameter(Mandatory=$false,Position=14)]
         [Boolean]$LogDebugMessage = $configToolkitLogDebugMessage
     )
 
@@ -1251,24 +1259,58 @@ https://psappdeploytoolkit.com
         ## Assemble the fully qualified path to the log file
         [String]$LogFilePath = Join-Path -Path $LogFileDirectory -ChildPath $LogFileName
 
-		# Check if the log file exists on first run and if the $DoNotAppendToLogFile switch is set then delete the existing log file and set the LogFileExistsCheck variable to $true
-		If ($DoNotAppendToLogFile -and (!($script:LogFileExistsCheck))) {
-            # Set the LogFileExistsCheck variable to $true with scope script
-			$script:LogFileExistsCheck = $true
-			If (Test-Path -LiteralPath $LogFilePath -PathType 'Leaf') {
-				Try {
-					Remove-Item -LiteralPath $LogFilePath -Force -ErrorAction 'Stop'
-				}
-				Catch {
-					[Boolean]$ExitLoggingFunction = $fals
-					#  If error deleting log file, write message to console
-					If (-not $ContinueOnError) {
-						Write-Host -Object "[$LogDate $LogTime] [${CmdletName}] $ScriptSection :: Failed to delete the log file [$LogFilePath]. `r`n$(Resolve-Error)" -ForegroundColor 'Red'
-					}
-					Return
-				}
-			}
-		}
+        if (Test-Path -Path $LogFilePath -PathType Leaf) {
+            Try {
+                $LogFile = Get-Item $LogFilePath
+                [Decimal]$LogFileSizeMB = $LogFile.Length / 1MB
+
+                # Check if log file needs to be rotated
+                if ((!$script:LogFileInitialized -and !$AppendToLogFile) -or ($MaxLogFileSizeMB -gt 0 -and $LogFileSizeMB -gt $MaxLogFileSizeMB)) {
+
+                    # Get new log file path
+                    $LogFileNameWithoutExtension = [IO.Path]::GetFileNameWithoutExtension($LogFileName)
+                    $LogFileExtension = [IO.Path]::GetExtension($LogFileName)
+                    $Timestamp = $LogFile.LastWriteTime.ToString('yyyy-MM-dd-HH-mm-ss')
+                    $ArchiveLogFileName = "{0}_{1}{2}" -f $LogFileNameWithoutExtension, $Timestamp, $LogFileExtension
+                    [String]$ArchiveLogFilePath = Join-Path -Path $LogFileDirectory -ChildPath $ArchiveLogFileName
+
+                    if ($MaxLogFileSizeMB -gt 0 -and $LogFileSizeMB -gt $MaxLogFileSizeMB) {
+                        [Hashtable]$ArchiveLogParams = @{ ScriptSection = $ScriptSection; Source = ${CmdletName}; Severity = 2; LogFileDirectory = $LogFileDirectory; LogFileName = $LogFileName; LogType = $LogType; MaxLogFileSizeMB = 0; AppendToLogFile = $true; WriteHost = $WriteHost; ContinueOnError = $ContinueOnError; PassThru = $false }
+
+                        ## Log message about archiving the log file
+                        $ArchiveLogMessage = "Maximum log file size [$MaxLogFileSizeMB MB] reached. Rename log file to [$ArchiveLogFileName]."
+                        Write-Log -Message $ArchiveLogMessage @ArchiveLogParams
+                    }
+
+                    # Rename the file
+                    Move-Item -Path $LogFilePath -Destination $ArchiveLogFilePath -Force -ErrorAction 'Stop'
+
+                    if ($MaxLogFileSizeMB -gt 0 -and $LogFileSizeMB -gt $MaxLogFileSizeMB) {
+                        ## Start new log file and Log message about archiving the old log file
+                        $NewLogMessage = "Previous log file was renamed to [$ArchiveLogFileName] because maximum log file size of [$MaxLogFileSizeMB MB] was reached."
+                        Write-Log -Message $NewLogMessage @ArchiveLogParams
+                    }
+
+                    # Get all log files (including any .lo_ files that may have been created by previous toolkit versions) sorted by last write time
+                    $LogFiles = @(Get-ChildItem -LiteralPath $LogFileDirectory -Filter ("{0}_*{1}" -f $LogFileNameWithoutExtension, $LogFileExtension)) + @(Get-Item -LiteralPath ([IO.Path]::ChangeExtension($LogFilePath, 'lo_')) -ErrorAction Ignore) | Sort-Object LastWriteTime
+
+                    # Keep only the max number of log files
+                    if ($LogFiles.Count -gt $MaxLogHistory) {
+                        $LogFiles | Select-Object -First ($LogFiles.Count - $MaxLogHistory) | Remove-Item -ErrorAction 'Stop'
+                    }
+                }
+            }
+            Catch {
+                Write-Host -Object "[$LogDate $LogTime] [${CmdletName}] $ScriptSection :: Failed to rotate the log file [$LogFilePath]. `r`n$(Resolve-Error)" -ForegroundColor 'Red'
+                # Treat log rotation errors as non-terminating by default
+                If (-not $ContinueOnError) {
+                    [Boolean]$ExitLoggingFunction = $true                    
+                    Return
+                }
+            }
+        }
+
+        $script:LogFileInitialized = $true
     }
     Process {
         ## Exit function if logging is disabled
@@ -1356,36 +1398,8 @@ https://psappdeploytoolkit.com
         }
     }
     End {
-        ## Archive log file if size is greater than $MaxLogFileSizeMB and $MaxLogFileSizeMB > 0
-        Try {
-            If ((-not $ExitLoggingFunction) -and (-not $DisableLogging)) {
-                [IO.FileInfo]$LogFile = Get-ChildItem -LiteralPath $LogFilePath -ErrorAction 'Stop'
-                [Decimal]$LogFileSizeMB = $LogFile.Length / 1MB
-                If (($LogFileSizeMB -gt $MaxLogFileSizeMB) -and ($MaxLogFileSizeMB -gt 0)) {
-                    ## Change the file extension to "lo_"
-                    [String]$ArchivedOutLogFile = [IO.Path]::ChangeExtension($LogFilePath, 'lo_')
-                    [Hashtable]$ArchiveLogParams = @{ ScriptSection = $ScriptSection; Source = ${CmdletName}; Severity = 2; LogFileDirectory = $LogFileDirectory; LogFileName = $LogFileName; LogType = $LogType; MaxLogFileSizeMB = 0; WriteHost = $WriteHost; ContinueOnError = $ContinueOnError; PassThru = $false }
-
-                    ## Log message about archiving the log file
-                    $ArchiveLogMessage = "Maximum log file size [$MaxLogFileSizeMB MB] reached. Rename log file to [$ArchivedOutLogFile]."
-                    Write-Log -Message $ArchiveLogMessage @ArchiveLogParams
-
-                    ## Archive existing log file from <filename>.log to <filename>.lo_. Overwrites any existing <filename>.lo_ file. This is the same method SCCM uses for log files.
-                    Move-Item -LiteralPath $LogFilePath -Destination $ArchivedOutLogFile -Force -ErrorAction 'Stop'
-
-                    ## Start new log file and Log message about archiving the old log file
-                    $NewLogMessage = "Previous log file was renamed to [$ArchivedOutLogFile] because maximum log file size of [$MaxLogFileSizeMB MB] was reached."
-                    Write-Log -Message $NewLogMessage @ArchiveLogParams
-                }
-            }
-        }
-        Catch {
-            ## If renaming of file fails, script will continue writing to log file even if size goes over the max file size
-        }
-        Finally {
-            If ($PassThru) {
-                Write-Output -InputObject ($Message)
-            }
+        If ($PassThru) {
+            Write-Output -InputObject ($Message)
         }
     }
 }
@@ -1818,8 +1832,22 @@ https://psappdeploytoolkit.com
         ## Disable logging to file so that we can archive the log files
         . $DisableScriptLogging
 
-        [String]$DestinationArchiveFileName = $installName + '_' + $deploymentType + '_' + ((Get-Date -Format 'yyyy-MM-dd-HH-mm-ss').ToString()) + '.zip'
-        New-ZipFile -DestinationArchiveDirectoryPath $configToolkitLogDir -DestinationArchiveFileName $DestinationArchiveFileName -SourceDirectory $logTempFolder -RemoveSourceAfterArchiving
+        Try {
+            # Get all archive files sorted by last write time
+            $ArchiveFiles = Get-ChildItem -LiteralPath $configToolkitLogDir -Filter ($installName + '_' + $deploymentType + '_*.zip') | Sort-Object LastWriteTime
+
+            # Keep only the max number of archive files
+            if ($ArchiveFiles.Count -gt $configToolkitLogMaxHistory) {
+                $ArchiveFiles | Select-Object -First ($ArchiveFiles.Count - $configToolkitLogMaxHistory) | Remove-Item -ErrorAction 'Stop'
+            }
+
+            [String]$DestinationArchiveFileName = $installName + '_' + $deploymentType + '_' + ((Get-Date -Format 'yyyy-MM-dd-HH-mm-ss').ToString()) + '.zip'
+            New-ZipFile -DestinationArchiveDirectoryPath $configToolkitLogDir -DestinationArchiveFileName $DestinationArchiveFileName -SourceDirectory $logTempFolder -RemoveSourceAfterArchiving
+        }
+        Catch {
+            Write-Host -Object "[$LogDate $LogTime] [${CmdletName}] $ScriptSection :: Failed to manage archive file [$DestinationArchiveFileName]. `r`n$(Resolve-Error)" -ForegroundColor 'Red'
+        }
+
     }
 
     If (Test-Path -LiteralPath 'variable:notifyIcon') {


### PR DESCRIPTION
Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made. (only help inside function updated - main docs and site still to do)

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.

- Order of a few params in Write-Log / config.xml have changed (just for aesthetics to group the related params). This might technically be a breaking change, although very unlikely people would be using 10+ positional parameters.
- Default is <Toolkit_LogAppend>True</Toolkit_LogAppend> (which behaves the same as 3.9.3). Turn that to false and you have managed log rotation.
- Handling is combined with the max log size routine, which has now moved from the End to the Begin block of Write-Log.
- Max history set by <Toolkit_LogMaxHistory>; if set to 0 it will just retain the latest log only.
- Kept the -AppendToLogFile parameter in the function - turns out this is required so that we can force enable append when writing to the end of a log that has reached max size.
- Naming convention to append datetime matches that used by the zip files, with .log extension (_yyyy-MM-dd-HH-mm-ss is appended. Note that CM uses -yyyyMMdd-HHmmss which may be preferable).
- Previous naming convention to rename to .lo_ when max size reach is no longer used, but we also include them in the files to be checked for deletion.
- The same history count is applied to zip files if compression is enabled.