### PR TITLE
Change default log location based on deployment system

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitConfig.xml
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitConfig.xml
@@ -40,6 +40,12 @@
         registry key), e.g. deferral history. -->
         <Toolkit_LogPath>$envWinDir\Logs\Software</Toolkit_LogPath>
         <!-- Log path used for Toolkit logging. -->
+        <Toolkit_LogPathConfigMgr>$envWinDir\CCM\Logs</Toolkit_LogPathConfigMgr>
+        <!-- Log path used for Toolkit logging if script path is within CCMCache. -->
+        <Toolkit_LogPathIntune>$envProgramData\Microsoft\IntuneManagementExtension\Logs</Toolkit_LogPathIntune>
+        <!-- Log path used for Toolkit logging if script path is within IMECache. -->
+        <Toolkit_LogPathAutoDetect>True</Toolkit_LogPathAutoDetect>
+        <!-- Enable detection automatic log location based on where the script is executed from. -->
         <Toolkit_TempPathNoAdminRights>$envTemp</Toolkit_TempPathNoAdminRights>
         <!-- Same as TempPath but used when RequireAdmin is False. -->
         <Toolkit_RegPathNoAdminRights>HKCU:\SOFTWARE</Toolkit_RegPathNoAdminRights>

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -389,6 +389,10 @@ Else {
     [String]$scriptParentPath = (Get-Item -LiteralPath $scriptRoot).Parent.FullName
 }
 
+## Variables: Deployment System Check
+[Boolean]$IsConfigMgr = [Boolean]($scriptRoot -like "$envWinDir\ccmcache\*")
+[Boolean]$IsIntune = [Boolean]($scriptRoot -like "$envWinDir\IMECache\*")
+
 ## Variables: App Deploy Script Dependency Files
 [String]$appDeployConfigFile = Join-Path -Path $scriptRoot -ChildPath 'AppDeployToolkitConfig.xml'
 [String]$appDeployCustomTypesSourceCode = Join-Path -Path $scriptRoot -ChildPath 'AppDeployToolkitMain.cs'
@@ -460,9 +464,9 @@ If (-not (Test-Path -LiteralPath $appDeployLogoBanner -PathType 'Leaf')) {
 [Boolean]$configToolkitLogPathAutoDetect = [Boolean]::Parse($xmlToolkitOptions.Toolkit_LogPathAutoDetect)
 #  Set Log Path
 If ($configToolkitLogPathAutoDetect) {
-    If ($scriptRoot -like "$envWinDir\ccmcache\*") {
+    If ($IsConfigMgr) {
         [String]$configToolkitLogDir = $ExecutionContext.InvokeCommand.ExpandString($xmlToolkitOptions.Toolkit_LogPathConfigMgr)
-    } elseif ($scriptRoot -like "$envWinDir\IMECache\*") {
+    } elseif ($IsIntune) {
         [String]$configToolkitLogDir = $ExecutionContext.InvokeCommand.ExpandString($xmlToolkitOptions.Toolkit_LogPathIntune)
     }
 }

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -457,6 +457,15 @@ If (-not (Test-Path -LiteralPath $appDeployLogoBanner -PathType 'Leaf')) {
 [String]$configMSIUninstallParams = $ExecutionContext.InvokeCommand.ExpandString($xmlConfigMSIOptions.MSI_UninstallParams)
 [String]$configMSILogDir = $ExecutionContext.InvokeCommand.ExpandString($xmlConfigMSIOptions.MSI_LogPath)
 [Int32]$configMSIMutexWaitTime = $xmlConfigMSIOptions.MSI_MutexWaitTime
+[Boolean]$configToolkitLogPathAutoDetect = [Boolean]::Parse($xmlToolkitOptions.Toolkit_LogPathAutoDetect)
+#  Set Log Path
+If ($configToolkitLogPathAutoDetect) {
+    If ($scriptRoot -like "$envWinDir\ccmcache\*") {
+        [String]$configToolkitLogDir = $ExecutionContext.InvokeCommand.ExpandString($xmlToolkitOptions.Toolkit_LogPathConfigMgr)
+    } elseif ($scriptRoot -like "$envWinDir\IMECache\*") {
+        [String]$configToolkitLogDir = $ExecutionContext.InvokeCommand.ExpandString($xmlToolkitOptions.Toolkit_LogPathIntune)
+    }
+}
 #  Change paths to user accessible ones if user isn't an admin
 If (!$IsAdmin) {
     If ($xmlToolkitOptions.Toolkit_TempPathNoAdminRights) {

--- a/wiki/Logging.md
+++ b/wiki/Logging.md
@@ -1,6 +1,13 @@
 The toolkit generates extensive logging for all toolkit and MSI operations.
 
-The default log directory for the toolkit and MSI log files can be specified in the XML configuration file. The default directory is `C:\Windows\Logs\Software\`.
+The toolkit will automatically place logs in the default log location for ConfigMgr or Intune. A custom default log path can be specified by setting LogPathAutoDetect to *False* and specifying the LogPath in the XML configuration file.
+
+**Log Locations**
+  - Deployed from ConfigMgr: `C:\Windows\CCM\Logs\`
+
+  - Deployed from Intune: `C:\ProgramData\Microsoft\IntuneManagementExtension\Logs\`
+
+  - Default: `C:\Windows\Logs\Software\`
 
 The toolkit log file is named after the application with `_PSAppDeployToolkit` appended to the end, e.g.
 

--- a/wiki/Toolkit-Usage.md
+++ b/wiki/Toolkit-Usage.md
@@ -25,27 +25,27 @@ There are two ways to launch the toolkit for deployment of applications.
 #### Examples:
 
 > **Deploy-Application.ps1**
-> 
+>
 > *Deploy an application for installation*
-> 
+>
 > **Deploy-Application.ps1 -DeploymentType "Uninstall" -DeployMode "Silent"**
-> 
+>
 > *Deploy an application for uninstallation in silent mode*
-> 
+>
 > **Deploy-Application.exe /32 -DeploymentType "Uninstall" -DeployMode "Silent"**
-> 
+>
 > *Deploy an application for uninstallation using PowerShell x86, supressing the PowerShell console window and deploying in silent mode.*
-> 
+>
 > **Deploy-Application.exe -AllowRebootPassThru**
-> 
+>
 > *Deploy an application for installation, supressing the PowerShell console window and allowing reboot codes to be returned to the parent process.*
-> 
+>
 > **Deploy-Application.exe "Custom-Script.ps1"**
-> 
+>
 > *Deploy an application with a custom name instead of Deploy-Application.ps1.*
-> 
+>
 > **Deploy-Application.exe -Command "C:\\Testing\\Custom-Script.ps1" -DeploymentType "Uninstall"**
-> 
+>
 > *Deploy an application with a custom name and custom location for the script file.*
 
 ### Toolkit Parameters
@@ -90,10 +90,10 @@ Aside from customizing the “Deploy-Application.ps1” script to deploy your ap
 
 **CompressLogs (option in AppDeployToolkitConfig.xml)** - One of the Toolkit Options in the AppDeployToolkitConfig.xml file is CompressLogs. Enabling this option will create a temporary logging folder where you can save all of the log files you want to include in the single ZIP file that will be created from this folder.
 
-To enable the CompressLogs, set the follow option in AppDeployToolkitConfig.xml to True:
+To enable the CompressLogs, set the following option in AppDeployToolkitConfig.xml to True:
 
 *<Toolkit_CompressLogs>True</Toolkit_CompressLogs>*
- 
+
 When set to True, the following happens:
 
   - Both toolkit and MSI logs are temporally placed in $envTemp\\$installName which gets cleaned up at the end of the install.
@@ -103,6 +103,22 @@ When set to True, the following happens:
   - The Zip file name indicates whether it is an Install / Uninstall and has the timestamp in the filename so previous logs do not get overwritten.
 
   - If your package creates other log files, you can send them to the temporary logging FOLDER at $envTemp\\$installName.
+
+**Log Location Auto Detection (option in AppDeployToolkitConfig.xml)** - One of the Toolkit Options in the AppDeployToolkitConfig.xml file is to automatically detect the log location based on the deployment method so the logs can be collected with Diagnostics data collection from ConfigMgr or Intune.
+
+To disable the Log Location Auto Detection, set the following option in AppDeployToolkitConfig.xml to True:
+
+*<Toolkit_LogPathAutoDetect>False</Toolkit_LogPathAutoDetect>*
+
+When set to True, the following happens:
+
+  - Deployed from ConfigMgr: Logs are placed within `C:\Windows\CCM\Logs\`
+
+  - Deployed from Intune: Logs are placed within `C:\ProgramData\Microsoft\IntuneManagementExtension\Logs\`
+
+When set to False, the following happens:
+
+  - Logs are placed within `C:\Windows\Logs\Software\`
 
 ## Example Deployments
 

--- a/wiki/Toolkit-Variables.md
+++ b/wiki/Toolkit-Variables.md
@@ -233,3 +233,5 @@ The toolkit has a number of internal variables which can be used in your script.
 | $invalidFileNameChars                    | Array of all invalid file name characters used to sanitize variables which                    |
 |                                          | may be used to create file names.                                                             |
 | $useDefaultMsi                           | A Zero-Config MSI installation was detected.                                                  |
+| $IsConfigMgr                             | Is the toolkit deployed from ConfigMgr? (e.g. $true/$false)                                   |
+| $IsIntune                                | Is the toolkit deployed from Intune? (e.g. $true/$false)                                      |


### PR DESCRIPTION
Check if script is executing from ConfigMgr or Intune and if so, change the default log location so that logs can be collected via diagnostics data collection of those respective systems. This option is enabled by default but an additional XML config option has been added to disable this functionality. Proposing to include this as default with the 4.0 release as it can be considered a breaking change. Alternatively, we could set the config file option to False and adjust the documentation changes accordingly though I think this is a nice default feature to include.

Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.
