### PR TITLE
Fix Get-FileVersion -ProductVersion whitespace bug

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -7234,6 +7234,7 @@ https://psappdeploytoolkit.com
                 }
 
                 If ($fileVersion) {
+                    $fileVersion = $fileVersion.Trim()
                     If ($ProductVersion) {
                         Write-Log -Message "Product version is [$fileVersion]." -Source ${CmdletName}
                     }


### PR DESCRIPTION
# Pull Request

## Description

Add .Trim() to $fileVersion as some uninstall .exes packaged by INNO Setup will have whitespace at the end. 
The variable is a string so the type isn't being changed. 

Fixes: #1006 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **develop** branch
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Updated a local copy of 3.10.1 with this fix, ran Get-FileVersion -ProductVersion against an uninstaller created by INNO Setup, no whitespace anymore

My apologies if there are issues with this pull request, I'm very new to using Github