### PR TITLE
Add MARKs

### DIFF
--- a/Toolkit/Deploy-Application.ps1
+++ b/Toolkit/Deploy-Application.ps1
@@ -103,7 +103,7 @@ Try {
     }
 
     ##*===============================================
-    ##* VARIABLE DECLARATION
+    #region VARIABLE DECLARATION
     ##*===============================================
     ## Variables: Application
     [String]$appVendor = ''
@@ -171,12 +171,12 @@ Try {
     #endregion
     ##* Do not modify section above
     ##*===============================================
-    ##* END VARIABLE DECLARATION
+    #endregion END VARIABLE DECLARATION
     ##*===============================================
 
     If ($deploymentType -ine 'Uninstall' -and $deploymentType -ine 'Repair') {
         ##*===============================================
-        ##* PRE-INSTALLATION
+        ##* MARK: PRE-INSTALLATION
         ##*===============================================
         [String]$installPhase = 'Pre-Installation'
 
@@ -190,7 +190,7 @@ Try {
 
 
         ##*===============================================
-        ##* INSTALLATION
+        ##* MARK: INSTALLATION
         ##*===============================================
         [String]$installPhase = 'Installation'
 
@@ -208,7 +208,7 @@ Try {
 
 
         ##*===============================================
-        ##* POST-INSTALLATION
+        ##* MARK: POST-INSTALLATION
         ##*===============================================
         [String]$installPhase = 'Post-Installation'
 
@@ -221,7 +221,7 @@ Try {
     }
     ElseIf ($deploymentType -ieq 'Uninstall') {
         ##*===============================================
-        ##* PRE-UNINSTALLATION
+        ##* MARK: PRE-UNINSTALLATION
         ##*===============================================
         [String]$installPhase = 'Pre-Uninstallation'
 
@@ -235,7 +235,7 @@ Try {
 
 
         ##*===============================================
-        ##* UNINSTALLATION
+        ##* MARK: UNINSTALLATION
         ##*===============================================
         [String]$installPhase = 'Uninstallation'
 
@@ -251,7 +251,7 @@ Try {
 
 
         ##*===============================================
-        ##* POST-UNINSTALLATION
+        ##* MARK: POST-UNINSTALLATION
         ##*===============================================
         [String]$installPhase = 'Post-Uninstallation'
 
@@ -261,7 +261,7 @@ Try {
     }
     ElseIf ($deploymentType -ieq 'Repair') {
         ##*===============================================
-        ##* PRE-REPAIR
+        ##* MARK: PRE-REPAIR
         ##*===============================================
         [String]$installPhase = 'Pre-Repair'
 
@@ -274,7 +274,7 @@ Try {
         ## <Perform Pre-Repair tasks here>
 
         ##*===============================================
-        ##* REPAIR
+        ##* MARK: REPAIR
         ##*===============================================
         [String]$installPhase = 'Repair'
 
@@ -288,7 +288,7 @@ Try {
         ## <Perform Repair tasks here>
 
         ##*===============================================
-        ##* POST-REPAIR
+        ##* MARK: POST-REPAIR
         ##*===============================================
         [String]$installPhase = 'Post-Repair'
 
@@ -296,9 +296,6 @@ Try {
 
 
     }
-    ##*===============================================
-    ##* END SCRIPT BODY
-    ##*===============================================
 
     ## Call the Exit-Script function to perform final cleanup operations
     Exit-Script -ExitCode $mainExitCode


### PR DESCRIPTION
# Pull Request

## Description

With VSCode 1.88 (https://code.visualstudio.com/updates/v1_88#_minimap-section-headers), support has been added to showing section headers in the minimap. This can be done via regions, or MARKs. This adds the sections to the code. I went with MARKs for this one to change the least amount of lines, but I can see a use of regions instead as that'll also show at the top of the editor and allow for collapsing. If you'd prefer that, I can update this PR.
![image](https://github.com/PSAppDeployToolkit/PSAppDeployToolkit/assets/1351571/ed5ebd37-bff4-4d19-82b1-ec2358cea6e9)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **develop** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?
No actual logic has been changed, just editor improvements.