### PR TITLE
Execute process as user enhancements

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 ﻿**Version 3.10.1 [04/04/2024]**
 - Resolved an issue with Configure-EdgeExtensions where a new extension would not be added if no extensions were configured previously. #931
 - Added parameter sets to Configure-EdgeExtensions to ensure mandatory parameters are correctly grouped.
+- Resolved an issue where Execute-ProcessAsUser was not able to execute with RunLevel = 'LeastPrivilege' in some cases.
+- Rewrote RunHidden.vbs to get rid of use of ArrayList as it caused problems on some systems.
+- Improved Execute-ProcessAsUser by adding an example for executing the function using "LeastPrivilege".
+- Resolved an issue in Execute-ProcessAsUser where the commandline for two of the examples was incorrect.
 
 **Version 3.10.0 [03/27/2024]**
 - Added the ability to configure Microsoft Edge Extensions using ExtensionSettings. Function: Configure-EdgeExtensions. This enables Edge Extensions to be installed and managed like applications, enabling extensions to be pushed to specific devices or users alongside existing GPO/Intune extension policies. This should not be used in conjunction with Edge Management Service which leverages the same registry key to configure Edge extensions.

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -7970,7 +7970,7 @@ https://psappdeploytoolkit.com
         [String]${CmdletName} = $PSCmdlet.MyInvocation.MyCommand.Name
         Write-FunctionHeaderOrFooter -CmdletName ${CmdletName} -CmdletBoundParameters $PSBoundParameters -Header
 
-        If ((-not [String]::IsNullOrEmpty($TempPath))) {
+        If (-not [String]::IsNullOrEmpty($TempPath)) {
             $executeAsUserTempPath = $TempPath
             If (($TempPath -eq $loggedOnUserTempPath) -and ($RunLevel -eq 'HighestPrivilege')) {
                 Write-Log -Message "WARNING: Using [${CmdletName}] with a user writable directory using the 'HighestPrivilege' creates a security vulnerability. Please use -RunLevel 'LeastPrivilege' when using a user writable directoy." -Severity 'Warning'
@@ -8132,7 +8132,12 @@ https://psappdeploytoolkit.com
 
                 #  Export the XML file
                 [String]$xmlSchTask | Out-File -FilePath $xmlSchTaskFilePath -Force -ErrorAction 'Stop'
-                Set-ItemPermission -Path $xmlSchTaskFilePath -User $UserName -Permission 'Read'
+                Try {
+                    Set-ItemPermission -Path $xmlSchTaskFilePath -User $UserName -Permission 'Read'
+                }
+                Catch {
+                    Write-Log -Message "Failed to set read permissions on path [$xmlSchTaskFilePath]. The function might not be able to work correctly." -Source ${CmdletName} -Severity 2
+                }
             }
             Catch {
                 [Int32]$executeProcessAsUserExitCode = 60007

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -7912,15 +7912,20 @@ Returns the exit code from this function or the process launched by the schedule
 
 .EXAMPLE
 
-Execute-ProcessAsUser -UserName 'CONTOSO\User' -Path "$PSHOME\powershell.exe" -Parameters "-Command & { & `"C:\Test\Script.ps1`"; Exit `$LastExitCode }" -Wait
+Execute-ProcessAsUser -UserName 'CONTOSO\User' -Path "$PSHOME\powershell.exe" -Parameters "-Command `"& { & 'C:\Test\Script.ps1'; Exit `$LastExitCode }`"" -Wait
 
 Execute process under a user account by specifying a username under which to execute it.
 
 .EXAMPLE
 
-Execute-ProcessAsUser -Path "$PSHOME\powershell.exe" -Parameters "-Command & { & `"C:\Test\Script.ps1`"; Exit `$LastExitCode }" -Wait
+Execute-ProcessAsUser -Path "$PSHOME\powershell.exe" -Parameters "-Command `"& { & 'C:\Test\Script.ps1'; Exit `$LastExitCode }`"" -Wait
 
 Execute process under a user account by using the default active logged in user that was detected when the toolkit was launched.
+
+.EXAMPLE
+Execute-ProcessAsUser -Path "$PSHOME\powershell.exe" -Parameters "-Command `"& { & 'C:\Test\Script.ps1'; Exit `$LastExitCode }`"" -RunLevel 'LeastPrivilege'
+
+Execute process using 'LeastPrivilege' under a user account by using the default active logged in user that was detected when the toolkit was launched.
 
 .NOTES
 

--- a/Toolkit/AppDeployToolkit/RunHidden.vbs
+++ b/Toolkit/AppDeployToolkit/RunHidden.vbs
@@ -88,20 +88,22 @@ Function ArgvQuote(Argument, ForceQuote, CmdDetected)
     ArgvQuote = sEscapedArgument
 End Function
 
-Dim sCmd, oWShell, iReturn, arg, bCmdDetected, oArgumentList
+Dim sCmd, oWShell, iReturn, sArg, bCmdDetected, oArgumentList(), iCount
 
 iReturn = 0
 If WScript.Arguments.Count > 0 Then
     ' Check if first argument references cmd or cmd.exe
     bCmdDetected = IsCmdAtEnd(WScript.Arguments(0))
 
-    Set oArgumentList = CreateObject("System.Collections.ArrayList")
-    For Each arg In WScript.Arguments
-        oArgumentList.Add(ArgvQuote(arg, False, bCmdDetected))
+    ReDim oArgumentList(WScript.Arguments.Count - 1)
+    iCount = 0
+    For Each sArg In WScript.Arguments
+        oArgumentList(iCount) = ArgvQuote(sArg, False, bCmdDetected)
+        iCount = iCount + 1
     Next
-
-    sCmd = Join(oArgumentList.ToArray, " ")
-
+    
+    sCmd = Join(oArgumentList, " ")
+    
     Set oWShell = CreateObject("WScript.Shell")
     iReturn = oWShell.Run(sCmd, 0, True)
 End If


### PR DESCRIPTION
Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.

- Resolved an issue where Execute-ProcessAsUser was not able to execute with RunLevel = 'LeastPrivilege' in some cases.
- Rewrote RunHidden.vbs to get rid of use of ArrayList as it caused problems on some systems.
- Improved Execute-ProcessAsUser by adding an example for executing the function using "LeastPrivilege".
- Resolved an issue in Execute-ProcessAsUser where the commandline for two of the examples was incorrect.