### PR TITLE
Add functions Copy-FileToUserProfiles and Remove-FileFromUserProfiles

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5484,6 +5484,243 @@ https://psappdeploytoolkit.com
 }
 #endregion
 
+
+#region Function Copy-FileToUserProfiles
+function Copy-FileToUserProfiles {
+    <#
+.SYNOPSIS
+
+Copy one or more items to a each user profile on the system.
+
+.DESCRIPTION
+
+Copy one or more items to a each user profile on the system.
+
+.PARAMETER Path
+
+The path of the file or folder to copy.
+
+.PARAMETER Destination
+
+The path of the destination folder to append to the root of the user profile.
+
+.PARAMETER Recurse
+
+Copy files in subdirectories.
+
+.PARAMETER Flatten
+
+Flattens the files into the root destination directory.
+
+.PARAMETER ContinueOnError
+
+Continue if an error is encountered. This will continue the deployment script, but will not continue copying files if an error is encountered. Default is: $true.
+
+.PARAMETER ContinueFileCopyOnError
+
+Continue copying files if an error is encountered. This will continue the deployment script and will warn about files that failed to be copied. Default is: $false.
+
+.PARAMETER UseRobocopy
+
+Use Robocopy to copy files rather than native PowerShell method. Robocopy overcomes the 260 character limit. Only applies if $Path is specified as a folder. Default is configured in the AppDeployToolkitConfig.xml file: $true
+
+.PARAMETER RobocopyAdditionalParams
+
+Additional parameters to pass to Robocopy. Default is: $null
+
+.INPUTS
+
+You can pipe in string values for $Path.
+
+.OUTPUTS
+
+None
+
+This function does not generate any output.
+
+.EXAMPLE
+
+Copy-FileToUserProfiles -Path "$dirSupportFiles\config.txt" -Destination "AppData\Roaming\MyApp"
+
+Copy a single file to C:\Users\<UserName>\AppData\Roaming\MyApp for each user.
+
+.EXAMPLE
+
+Copy-FileToUserProfiles -Path "$dirSupportFiles\config.txt","$dirSupportFiles\config2.txt" -Destination "AppData\Roaming\MyApp"
+
+Copy two files to C:\Users\<UserName>\AppData\Roaming\MyApp for each user.
+
+.EXAMPLE
+
+Copy-FileToUserProfiles -Path "$dirFiles\MyApp" -Destination "AppData\Local" -Recurse
+
+Copy an entire folder to C:\Users\<UserName>\AppData\Local for each user.
+
+.EXAMPLE
+
+Copy-FileToUserProfiles -Path "$dirFiles\.appConfigFolder" -Recurse
+
+Copy an entire folder to C:\Users\<UserName> for each user.
+
+.NOTES
+
+.LINK
+
+https://psappdeploytoolkit.com
+#>
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory = $true, Position = 1, ValueFromPipeline = $true)]
+        [String[]]$Path,
+        [Parameter(Mandatory = $false, Position = 2)]
+        [String]$Destination,
+        [Parameter(Mandatory = $false)]
+        [Switch]$Recurse = $false,
+        [Parameter(Mandatory = $false)]
+        [Switch]$Flatten,
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [Boolean]$ContinueOnError = $true,
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [Boolean]$ContinueFileCopyOnError = $false,
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [Boolean]$UseRobocopy = $configToolkitUseRobocopy,
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [String]$RobocopyAdditionalParams = $null
+    )
+
+    Begin {
+        ## Get the name of this function and write header
+        [String]${CmdletName} = $PSCmdlet.MyInvocation.MyCommand.Name
+        Write-FunctionHeaderOrFooter -CmdletName ${CmdletName} -CmdletBoundParameters $PSBoundParameters -Header
+    }
+    Process {
+        [Hashtable]$CopyFileSplat = @{
+            Path = $Path
+            Recurse = $Recurse
+            Flatten = $Flatten
+            ContinueOnError = $ContinueOnError
+            ContinueFileCopyOnError = $ContinueFileCopyOnError
+            UseRobocopy = $UseRobocopy
+        }
+        if ($RobocopyAdditionalParams) {
+            $CopyFileSplat.RobocopyAdditionalParams = $RobocopyAdditionalParams
+        }
+
+        foreach ($UserProfilePath in (Get-UserProfiles).ProfilePath) {
+            $CopyFileSplat.Destination = Join-Path $UserProfilePath $Destination
+            Write-Log -Message "Copying path [$Path] to $($CopyFileSplat.Destination):" -Source ${CmdletName}
+            Copy-File @CopyFileSplat
+        }
+    }
+    End {
+        Write-FunctionHeaderOrFooter -CmdletName ${CmdletName} -Footer
+    }  
+}
+#endregion
+
+
+#region Function Remove-FileFromUserProfiles
+Function Remove-FileFromUserProfiles {
+    <#
+.SYNOPSIS
+
+Removes one or more items from each user profile on the system.
+
+.DESCRIPTION
+
+Removes one or more items from each user profile on the system.
+
+.PARAMETER Path
+
+Specifies the path to append to the root of the user profile to be resolved. The value of Path will accept wildcards. Will accept an array of values.
+
+.PARAMETER LiteralPath
+
+Specifies the path to append to the root of the user profile to be resolved. The value of LiteralPath is used exactly as it is typed; no characters are interpreted as wildcards. Will accept an array of values.
+
+.PARAMETER Recurse
+
+Deletes the files in the specified location(s) and in all child items of the location(s).
+
+.PARAMETER ContinueOnError
+
+Continue if an error is encountered. Default is: $true.
+
+.INPUTS
+
+None
+
+You cannot pipe objects to this function.
+
+.OUTPUTS
+
+None
+
+This function does not generate any output.
+
+.EXAMPLE
+
+Remove-FileFromUserProfiles -Path "AppData\Roaming\MyApp\config.txt"
+
+.EXAMPLE
+
+Remove-FileFromUserProfiles -Path "AppData\Local\MyApp" -Recurse
+
+.NOTES
+
+.LINK
+
+https://psappdeploytoolkit.com
+#>
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = 'Path')]
+        [ValidateNotNullorEmpty()]
+        [String[]]$Path,
+        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = 'LiteralPath')]
+        [ValidateNotNullorEmpty()]
+        [String[]]$LiteralPath,
+        [Parameter(Mandatory = $false)]
+        [Switch]$Recurse = $false,
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [Boolean]$ContinueOnError = $true
+    )
+
+    Begin {
+        ## Get the name of this function and write header
+        [String]${CmdletName} = $PSCmdlet.MyInvocation.MyCommand.Name
+        Write-FunctionHeaderOrFooter -CmdletName ${CmdletName} -CmdletBoundParameters $PSBoundParameters -Header
+    }
+    Process {
+        [Hashtable]$RemoveFileSplat = @{
+            Recurse = $Recurse
+            ContinueOnError = $ContinueOnError
+        }
+
+        ForEach ($UserProfilePath in (Get-UserProfiles).ProfilePath) {
+            If ($PSCmdlet.ParameterSetName -eq 'Path') {
+                $RemoveFileSplat.Path = $Path | ForEach-Object { Join-Path $UserProfilePath $_ }
+                Write-Log -Message "Removing path [$Path] from $UserProfilePath`:" -Source ${CmdletName}
+            }
+            ElseIf ($PSCmdlet.ParameterSetName -eq 'LiteralPath') {
+                $RemoveFileSplat.LiteralPath = $LiteralPath | ForEach-Object { Join-Path $UserProfilePath $_ }
+                Write-Log -Message "Removing literal path [$LiteralPath] from $UserProfilePath`:" -Source ${CmdletName}
+            }
+            Remove-File @RemoveFileSplat
+        }
+    }
+    End {
+        Write-FunctionHeaderOrFooter -CmdletName ${CmdletName} -Footer
+    }
+}
+#endregion
+
+
 #region Function Convert-RegistryPath
 Function Convert-RegistryPath {
     <#


### PR DESCRIPTION
Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.


These functions wrap the existing Copy-File and Remove-File functions, performing the actions against each user profile path.