### PR TITLE
Copy-File-enhancements

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5224,8 +5224,8 @@ https://psappdeploytoolkit.com
                                 [Hashtable]$CopyFileSplat = @{
                                     Path                    = (Join-Path $srcPath '*')
                                     Destination             = $Destination
-                                    Recurse                 = $Recurse
-                                    Flatten                 = $Flatten
+                                    Recurse                 = $false
+                                    Flatten                 = $false
                                     ContinueOnError         = $ContinueOnError
                                     ContinueFileCopyOnError = $ContinueFileCopyOnError
                                     UseRobocopy             = $UseRobocopy

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5210,6 +5210,9 @@ https://psappdeploytoolkit.com
 
                     }
                     If ($UseRobocopyThis) {
+                        # Trim ending backslash from paths which can cause problems
+                        $srcPath = $srcPath.TrimEnd('\')
+                        $Destination = $Destination.TrimEnd('\')
                         # Robocopy arguments: NJH = No Job Header; NJS = No Job Summary; NS = No Size; NC = No Class; NP = No Progress; NDL = No Directory List; FP = Full Path; IS = Include Same; MT = Number of Threads; R = Number of Retries; W = Wait time between retries in sconds
                         $RobocopyArgsCopy = "/NJH /NJS /NS /NC /NP /NDL /FP /IS /MT:4 /R:1 /W:1"
                         If (Test-Path -Path $srcPath -PathType Leaf) {

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5151,10 +5151,10 @@ https://psappdeploytoolkit.com
 #>
     [CmdletBinding()]
     Param (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true, Position = 0)]
         [ValidateNotNullorEmpty()]
         [String[]]$Path,
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true, Position = 1)]
         [ValidateNotNullorEmpty()]
         [String]$Destination,
         [Parameter(Mandatory = $false)]

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5270,7 +5270,8 @@ https://psappdeploytoolkit.com
         }
         If ($UseRobocopy -eq $false) {
             Try {
-                If ((-not ([IO.Path]::HasExtension($Destination))) -and (-not (Test-Path -LiteralPath $Destination -PathType 'Container'))) {
+                # If destination has no extension, or if it has an extension only and no name (e.g. a .config folder) and the destination folder does not exist
+                If ((-not ([IO.Path]::HasExtension($Destination))) -or ([IO.Path]::HasExtension($Destination) -and -not [IO.Path]::GetFileNameWithoutExtension($Destination)) -and (-not (Test-Path -LiteralPath $Destination -PathType 'Container'))) {
                     Write-Log -Message "Destination folder does not exist, creating destination folder [$destination]." -Source ${CmdletName}
                     $null = New-Item -Path $Destination -Type 'Directory' -Force -ErrorAction 'Stop'
                 }


### PR DESCRIPTION
Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.

Previous Robocopy implementation only supported copying folders, and reverted back to native mode if any of the paths in the array $Path were a file.

- Now it asseses each path in the array individually.
- If a * is found in the folder portion, it falls back to native mode still as Robocopy does not accept this.
- If the destination appears to be a file name and doesn't exist as a folder, fall back to native mode which supports copying and renaming files.
- Trim ending backslashes from paths given to Robocopy. I think this was already in and I took it out thinking it was unneccessary, which was a mistake.
- Test-Path -PathType Leaf is used to figure out if the source is a file; which also works for wildcard filenames. Then the path is split up to feed Robocopy 3 args: SourcePath DestPath FileName.
- Flatten now  works in Robocopy mode by getting current folder and all subfolders, appending * as the filename, and recursively calling the Copy-File function.
- /MT:4 added to Robocopy args to enable multi-threading (8 is the default, but opted for 4 here)
- /R:1 /W:1 added to Robocopy args - default is 1 million retries with 30 seconds between retries if an error is found. Now it's 1 retry after 1 second.
- Fixed bug in Copy-ContentToCache - it was written with Robocopy enabled which originally did not copy the subfolder itself when copying a directory recursively; Copy-File was updated to create this folder so that both copy engines produced the same result. Copy-ContentToCache was therefore now creating an extra subfolder in the destination when it was unwanted; fixed by appending \* to the Path sent to Copy-File.
- Flatten routine for both native copy and Robocopy now uses -File or -Directory on Get-ChildItem rather than piping to Where-Object {$_.PSIsContainer}
- Native file copy now supports auto creation of destination folders such as .config, which were previously being treated as filenames.