### PR TITLE
- Re-write `Get-RunningProcesses`.

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -8757,63 +8757,63 @@ https://psappdeploytoolkit.com
         [Switch]$DisableLogging
     )
 
-    Begin {
+    begin {
         ## Get the name of this function and write header
         [String]${CmdletName} = $PSCmdlet.MyInvocation.MyCommand.Name
         Write-FunctionHeaderOrFooter -CmdletName ${CmdletName} -CmdletBoundParameters $PSBoundParameters -Header
     }
-    Process {
-        If ($processObjects -and $processObjects[0].ProcessName) {
-            [String]$runningAppsCheck = $processObjects.ProcessName -join ','
-            If (-not $DisableLogging) {
-                Write-Log -Message "Checking for running applications: [$runningAppsCheck]" -Source ${CmdletName}
-            }
-            ## Prepare a filter for Where-Object
-            [ScriptBlock]$whereObjectFilter = {
-                ForEach ($processObject in $processObjects) {
-                    If ($_.ProcessName -ieq $processObject.ProcessName) {
-                        Add-Member -InputObject $_ -MemberType NoteProperty -Name ProcessDescription -Force -PassThru -Value $(
-                            If ($processObject.ProcessDescription) {
-                                #  The description of the process provided as a Parameter to the function, e.g. -ProcessName "winword=Microsoft Office Word".
-                                $processObject.ProcessDescription
-                            }
-                            ElseIf ($_.Description) {
-                                #  If the process already has a description field specified, then use it
-                                $_.Description
-                            }
-                            Else {
-                                #  Fall back on the process name if no description is provided by the process or as a parameter to the function
-                                $_.ProcessName
-                            }
-                        )
 
-                        Write-Output -InputObject ($true)
-                        Return
-                    }
-                }
-
-                Write-Output -InputObject ($false)
-                Return
-            }
-            ## Get all running processes and escape special characters. Match against the process names to search for to find running processes.
-            [Diagnostics.Process[]]$runningProcesses = Get-Process | Where-Object -FilterScript $whereObjectFilter | Sort-Object -Property 'ProcessName'
-
-            If (-not $DisableLogging) {
-                If ($runningProcesses) {
-                    [String]$runningProcessList = ($runningProcesses.ProcessName | Select-Object -Unique) -join ','
-                    Write-Log -Message "The following processes are running: [$runningProcessList]." -Source ${CmdletName}
-                }
-                Else {
-                    Write-Log -Message 'Specified applications are not running.' -Source ${CmdletName}
-                }
-            }
-            Write-Output -InputObject ($runningProcesses)
+    process {
+        ## Confirm input isn't null before proceeding.
+        if (!$processObjects -or !$processObjects[0].ProcessName)
+        {
+            return
         }
-        Else {
-            Write-Output -InputObject ($null)
+        if (!$DisableLogging)
+        {
+            Write-Log -Message "Checking for running applications: [$($processObjects.ProcessName -join ',')]" -Source ${CmdletName}
         }
+
+        ## Get all running processes and append properties.
+        [Diagnostics.Process[]]$runningProcesses = foreach ($process in (Get-Process -Name $processObjects.ProcessName -ErrorAction SilentlyContinue))
+        {
+            Add-Member -InputObject $process -MemberType NoteProperty -Name ProcessDescription -Force -PassThru -Value $(
+                if (![System.String]::IsNullOrWhiteSpace(($objDescription = ($processObjects | Where-Object {$_.ProcessName -eq $process.ProcessName}).ProcessDescription)))
+                {
+                    # The description of the process provided as a Parameter to the function, e.g. -ProcessName "winword=Microsoft Office Word".
+                    $objDescription
+                }
+                elseif ($process.Description)
+                {
+                    # If the process already has a description field specified, then use it
+                    $process.Description
+                }
+                else
+                {
+                    # Fall back on the process name if no description is provided by the process or as a parameter to the function
+                    $process.ProcessName
+                }
+            )
+        }
+
+        ## Return output if there's any.
+        if (!$runningProcesses)
+        {
+            if (!$DisableLogging)
+            {
+                Write-Log -Message 'Specified applications are not running.' -Source ${CmdletName}
+            }
+            return
+        }
+        if (!$DisableLogging)
+        {
+            Write-Log -Message "The following processes are running: [$(($runningProcesses.ProcessName | Select-Object -Unique) -join ',')]." -Source ${CmdletName}
+        }
+        return ($runningProcesses | Sort-Object)
     }
-    End {
+
+    end {
+        ## Write out the footer
         Write-FunctionHeaderOrFooter -CmdletName ${CmdletName} -Footer
     }
 }
@@ -9218,7 +9218,7 @@ https://psappdeploytoolkit.com
             $promptResult = $null
 
             While ((Get-RunningProcesses -ProcessObjects $processObjects -OutVariable 'runningProcesses') -or (($promptResult -ne 'Defer') -and ($promptResult -ne 'Close'))) {
-                [String]$runningProcessDescriptions = ($runningProcesses | Where-Object { $_.ProcessDescription } | Select-Object -ExpandProperty 'ProcessDescription' | Sort-Object -Unique) -join ','
+                [String]$runningProcessDescriptions = ($runningProcesses | Select-Object -ExpandProperty 'ProcessDescription' -ErrorAction SilentlyContinue | Sort-Object -Unique) -join ','
                 #  Check if we need to prompt the user to defer, to defer and close apps, or not to prompt them at all
                 If ($allowDefer) {
                     #  If there is deferral and closing apps is allowed but there are no apps to be closed, break the while loop


### PR DESCRIPTION
I kept getting property errors while running in strict mode and found the setup in `Get-RunningProcesses` could probably stand to do with a re-write.

Its probably not important enough for 3.9.4, but it does go to show again what `Set-StrictMode` finds that previously would go unnoticed. https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/set-strictmode?view=powershell-7.4

![image](https://github.com/PSAppDeployToolkit/PSAppDeployToolkit/assets/48643140/0a42ecfc-9639-4f50-a430-458d10bed69d)

* Significantly reduce code depth by adopting a "never-nesting" approach. This makes the code more readable by not having to keep track of how many branches down the chain you are.
* Remove almost all else branches by performing early returns where smart to do so. This goes hand in hand as part of never-nesting and keeps the code more readable.
* Speed up code by not looping through `$processObjects` for every single process. The setup in the `Where-Object` filterscript was a bit abusive and also costly.
* Get rid of `Write-Output` usage entirely. It needs to die and is not recommended, or required at all: https://get-powershellblog.blogspot.com/2017/06/lets-kill-write-output.html
* Remove now-unnecessary `Where-Object` call in `Show-InstallationWelcome` due to better setup in `Get-RunningProcesses`. We can just rely on the `Select-Object` call that proceeded it.

Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.
- [X] I updated the documentation with the changes I made.
- [X] The code I changed has comments with explanation.
- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.