### PR TITLE
Fix Get-LoggedOnUser in Windows Sandbox

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -16027,7 +16027,8 @@ https://psappdeploytoolkit.com
     Process {
         Try {
             Write-Log -Message 'Getting session information for all logged on users.' -Source ${CmdletName}
-            Write-Output -InputObject ([PSADT.QueryUser]::GetUserSessionInfo("$env:ComputerName"))
+            ## Changed from $env:ComputerName to [System.Net.Dns]::GetHostName(), as environment variable contains a truncated name which breaks operation in Windows Sandbox
+            Write-Output -InputObject ([PSADT.QueryUser]::GetUserSessionInfo([System.Net.Dns]::GetHostName()))
         }
         Catch {
             Write-Log -Message "Failed to get session information for all logged on users. `r`n$(Resolve-Error)" -Severity 3 -Source ${CmdletName}


### PR DESCRIPTION
# Pull Request

## Description

The following line fails in Windows Sandbox due to the computer name being a GUID, and $env:ComputerName containing a truncated form of the full name:

```powershell
[PSADT.QueryUser]::GetUserSessionInfo("$env:ComputerName")
```

Replaced with:

```powershell
[PSADT.QueryUser]::GetUserSessionInfo([System.Net.Dns]::GetHostName())
```

Fixes: #947

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **develop** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Tested that Get-LoggedOnUser as well as a generic Deploy-Application.ps1 script executes successfully in  regular VM as well as Windows Sandbox.