### PR TITLE
Update documentation for Test-IsMutexAvailable and Get-PEFileArchitecture

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -4722,7 +4722,7 @@ Wait, up to a timeout (default is 1 millisecond), for the mutex to become availa
 
 The name of the system mutex.
 
-.PARAMETER MutexWaitTime
+.PARAMETER MutexWaitTimeInMilliseconds
 
 The number of milliseconds the current thread should wait to acquire an exclusive lock of a named mutex. Default is: 1 millisecond.
 A wait timeof -1 milliseconds means to wait indefinitely. A wait time of zero does not acquire an exclusive lock but instead tests the state of the wait handle and returns immediately.

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -12124,6 +12124,7 @@ This is an internal script function and should typically not be called directly.
 
 .LINK
 
+https://psappdeploytoolkit.com
 #>
     [CmdletBinding()]
     Param (


### PR DESCRIPTION
old documentation has an incorrect parameter name

Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.
