### PR TITLE
Fix for Copy-File

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5219,16 +5219,16 @@ https://psappdeploytoolkit.com
                         $Destination = $Destination.TrimEnd('\')
                         # Robocopy arguments: NJH = No Job Header; NJS = No Job Summary; NS = No Size; NC = No Class; NP = No Progress; NDL = No Directory List; FP = Full Path; IS = Include Same; MT = Number of Threads; R = Number of Retries; W = Wait time between retries in sconds
                         $RobocopyArgsCopy = "/NJH /NJS /NS /NC /NP /NDL /FP /IS /MT:4 /R:1 /W:1"
-                        If ((Test-Path -Path $srcPath -PathType Leaf) -or (Split-Path -Path $srcPath -Leaf) -match '\*') {
-                            # If source is a file, or if leaf contains *, split args to the format <SourceFolder> <DestinationFolder> <FileName>
+                        If (Test-Path -LiteralPath $srcPath -PathType Container) {
+                            # If source exists as a folder, append the last subfolder to the destination, so that Robocopy produces similar results to native Powershell
+                            $DestinationFolderPath = Join-Path $Destination (Split-Path -Path $srcPath -Leaf)
+                            $RobocopyArgsPath =  "`"$srcPath`" `"$DestinationFolderPath`" *"
+                        }
+                        Else {
+                            # Else assume source is a file and split args to the format <SourceFolder> <DestinationFolder> <FileName>
                             $SourceFolderPath = (Split-Path -Path $srcPath -Parent)
                             $SourceFilePath = (Split-Path -Path $srcPath -Leaf)
                             $RobocopyArgsPath =  "`"$SourceFolderPath`" `"$Destination`" `"$SourceFilePath`""
-                        }
-                        Else {
-                            # If source is a folder, append the last subfolder to the destination, so that Robocopy produces similar results to native Powershell
-                            $DestinationFolderPath = Join-Path $Destination (Split-Path -Path $srcPath -Leaf)
-                            $RobocopyArgsPath =  "`"$srcPath`" `"$DestinationFolderPath`" *"
                         }
                         If ($Flatten) {
                             Write-Log -Message "Copying file(s) recursively in path [$srcPath] to destination [$Destination] root folder, flattened." -Source ${CmdletName}

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5219,8 +5219,8 @@ https://psappdeploytoolkit.com
                         $Destination = $Destination.TrimEnd('\')
                         # Robocopy arguments: NJH = No Job Header; NJS = No Job Summary; NS = No Size; NC = No Class; NP = No Progress; NDL = No Directory List; FP = Full Path; IS = Include Same; MT = Number of Threads; R = Number of Retries; W = Wait time between retries in sconds
                         $RobocopyArgsCopy = "/NJH /NJS /NS /NC /NP /NDL /FP /IS /MT:4 /R:1 /W:1"
-                        If (Test-Path -Path $srcPath -PathType Leaf) {
-                            # If source is a file, split args to the format <SourceFolder> <DestinationFolder> <FileName>
+                        If ((Test-Path -Path $srcPath -PathType Leaf) -or (Split-Path -Path $srcPath -Leaf) -match '\*') {
+                            # If source is a file, or if leaf contains *, split args to the format <SourceFolder> <DestinationFolder> <FileName>
                             $SourceFolderPath = (Split-Path -Path $srcPath -Parent)
                             $SourceFilePath = (Split-Path -Path $srcPath -Leaf)
                             $RobocopyArgsPath =  "`"$SourceFolderPath`" `"$Destination`" `"$SourceFilePath`""


### PR DESCRIPTION
Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.

Issue reported on Discord - Copy-File fails if copying a source of `"$dirFiles\*"` with -Recurse, if the source folder contains subfolders but no files in the root.

If a file is specified in the path (or anything with a wildcard), we're supposed to be splitting the path argument so we can give Robocopy SourceFolder, DestFolder and Files.

Previous code only checked to see if the source contains a file via Test-Path -PathType Leaf. Now it also will hit this code branch if the last portion of the path contains a *.