### PR TITLE
Load 'AppDeployToolkitExtensions.ps1' after the $installName ist conf…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,4 @@
-﻿**Version 3.9.4 [03/27/2024]**
+﻿**Version 3.10.0 [03/27/2024]**
 - Added the ability to configure Microsoft Edge Extensions using ExtensionSettings. Function: Configure-EdgeExtensions. This enables Edge Extensions to be installed and managed like applications, enabling extensions to be pushed to specific devices or users alongside existing GPO/Intune extension policies. This should not be used in conjunction with Edge Management Service which leverages the same registry key to configure Edge extensions.
 - Added the ability to copy the Toolkit folder and files to a cache folder on the local machine and execute from there.
     Functions: Copy-ContentToCache and Remove-ContentFromCache. The cache path can be configured in the config.xml file, default is $envProgramData\SoftwareCache. When Copy-ContentToCache is used, $dirFiles is updated to point to the local cache path.

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -16613,11 +16613,6 @@ If (-not ([Management.Automation.PSTypeName]'PSADT.UiAutomation').Type) {
 ## Dot source ScriptBlock to get system DPI scale factor
 . $GetDisplayScaleFactor
 
-## Dot Source script extensions
-If (Test-Path -LiteralPath "$scriptRoot\$appDeployToolkitDotSourceExtensions" -PathType 'Leaf') {
-    . "$scriptRoot\$appDeployToolkitDotSourceExtensions"
-}
-
 ## If the default Deploy-Application.ps1 hasn't been modified, and the main script was not called by a referring script, check for MSI / MST and modify the install accordingly
 If ((-not $appName) -and (-not $ReferredInstallName)) {
     # Build properly formatted Architecture String
@@ -16767,6 +16762,11 @@ If ($configToolkitCompressLogs) {
     If (Test-Path -LiteralPath $logTempFolder -PathType 'Container' -ErrorAction 'SilentlyContinue') {
         $null = Remove-Item -LiteralPath $logTempFolder -Recurse -Force -ErrorAction 'SilentlyContinue'
     }
+}
+
+## Dot Source script extensions
+If (Test-Path -LiteralPath "$scriptRoot\$appDeployToolkitDotSourceExtensions" -PathType 'Leaf') {
+    . "$scriptRoot\$appDeployToolkitDotSourceExtensions"
 }
 
 ## Revert script logging to original setting


### PR DESCRIPTION
…igured

Currently you can't use the varibale $installname in the toolkit extension to define other custom varibales as this variable is set AFTER the extension is being procesesd.

Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.
