### PR TITLE
Allow service functions to work in Windows Sandbox

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1324,7 +1324,7 @@ https://psappdeploytoolkit.com
                     }
 
                     # Get all log files (including any .lo_ files that may have been created by previous toolkit versions) sorted by last write time
-                    $LogFiles = @(Get-ChildItem -LiteralPath $LogFileDirectory -Filter ("{0}_*{1}" -f $LogFileNameWithoutExtension, $LogFileExtension)) + @(Get-Item -LiteralPath ([IO.Path]::ChangeExtension($LogFilePath, 'lo_')) -ErrorAction Ignore) | Sort-Object LastWriteTime
+                    $LogFiles = @(Get-ChildItem -LiteralPath $LogFileDirectory -Filter ("{0}_*{1}" -f $LogFileNameWithoutExtension, $LogFileExtension)) + @(Get-Item -LiteralPath ([IO.Path]::ChangeExtension($LogFilePath, 'lo_')) -ErrorAction SilentlyContinue) | Sort-Object LastWriteTime
 
                     # Keep only the max number of log files
                     if ($LogFiles.Count -gt $MaxLogHistory) {
@@ -3142,7 +3142,7 @@ https://psappdeploytoolkit.com
                 ForEach ($UninstallKeyApp in $UninstallKeyApps) {
                     Try {
                         [PSObject]$regKeyApplicationProps = Get-ItemProperty -LiteralPath $UninstallKeyApp.PSPath -ErrorAction 'Stop'
-                        If ($regKeyApplicationProps | Select-Object -ExpandProperty DisplayName -ErrorAction Ignore) {
+                        If ($regKeyApplicationProps | Select-Object -ExpandProperty DisplayName -ErrorAction SilentlyContinue) {
                             $regKeyApplicationProps
                         }
                     }
@@ -15371,7 +15371,7 @@ https://psappdeploytoolkit.com
             }
             else {
                 # Known issue that WMI method fails in Sandbox, so only use it if -PassThru requested
-                $ServiceObject = (Get-Service -ComputerName $ComputerName -Name $Name -ErrorAction Ignore).Count -gt 0
+                $ServiceObject = (Get-Service -ComputerName $ComputerName -Name $Name -ErrorAction SilentlyContinue).Count -gt 0
             }
 
             If ($ServiceObject) {

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -15348,7 +15348,7 @@ https://psappdeploytoolkit.com
         [String]$Name,
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
-        [String]$ComputerName = $env:ComputerName,
+        [String]$ComputerName = 'localhost',
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [Switch]$PassThru,
@@ -15465,7 +15465,7 @@ https://psappdeploytoolkit.com
         [String]$Name,
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
-        [String]$ComputerName = $env:ComputerName,
+        [String]$ComputerName = 'localhost',
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [Switch]$SkipServiceExistsTest,
@@ -15634,7 +15634,7 @@ https://psappdeploytoolkit.com
         [String]$Name,
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
-        [String]$ComputerName = $env:ComputerName,
+        [String]$ComputerName = 'localhost',
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [Switch]$SkipServiceExistsTest,
@@ -15788,7 +15788,7 @@ https://psappdeploytoolkit.com
         [String]$Name,
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
-        [String]$ComputerName = $env:ComputerName,
+        [String]$ComputerName = 'localhost',
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [Boolean]$ContinueOnError = $true
@@ -15884,7 +15884,7 @@ https://psappdeploytoolkit.com
         [String]$Name,
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
-        [String]$ComputerName = $env:ComputerName, # Not used but kept for backwards compatibility
+        [String]$ComputerName = 'localhost', # Not used but kept for backwards compatibility
         [Parameter(Mandatory = $true)]
         [ValidateSet('Automatic', 'Automatic (Delayed Start)', 'Manual', 'Disabled', 'Boot', 'System')]
         [String]$StartMode,

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -15370,8 +15370,8 @@ https://psappdeploytoolkit.com
                 }
             }
             else {
-                # Known issue that WMI method fails in Sandbox, so only use it if -PassThru requested
-                $ServiceObject = (Get-Service -ComputerName $ComputerName -Name $Name -ErrorAction SilentlyContinue).Count -gt 0
+                # Known issue that WMI method fails in Sandbox, so only use it if -PassThru requested. !! is used to convert to boolean.
+                $ServiceObject = !!(Get-Service -ComputerName $ComputerName -Name $Name -ErrorAction SilentlyContinue)
             }
 
             If ($ServiceObject) {


### PR DESCRIPTION
# Pull Request

## Description

- Service functions now use Get-Service instead of WMI where possible. Only exception is Test-ServiceExists will still use WMI if -PassThru supplied, so that it can return output in the same format as previously, for backwards compatibility. Windows Sandbox does not have the required WMI classes for services available.

- Service functions use 'localhost' as default computer name instead of $env:ComputerName. In Windows Sandbox, this name is truncated and is not the same as the DNS hostname, so fails.

Fixes: #1031

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **develop** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Tested functions work as before in a regular VM and also Windows Sandbox.