### PR TITLE
Replace IsNullOrWhiteSpace methods with .Net 3.5 compatible alternative

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1169,13 +1169,13 @@ https://psappdeploytoolkit.com
         If (-not (Test-Path -LiteralPath 'variable:DisableLogging')) {
             $DisableLogging = $false
         }
-        If ([System.String]::IsNullOrWhiteSpace($LogFileName)) {
+        If ($LogFileName -notmatch '\S') {
             $DisableLogging = $true
         }
         #  Check if the script section is defined
         [Boolean]$ScriptSectionDefined = [Boolean](-not [String]::IsNullOrEmpty($ScriptSection))
         #  Get the file name of the source script
-        $ScriptSource = If (![System.String]::IsNullOrWhiteSpace($script:MyInvocation.ScriptName)) {
+        $ScriptSource = If ($script:MyInvocation.ScriptName -match '\S') {
             Split-Path -Path $script:MyInvocation.ScriptName -Leaf -ErrorAction SilentlyContinue
         }
         Else {
@@ -9125,7 +9125,7 @@ https://psappdeploytoolkit.com
         [Diagnostics.Process[]]$runningProcesses = foreach ($process in (Get-Process -Name $processObjects.ProcessName -ErrorAction SilentlyContinue))
         {
             Add-Member -InputObject $process -MemberType NoteProperty -Name ProcessDescription -Force -PassThru -Value $(
-                if (![System.String]::IsNullOrWhiteSpace(($objDescription = ($processObjects | Where-Object {$_.ProcessName -eq $process.ProcessName}).ProcessDescription)))
+                if (($objDescription = ($processObjects | Where-Object {$_.ProcessName -eq $process.ProcessName}).ProcessDescription) -match '\S')
                 {
                     # The description of the process provided as a Parameter to the function, e.g. -ProcessName "winword=Microsoft Office Word".
                     $objDescription

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -366,12 +366,7 @@ Try {
 Catch{}
 [String]$LocalAdministratorsGroup = & $GetAccountNameUsingSid 'BuiltinAdministratorsSid'
 #  Check if script is running in session zero
-If ($IsLocalSystemAccount -or $IsLocalServiceAccount -or $IsNetworkServiceAccount -or $IsServiceAccount) {
-    $SessionZero = $true
-}
-Else {
-    $SessionZero = $false
-}
+[Boolean]$SessionZero = ($IsLocalSystemAccount -or $IsLocalServiceAccount -or $IsNetworkServiceAccount -or $IsServiceAccount)
 
 ## Variables: Script Name and Script Paths
 [String]$scriptPath = $MyInvocation.MyCommand.Definition

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -7814,12 +7814,7 @@ https://psappdeploytoolkit.com
                 $shortcut = $null
                 ## Run as admin
                 [Byte[]]$filebytes = [IO.FIle]::ReadAllBytes($FullPath)
-                If ($filebytes[21] -band 32) {
-                    $Output.RunAsAdmin = $true
-                }
-                Else {
-                    $Output.RunAsAdmin = $false
-                }
+                $Output.RunAsAdmin = [Boolean]($filebytes[21] -band 32)
             }
             Write-Output -InputObject ($Output)
         }

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -13631,13 +13631,7 @@ https://psappdeploytoolkit.com
 
                 ## Send the Key sequence
                 If ($Keys) {
-                    [Boolean]$IsWindowModal = If ([PSADT.UiAutomation]::IsWindowEnabled($WindowHandle)) {
-                        $false
-                    }
-                    Else {
-                        $true
-                    }
-                    If ($IsWindowModal) {
+                    If (-not [PSADT.UiAutomation]::IsWindowEnabled($WindowHandle)) {
                         Throw 'Unable to send keys to window because it may be disabled due to a modal dialog being shown.'
                     }
                     Write-Log -Message "Sending key(s) [$Keys] to window title [$($Window.WindowTitle)] with window handle [$WindowHandle]." -Source ${CmdletName}

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -3630,41 +3630,39 @@ https://psappdeploytoolkit.com
             }
         }
 
-        ## Enclose the MSI file in quotes to avoid issues with spaces when running msiexec
-        [String]$msiFile = "`"$msiFile`""
-
         ## Start building the MsiExec command line starting with the base action and file
-        [String]$argsMSI = "$option $msiFile"
-        #  Add MST
-        If ($transform) {
-            $argsMSI = "$argsMSI TRANSFORMS=$mstFile TRANSFORMSSECURE=1"
-        }
-        #  Add MSP
-        If ($patch) {
-            $argsMSI = "$argsMSI PATCH=$mspFile"
-        }
-        #  Replace default parameters if specified.
-        If ($Parameters) {
-            $argsMSI = "$argsMSI $Parameters"
-        }
-        Else {
-            $argsMSI = "$argsMSI $msiDefaultParams"
-        }
-        #  Add reinstallmode and reinstall variable for Patch
-        If ($action -eq 'Patch') {
-            $argsMSI += ' REINSTALLMODE=ecmus REINSTALL=ALL'
-        }
-        #  Append parameters to default parameters if specified.
-        If ($AddParameters) {
-            $argsMSI = "$argsMSI $AddParameters"
-        }
-        #  Add custom Logging Options if specified, otherwise, add default Logging Options from Config file
-        If ($LoggingOptions) {
-            $argsMSI = "$argsMSI $LoggingOptions $msiLogFile"
-        }
-        Else {
-            $argsMSI = "$argsMSI $configMSILoggingOptions $msiLogFile"
-        }
+        #  Enclose the MSI file in quotes to avoid issues with spaces when running msiexec
+        [String]$argsMSI = "$option `"$msiFile`"" + `
+            #  Add MST
+            $(If ($transform) {
+                " TRANSFORMS=$mstFile TRANSFORMSSECURE=1"
+            }) + `
+            #  Add MSP
+            $(If ($patch) {
+                " PATCH=$mspFile"
+            }) + `
+            #  Replace default parameters if specified.
+            $(If ($Parameters) {
+                " $Parameters"
+            }
+            Else {
+                " $msiDefaultParams"
+            }) + `
+            #  Add reinstallmode and reinstall variable for Patch.
+            $(If ($action -eq 'Patch') {
+                ' REINSTALLMODE=ecmus REINSTALL=ALL'
+            }) + `
+            #  Append parameters to default parameters if specified.
+            $(If ($AddParameters) {
+                " $AddParameters"
+            }) + `
+            #  Add custom Logging Options if specified, otherwise, add default Logging Options from Config file.
+            $(If ($LoggingOptions) {
+                " $LoggingOptions $msiLogFile"
+            }
+            Else {
+                " $configMSILoggingOptions $msiLogFile"
+            })
 
         ## Check if the MSI is already installed. If no valid ProductCode to check or SkipMSIAlreadyInstalledCheck supplied, then continue with requested MSI action.
         [Boolean]$IsMsiInstalled = If ($MSIProductCode -and -not $SkipMSIAlreadyInstalledCheck) {

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -8036,21 +8036,18 @@ https://psappdeploytoolkit.com
                     Write-Log -Message "Preparing parameters for VBScript that will start [$Path $Parameters] as the logged-on user [$userName] and suppress the console window..." -Source ${CmdletName}
                 }
 
-                [String]$NewParameters = "/e:vbscript"
-                If ($executeAsUserTempPath -match ' ') {
-                    $NewParameters = "$($NewParameters) `"$($executeAsUserTempPath)\RunHidden.vbs`""
-                }
-                Else {
-                    $NewParameters = "$($NewParameters) $($executeAsUserTempPath)\RunHidden.vbs"
-                }
-                If (($Path -notmatch "^[`'].*[`']$") -and ($Path -notmatch "^[`"].*[`"]$") -and $Path -match ' ') {
-                    $NewParameters = "$($NewParameters) `"$($Path)`""
-                }
-                Else {
-                    $NewParameters = "$NewParameters $Path"
-                }
-
-                $Parameters = "$NewParameters $Parameters"
+                $Parameters = '/e:vbscript' + `
+                    $(If ($executeAsUserTempPath -match ' ') {
+                        " `"$executeAsUserTempPath\RunHidden.vbs`""
+                    } Else {
+                        " $executeAsUserTempPath\RunHidden.vbs"
+                    }) + `
+                    $(If (($Path -notmatch "^[`'].*[`']$") -and ($Path -notmatch "^[`"].*[`"]$") -and $Path -match ' ') {
+                        " `"$($Path)`""
+                    } Else {
+                        " $Path"
+                    }) + `
+                    " $Parameters"
                 $Path = "$envWinDir\System32\wscript.exe"
             }
             #  Replace invalid XML characters in parameters with their valid XML equivalent


### PR DESCRIPTION
Replace IsNullOrWhiteSpace methods with .Net 3.5 compatible alternative and simplify the creation of a few variables.

Before submitting this Pull Request, I made sure:

- [X] I tested the toolkit with my changes and made sure it doesn't break other code.

- [X] I updated the documentation with the changes I made.

- [X] The code I changed has comments with explanation.

- [X] The encoding of the file wasn't changed. It is still UTF8 with BOM.
