### PR TITLE
`Execute-Process` improvements

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1769,13 +1769,7 @@ https://psappdeploytoolkit.com
         $configInstallationDeferExitCode {
             $installSuccess = $false
         }
-        3010 {
-            $installSuccess = $true
-        }
-        1641 {
-            $installSuccess = $true
-        }
-        0 {
+        {$ValidExitCodes -contains $_} {
             $installSuccess = $true
         }
         Default {
@@ -4572,7 +4566,7 @@ https://psappdeploytoolkit.com
                 ElseIf (($returnCode -eq 17025) -and ($Path -match 'fullfile')) {
                     Write-Log -Message "Execution failed with exit code [$returnCode] because the Office Update is not applicable to this system." -Severity 3 -Source ${CmdletName}
                 }
-                ElseIf ($returnCode -eq 0) {
+                ElseIf ($ValidExitCodes.Contains($returnCode)) {
                     Write-Log -Message "Execution completed successfully with exit code [$returnCode]." -Source ${CmdletName}
                 }
                 Else {

--- a/Toolkit/Deploy-Application.ps1
+++ b/Toolkit/Deploy-Application.ps1
@@ -92,7 +92,10 @@ Param (
     [Parameter(Mandatory = $false)]
     [switch]$TerminalServerMode = $false,
     [Parameter(Mandatory = $false)]
-    [switch]$DisableLogging = $false
+    [switch]$DisableLogging = $false,
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [Int32[]]$ValidExitCodes = @(0, 1641, 3010)
 )
 
 Try {


### PR DESCRIPTION
There's two things included here:
* Allow specification of valid exit codes.
  * This is needed as I'm often running non-MSI installers through PSADT where the measures of success can be anything.
* Add option for `Execute-Process` to be able to throw on failure.
  * I need this so that I can catch a failed execution in `Deploy-Application.ps1`'s main try/catch block as its important I'm able to present the exit code on-screen in a dialog.
  * Being able to throw here could be beneficial to others and removes a bit of boilerplate from my side. 

Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.
- [X] I updated the documentation with the changes I made.
- [X] The code I changed has comments with explanation.
- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.