### PR TITLE
Set WindowState = 'Normal' in Show-InstallationPrompt and Show-WelcomePrompt - Fixes #1004

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -2365,6 +2365,9 @@ https://psappdeploytoolkit.com
                 Write-Log 'Failed to disable the Close button. Disabling the Control Box instead.' -Severity 2 -Source ${CmdletName}
                 $formInstallationPrompt.ControlBox = $false
             }
+            # Correct the initial state of the form
+            $formInstallationPrompt.WindowState = 'Normal'
+
             # Get the start position of the form so we can return the form to this position if PersistPrompt is enabled
             Set-Variable -Name 'formInstallationPromptStartPosition' -Value $formInstallationPrompt.Location -Scope 'Script'
         }
@@ -10137,7 +10140,10 @@ https://psappdeploytoolkit.com
                 Write-Log 'Failed to disable the Close button. Disabling the Control Box instead.' -Severity 2 -Source ${CmdletName}
                 $formWelcome.ControlBox = $false
             }
-            #  Get the start position of the form so we can return the form to this position if PersistPrompt is enabled
+            # Correct the initial state of the form
+            $formWelcome.WindowState = 'Normal'
+
+            # Get the start position of the form so we can return the form to this position if PersistPrompt is enabled
             Set-Variable -Name 'formWelcomeStartPosition' -Value $formWelcome.Location -Scope 'Script'
 
             ## Initialize the countdown timer


### PR DESCRIPTION
# Pull Request

## Description

Set WindowState = 'Normal' has been re-introduced in Show-InstallationPrompt and Show-WelcomePrompt. Without this, the dialogs would remain hidden if executing the toolkit from ConfigMgr executing Powershell.exe directly (and hidden).

Fixes #1004

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **develop** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

I tried running a deployment script via ConfigMgr, with this command set to run hidden:

`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -NoProfile -File Deploy-Application.ps1`

The deploy script contains:

```ps
Show-InstallationPrompt -Title "Installation of $appName, v$appVersion" -MessageAlignment Center -Message "Your device will be restarted upon completion. In case you are teleworking, please be advised that this operation will disconnect you from VPN immediately." -ButtonMiddleText "OK" -Icon Information -MinimizeWindows $true
```

The prompt would not display until this change had been made.