### PR TITLE
Robocopy-changes

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5189,7 +5189,9 @@ https://psappdeploytoolkit.com
                     Foreach ($srcPath in $Path) {
                         # Robocopy arguments: NJH = No Job Header; NJS = No Job Summary; NS = No Size; NC = No Class; NP = No Progress; NDL = No Directory List; FP = Full Path; IS = Include Same
                         $RobocopyArgsCopy = "/NJH /NJS /NS /NC /NP /NDL /FP /IS"
-                        $RobocopyArgsPath =  "`"$srcPath`" `"$Destination`"" 
+                        # Append subfolder from source to destination, so that Robocopy produces similar results to native Powershell
+                        $SubFolder = Split-Path -Path $srcPath -Leaf
+                        $RobocopyArgsPath =  "`"$srcPath`" `"$Destination\$SubFolder`"" 
                         If ($Recurse) {
                             $RobocopyArgsCopy = $RobocopyArgsCopy + " /E"
                         }

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5171,7 +5171,10 @@ https://psappdeploytoolkit.com
                     }
                 }
                 # Check if Robocopy is on the system
-                If (-not (Test-Path -Path "$env:SystemRoot\System32\Robocopy.exe" -PathType Leaf)) {
+                If (Test-Path -Path "$env:SystemRoot\System32\Robocopy.exe" -PathType Leaf) {
+                    $RobocopyCommand = "$env:SystemRoot\System32\Robocopy.exe"
+                }
+                Else {
                     $UseRobocopy = $false
                     Write-Log "Robocopy is not available on this system. Falling back to native PowerShell method." -Source ${CmdletName} -Severity 2
                 }
@@ -5184,9 +5187,9 @@ https://psappdeploytoolkit.com
                     }
                     # Build Robocopy command   
                     Foreach ($srcPath in $Path) {
-                        $RobocopyCommand = "$env:SystemRoot\System32\Robocopy.exe"
+                        # Robocopy arguments: NJH = No Job Header; NJS = No Job Summary; NS = No Size; NC = No Class; NP = No Progress; NDL = No Directory List; FP = Full Path; IS = Include Same
                         $RobocopyArgsCopy = "/NJH /NJS /NS /NC /NP /NDL /FP /IS"
-                        $RobocopyArgsPath =  "`"$srcPath`" `"$destination`"" 
+                        $RobocopyArgsPath =  "`"$srcPath`" `"$Destination`"" 
                         If ($Recurse) {
                             $RobocopyArgsCopy = $RobocopyArgsCopy + " /E"
                         }

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5133,7 +5133,7 @@ https://psappdeploytoolkit.com
         [String]$Destination,
         [Parameter(Mandatory = $false)]
         [Switch]$Recurse = $false,
-        [Parameter(Mandatory = $false, ParameterSetName = 'PowerShell')]
+        [Parameter(Mandatory = $false)]
         [Switch]$Flatten,
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
@@ -5141,10 +5141,10 @@ https://psappdeploytoolkit.com
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [Boolean]$ContinueFileCopyOnError = $false,
-        [Parameter(Mandatory = $false, ParameterSetName = 'Robocopy')]
+        [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [Boolean]$UseRobocopy = $configToolkitUseRobocopy,
-        [Parameter(Mandatory = $false, ParameterSetName = 'Robocopy')]
+        [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [String]$RobocopyAdditionalParams = $null
         )    


### PR DESCRIPTION
Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.

Issues with previous code:

- /IM only copied files with different timestamps, switched to /IS to copy everything, to match native PowerShell behaviour
- /NJH /NJS /NS /NC /NP /NDL /FP switches added to minimise Robocopy verbosity (NJH = No Job Header; NJS = No Job Summary; NS = No Size; NC = No Class; NP = No Progress; NDL = No Directory List; FP = Full Path)
- Robocopy now launched with -CreateNoWindow rather than -WindowStyle Hidden. A recent 3.9.4 commit enables -UseShellExecute when supplying -WindowStyle Hidden, which makes StdOut inaccessible.
- Previous Robocopy log was unnecessary and was overwritten on each command execution. Now StdOut is captured and sent to Write-Log.
- Robocopy disabled if -Path contains *, as Robocopy only accepts wildcards for filenames and not folder names, and we are currently only using Robocopy for folders.
- Copy-File help for -UseRoboCopy parameter now includes comment "Only applies if $Path is specified as a folder."
- When copying a folder, subfolder name is now appended to destination to match native PowerShell behaviour. For example, these 2 now produce the same result:
```
Copy-File -Path "$dirFiles\Application" -Destination $envProgramFiles -Recurse -UseRobocopy $false
Copy-File -Path "$dirFiles\Application" -Destination $envProgramFiles -Recurse -UseRobocopy $true
```

Additional notes:
- One difference between Robocopy and native behaviour still; if copying a folder without -Recurse, native Copy-Item just produces an empty folder at the destination, Robocopy also includes the first level files. Should not be a problem as nobody in their right mind would have used Copy-File on a folder without Recurse if it never included any contents.
- Robocopy could potentially still be used for file copies, as it supports syntax 'Robocopy <SourceFolder> <DestFolder> <File1> <File2>' (where filenames *do* support wildcards).  This has not been implemented here as there are a few gotchas with this, for example native Powershell copy allows for copying and renaming a file in one operation, whereas Robocopy wouldn't know if the destination was a file name or a folder name:
```
Copy-File -Path C:\Temp\test1.txt -Destination C:\Temp\test2.txt
```