### PR TITLE
Write-log rewrite

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1225,37 +1225,6 @@ https://psappdeploytoolkit.com
             "<![LOG[$lMessage]LOG]!>" + "<time=`"$LogTimePlusBias`" " + "date=`"$LogDate`" " + "component=`"$lSource`" " + "context=`"$([Security.Principal.WindowsIdentity]::GetCurrent().Name)`" " + "type=`"$lSeverity`" " + "thread=`"$PID`" " + "file=`"$ScriptSource`">"
         }
 
-        ## Create script block for writing log entry to the console
-        [ScriptBlock]$WriteLogLineToHost = {
-            Param (
-                [String]$lTextLogLine,
-                [Int16]$lSeverity
-            )
-            If ($WriteHost) {
-                #  Only output using color options if running in a host which supports colors.
-                If ($Host.UI.RawUI.ForegroundColor) {
-                    Switch ($lSeverity) {
-                        3 {
-                            Write-Host -Object $lTextLogLine -ForegroundColor 'Red' -BackgroundColor 'Black'
-                        }
-                        2 {
-                            Write-Host -Object $lTextLogLine -ForegroundColor 'Yellow' -BackgroundColor 'Black'
-                        }
-                        1 {
-                            Write-Host -Object $lTextLogLine
-                        }
-                        0 {
-                            Write-Host -Object $lTextLogLine -ForegroundColor 'Green' -BackgroundColor 'Black'
-                        }
-                    }
-                }
-                #  If executing "powershell.exe -File <filename>.ps1 > log.txt", then all the Write-Host calls are converted to Write-Output calls so that they are included in the text log.
-                Else {
-                    Write-Output -InputObject ($lTextLogLine)
-                }
-            }
-        }
-
         ## Exit function if it is a debug message and logging debug messages is not enabled in the config XML file
         If (($DebugMessage) -and (-not $LogDebugMessage)) {
             [Boolean]$ExitLoggingFunction = $true; Return
@@ -1425,8 +1394,30 @@ https://psappdeploytoolkit.com
                 }
             }
 
-            ## Execute script block to write the log entry to the console if $WriteHost is $true
-            & $WriteLogLineToHost -lTextLogLine $ConsoleLogLine -lSeverity $Severity
+            ## Write the log entry to the console if $WriteHost is $true
+            If ($WriteHost) {
+                #  Only output using color options if running in a host which supports colors.
+                If ($Host.UI.RawUI.ForegroundColor) {
+                    Switch ($Severity) {
+                        3 {
+                            Write-Host -Object $ConsoleLogLine -ForegroundColor 'Red' -BackgroundColor 'Black'
+                        }
+                        2 {
+                            Write-Host -Object $ConsoleLogLine -ForegroundColor 'Yellow' -BackgroundColor 'Black'
+                        }
+                        1 {
+                            Write-Host -Object $ConsoleLogLine
+                        }
+                        0 {
+                            Write-Host -Object $ConsoleLogLine -ForegroundColor 'Green' -BackgroundColor 'Black'
+                        }
+                    }
+                }
+                #  If executing "powershell.exe -File <filename>.ps1 > log.txt", then all the Write-Host calls are converted to Write-Output calls so that they are included in the text log.
+                Else {
+                    Write-Output -InputObject ($ConsoleLogLine)
+                }
+            }
         }
     }
     End {

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1161,26 +1161,26 @@ https://psappdeploytoolkit.com
         [Parameter(Mandatory = $false, Position = 6)]
         [ValidateNotNullorEmpty()]
         [String]$LogFileName = $logName,
-        [Parameter(Mandatory=$false,Position=7)]
+        [Parameter(Mandatory = $false, Position = 7)]
         [ValidateNotNullorEmpty()]
         [Boolean]$AppendToLogFile = $configToolkitLogAppend,
-        [Parameter(Mandatory=$false,Position=8)]
+        [Parameter(Mandatory = $false, Position = 8)]
         [ValidateNotNullorEmpty()]
         [Int]$MaxLogHistory = $configToolkitLogMaxHistory,
         [Parameter(Mandatory = $false, Position = 9)]
         [ValidateNotNullorEmpty()]
         [Decimal]$MaxLogFileSizeMB = $configToolkitLogMaxSize,
-	    [Parameter(Mandatory=$false,Position=10)]
+        [Parameter(Mandatory = $false, Position = 10)]
         [ValidateNotNullorEmpty()]
         [Boolean]$ContinueOnError = $true,
         [Parameter(Mandatory = $false, Position = 11)]
         [ValidateNotNullorEmpty()]
         [Boolean]$WriteHost = $configToolkitLogWriteToHost,
-        [Parameter(Mandatory=$false,Position=12)]
+        [Parameter(Mandatory = $false, Position = 12)]
         [Switch]$PassThru = $false,
-	    [Parameter(Mandatory=$false,Position=13)]
+        [Parameter(Mandatory = $false, Position = 13)]
         [Switch]$DebugMessage = $false,
-	    [Parameter(Mandatory=$false,Position=14)]
+        [Parameter(Mandatory = $false, Position = 14)]
         [Boolean]$LogDebugMessage = $configToolkitLogDebugMessage
     )
 
@@ -1208,7 +1208,7 @@ https://psappdeploytoolkit.com
         #  Check if the script section is defined
         [Boolean]$ScriptSectionDefined = [Boolean](-not [String]::IsNullOrEmpty($ScriptSection))
         #  Get the file name of the source script
-        $ScriptSource = If (![System.String]::IsNullOrEmpty($script:MyInvocation.ScriptName)) {
+        $ScriptSource = If (-not [System.String]::IsNullOrEmpty($script:MyInvocation.ScriptName)) {
             Split-Path -Path $script:MyInvocation.ScriptName -Leaf -ErrorAction SilentlyContinue
         }
         Else {

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1325,15 +1325,11 @@ https://psappdeploytoolkit.com
             [String]$ConsoleLogLine = ''
             [String]$LegacyTextLogLine = ''
             If ($Msg) {
-                #  Create the CMTrace log message
-                If ($ScriptSectionDefined) {
-                    [String]$CMTraceMsg = "[$ScriptSection] :: $Msg"
-                }
-
                 #  Create a Console and Legacy "text" log entry
                 [String]$LegacyMsg = "[$LogDate $LogTime]"
                 If ($ScriptSectionDefined) {
                     [String]$LegacyMsg += " [$ScriptSection]"
+                    [String]$CMTraceMsg = "[$ScriptSection] :: "
                 }
                 If ($Source) {
                     [String]$LegacyMsg += " [$Source]"
@@ -1353,6 +1349,7 @@ https://psappdeploytoolkit.com
                         "$LegacyMsg [Success] :: $Msg"
                     }
                 }
+                [String]$CMTraceMsg += $Msg
             }
 
             ## Execute script block to create the CMTrace.exe compatible log entry

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1241,7 +1241,14 @@ https://psappdeploytoolkit.com
                 [Boolean]$ExitLoggingFunction = $true
                 #  If error creating directory, write message to console
                 If (-not $ContinueOnError) {
-                    Write-Host -Object "[$LogDate $LogTime] [${CmdletName}] $ScriptSection :: Failed to create the log directory [$LogFileDirectory]. `r`n$(Resolve-Error)" -ForegroundColor 'Red'
+                    #  Only output using color options if running in a host which supports colors.
+                    If ($Host.UI.RawUI.ForegroundColor) {
+                        Write-Host -Object "[$LogDate $LogTime] [$ScriptSection] [${CmdletName}] :: Failed to create the log directory [$LogFileDirectory]. `r`n$(Resolve-Error)" -ForegroundColor 'Red' -BackgroundColor 'Black'
+                    }
+                    #  If executing "powershell.exe -File <filename>.ps1 > log.txt", then all the Write-Host calls are converted to Write-Output calls so that they are included in the text log.
+                    Else {
+                        Write-Output -InputObject "[$LogDate $LogTime] [$ScriptSection] [${CmdletName}] :: Failed to create the log directory [$LogFileDirectory]. `r`n$(Resolve-Error)"
+                    }
                 }
                 Return
             }
@@ -1292,7 +1299,12 @@ https://psappdeploytoolkit.com
                 }
             }
             Catch {
-                Write-Host -Object "[$LogDate $LogTime] [${CmdletName}] $ScriptSection :: Failed to rotate the log file [$LogFilePath]. `r`n$(Resolve-Error)" -ForegroundColor 'Red'
+                If ($Host.UI.RawUI.ForegroundColor) {
+                    Write-Host -Object "[$LogDate $LogTime] [$ScriptSection] [${CmdletName}] :: Failed to rotate the log file [$LogFilePath]. `r`n$(Resolve-Error)" -ForegroundColor 'Red' -BackgroundColor 'Black'
+                }
+                Else {
+                    Write-Output -InputObject "[$LogDate $LogTime] [$ScriptSection] [${CmdletName}] :: Failed to rotate the log file [$LogFilePath]. `r`n$(Resolve-Error)"
+                }
                 # Treat log rotation errors as non-terminating by default
                 If (-not $ContinueOnError) {
                     [Boolean]$ExitLoggingFunction = $true
@@ -1355,7 +1367,12 @@ https://psappdeploytoolkit.com
                 }
                 Catch {
                     If (-not $ContinueOnError) {
-                        Write-Host -Object "[$LogDate $LogTime] [$ScriptSection] [${CmdletName}] :: Failed to write message [$Msg] to the log file [$LogFilePath]. `r`n$(Resolve-Error)" -ForegroundColor 'Red'
+                        If ($Host.UI.RawUI.ForegroundColor) {
+                            Write-Host -Object "[$LogDate $LogTime] [$ScriptSection] [${CmdletName}] :: Failed to write message [$Msg] to the log file [$LogFilePath]. `r`n$(Resolve-Error)" -ForegroundColor 'Red' -BackgroundColor 'Black'
+                        }
+                        Else {
+                            Write-Output -InputObject "[$LogDate $LogTime] [$ScriptSection] [${CmdletName}] :: Failed to write message [$Msg] to the log file [$LogFilePath]. `r`n$(Resolve-Error)"
+                        }
                     }
                 }
             }

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1138,12 +1138,7 @@ https://psappdeploytoolkit.com
         [Int16]$Severity = 1,
         [Parameter(Mandatory = $false, Position = 2)]
         [ValidateNotNull()]
-        [String]$Source = $([String]$parentFunctionName = [IO.Path]::GetFileNameWithoutExtension((Get-Variable -Name 'MyInvocation' -Scope 1 -ErrorAction 'SilentlyContinue').Value.MyCommand.Name); If ($parentFunctionName) {
-                $parentFunctionName
-            }
-            Else {
-                'Unknown'
-            }),
+        [String]$Source = [IO.Path]::GetFileNameWithoutExtension((Get-Variable -Name 'MyInvocation' -Scope 1 -ErrorAction 'SilentlyContinue').Value.MyCommand.Name),
         [Parameter(Mandatory = $false, Position = 3)]
         [ValidateNotNullorEmpty()]
         [String]$ScriptSection = $script:installPhase,
@@ -1204,6 +1199,9 @@ https://psappdeploytoolkit.com
         }
         If ([System.String]::IsNullOrEmpty($LogFileName) -or $LogFileName.Trim().Length -eq 0) {
             $DisableLogging = $true
+        }
+        If ($Source.Trim().Length -eq 0) {
+            $Source = 'Unknown'
         }
         #  Check if the script section is defined
         [Boolean]$ScriptSectionDefined = [Boolean](-not [String]::IsNullOrEmpty($ScriptSection))

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1336,37 +1336,21 @@ https://psappdeploytoolkit.com
                     [String]$LegacyMsg += " [$ScriptSection]"
                 }
                 If ($Source) {
-                    [String]$ConsoleLogLine = "$LegacyMsg [$Source] :: $Msg"
-                    Switch ($Severity) {
-                        3 {
-                            [String]$LegacyTextLogLine = "$LegacyMsg [$Source] [Error] :: $Msg"
-                        }
-                        2 {
-                            [String]$LegacyTextLogLine = "$LegacyMsg [$Source] [Warning] :: $Msg"
-                        }
-                        1 {
-                            [String]$LegacyTextLogLine = "$LegacyMsg [$Source] [Info] :: $Msg"
-                        }
-                        0 {
-                            [String]$LegacyTextLogLine = "$LegacyMsg [$Source] [Success] :: $Msg"
-                        }
-                    }
+                    [String]$LegacyMsg += " [$Source]"
                 }
-                Else {
-                    [String]$ConsoleLogLine = "$LegacyMsg :: $Msg"
-                    Switch ($Severity) {
-                        3 {
-                            [String]$LegacyTextLogLine = "$LegacyMsg [Error] :: $Msg"
-                        }
-                        2 {
-                            [String]$LegacyTextLogLine = "$LegacyMsg [Warning] :: $Msg"
-                        }
-                        1 {
-                            [String]$LegacyTextLogLine = "$LegacyMsg [Info] :: $Msg"
-                        }
-                        0 {
-                            [String]$LegacyTextLogLine = "$LegacyMsg [Success] :: $Msg"
-                        }
+                [String]$ConsoleLogLine = "$LegacyMsg :: $Msg"
+                [String]$LegacyTextLogLine = Switch ($Severity) {
+                    3 {
+                        "$LegacyMsg [Error] :: $Msg"
+                    }
+                    2 {
+                        "$LegacyMsg [Warning] :: $Msg"
+                    }
+                    1 {
+                        "$LegacyMsg [Info] :: $Msg"
+                    }
+                    0 {
+                        "$LegacyMsg [Success] :: $Msg"
                     }
                 }
             }

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1320,13 +1320,13 @@ https://psappdeploytoolkit.com
         }
 
         ForEach ($Msg in $Message) {
-            ## If the message is not $null, empty, or white space, create the log entry for the different logging methods
+            ## Skip message if the message is $null, empty, or white space
             If ([String]::IsNullOrEmtpy($Msg) -or $Msg.Trim().Length -eq 0) {
                 Continue
             }
             [String]$CMTraceMsg = ''
 
-            #  Create a Console and Legacy "text" log entry
+            #  Create log entry
             [String]$LegacyMsg = "[$LogDate $LogTime]"
             If ($ScriptSectionDefined) {
                 [String]$LegacyMsg += " [$ScriptSection]"
@@ -1358,7 +1358,7 @@ https://psappdeploytoolkit.com
                 }
             }
 
-            ## Write the log entry to the log file if logging is not currently disabled
+            ## Write the log entry to the log file if logging is not currently disabled.
             If (-not $DisableLogging) {
                 Try {
                     $LogLine | Out-File -FilePath $LogFilePath -Append -NoClobber -Force -Encoding 'UTF8' -ErrorAction 'Stop'
@@ -1375,7 +1375,7 @@ https://psappdeploytoolkit.com
                 }
             }
 
-            ## Write the log entry to the console if $WriteHost is $true
+            ## Write the log entry to the console if $WriteHost is $true.
             If ($WriteHost) {
                 [String]$ConsoleLogLine = "$LegacyMsg :: $Msg"
                 #  Only output using color options if running in a host which supports colors.

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1320,37 +1320,39 @@ https://psappdeploytoolkit.com
         }
 
         ForEach ($Msg in $Message) {
-            ## If the message is not $null or empty, create the log entry for the different logging methods
+            ## If the message is not $null, empty, or white space, create the log entry for the different logging methods
+            If ([String]::IsNullOrEmtpy($Msg) -or $Msg.Trim().Length -eq 0) {
+                Continue
+            }
             [String]$CMTraceMsg = ''
             [String]$ConsoleLogLine = ''
             [String]$LegacyTextLogLine = ''
-            If ($Msg) {
-                #  Create a Console and Legacy "text" log entry
-                [String]$LegacyMsg = "[$LogDate $LogTime]"
-                If ($ScriptSectionDefined) {
-                    [String]$LegacyMsg += " [$ScriptSection]"
-                    [String]$CMTraceMsg = "[$ScriptSection] :: "
-                }
-                If ($Source) {
-                    [String]$LegacyMsg += " [$Source]"
-                }
-                [String]$ConsoleLogLine = "$LegacyMsg :: $Msg"
-                [String]$LegacyTextLogLine = Switch ($Severity) {
-                    3 {
-                        "$LegacyMsg [Error] :: $Msg"
-                    }
-                    2 {
-                        "$LegacyMsg [Warning] :: $Msg"
-                    }
-                    1 {
-                        "$LegacyMsg [Info] :: $Msg"
-                    }
-                    0 {
-                        "$LegacyMsg [Success] :: $Msg"
-                    }
-                }
-                [String]$CMTraceMsg += $Msg
+
+            #  Create a Console and Legacy "text" log entry
+            [String]$LegacyMsg = "[$LogDate $LogTime]"
+            If ($ScriptSectionDefined) {
+                [String]$LegacyMsg += " [$ScriptSection]"
+                [String]$CMTraceMsg = "[$ScriptSection] :: "
             }
+            If ($Source) {
+                [String]$LegacyMsg += " [$Source]"
+            }
+            [String]$ConsoleLogLine = "$LegacyMsg :: $Msg"
+            [String]$LegacyTextLogLine = Switch ($Severity) {
+                3 {
+                    "$LegacyMsg [Error] :: $Msg"
+                }
+                2 {
+                    "$LegacyMsg [Warning] :: $Msg"
+                }
+                1 {
+                    "$LegacyMsg [Info] :: $Msg"
+                }
+                0 {
+                    "$LegacyMsg [Success] :: $Msg"
+                }
+            }
+            [String]$CMTraceMsg += $Msg
 
             ## Execute script block to create the CMTrace.exe compatible log entry
             [String]$CMTraceLogLine = & $CMTraceLogString -lMessage $CMTraceMsg -lSource $Source -lSeverity $Severity

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1321,7 +1321,7 @@ https://psappdeploytoolkit.com
 
         ForEach ($Msg in $Message) {
             ## Skip message if the message is $null, empty, or white space
-            If ([String]::IsNullOrEmtpy($Msg) -or $Msg.Trim().Length -eq 0) {
+            If ([String]::IsNullOrEmpty($Msg) -or $Msg.Trim().Length -eq 0) {
                 Continue
             }
             [String]$CMTraceMsg = ''

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1315,7 +1315,6 @@ https://psappdeploytoolkit.com
                 Continue
             }
             [String]$CMTraceMsg = ''
-            [String]$ConsoleLogLine = ''
 
             #  Create a Console and Legacy "text" log entry
             [String]$LegacyMsg = "[$LogDate $LogTime]"
@@ -1326,7 +1325,6 @@ https://psappdeploytoolkit.com
             If ($Source) {
                 [String]$LegacyMsg += " [$Source]"
             }
-            [String]$ConsoleLogLine = "$LegacyMsg :: $Msg"
             [String]$CMTraceMsg += $Msg
 
             ## Choose which log type to write to file and create it.
@@ -1364,6 +1362,7 @@ https://psappdeploytoolkit.com
 
             ## Write the log entry to the console if $WriteHost is $true
             If ($WriteHost) {
+                [String]$ConsoleLogLine = "$LegacyMsg :: $Msg"
                 #  Only output using color options if running in a host which supports colors.
                 If ($Host.UI.RawUI.ForegroundColor) {
                     Switch ($Severity) {


### PR DESCRIPTION
# Pull Request

## Description

- Ensure that error messages are always logged
    - Before they were presented using `Write-Host` now they will check if the host supports color and use `Write-Host` or `Write-Output` based upon whichever is supported.
- Ensure consistent formatting of error messages
- Ensure that $Source always has a value (before it was possible for $Source to be white space)
- Simplify the creation of variables and remove variables that are only used once.
- Small formatting fixes
- Ensure that CMTrace messages are logged regardless of if the script source is defined

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **develop** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Testing was performed by deploying Google Chrome using a script based on [Jason Bergner's](https://silentinstallhq.com/google-chrome-msi-v123-silent-install-how-to-guide/) Google Chrome install script. His code was adapted to the PSADT 3.10.1 Deploy-Application.ps1 script. The test host was a VMware Windows 11 VM running 23H2. Deploy-Application.exe was called from an elevated PowerShell terminal.