### PR TITLE
Replace Select-Object -SkipLast with PowerShell 2 compatible equivalent

### DIFF
--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5333,9 +5333,8 @@ https://psappdeploytoolkit.com
                         $RobocopyArgs = "$RobocopyParams $RobocopyAdditionalParams `"$RobocopySource`" `"$RobocopyDestination`" `"$RobocopyFile`""
                         Write-Log -Message "Executing Robocopy command: $RobocopyCommand $RobocopyArgs" -Source ${CmdletName}
                         $RobocopyResult = Execute-Process -Path $RobocopyCommand -Parameters $RobocopyArgs -CreateNoWindow -ContinueOnError $true -ExitOnProcessFailure $false -Passthru -IgnoreExitCodes '0,1,2,3,4,5,6,7,8'
-                        # Trim the leading whitespace from each line of Robocopy output, ignore the last empty line, and join the lines back together
-                        $RobocopyOutput = $RobocopyResult.StdOut.Split("`n").TrimStart()
-                        $RobocopyOutput = $RobocopyOutput[0..($RobocopyOutput.Count - 2)] -join "`n"
+                        # Trim the last line plus leading whitespace from each line of Robocopy output
+                        $RobocopyOutput = $RobocopyResult.StdOut.Trim() -Replace '\n\s+',"`n"
                         Write-Log -Message "Robocopy output:`n$RobocopyOutput" -Source ${CmdletName}
 
                         Set-ItemProperty -LiteralPath $RobocopyDestination -Name Attributes -Value ($DestFolderAttributes -band (-bnot [System.IO.FileAttributes]::Directory))

--- a/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/Toolkit/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -5334,7 +5334,8 @@ https://psappdeploytoolkit.com
                         Write-Log -Message "Executing Robocopy command: $RobocopyCommand $RobocopyArgs" -Source ${CmdletName}
                         $RobocopyResult = Execute-Process -Path $RobocopyCommand -Parameters $RobocopyArgs -CreateNoWindow -ContinueOnError $true -ExitOnProcessFailure $false -Passthru -IgnoreExitCodes '0,1,2,3,4,5,6,7,8'
                         # Trim the leading whitespace from each line of Robocopy output, ignore the last empty line, and join the lines back together
-                        $RobocopyOutput = ($RobocopyResult.StdOut.Split("`n").TrimStart() | Select-Object -SkipLast 1) -join "`n"
+                        $RobocopyOutput = $RobocopyResult.StdOut.Split("`n").TrimStart()
+                        $RobocopyOutput = $RobocopyOutput[0..($RobocopyOutput.Count - 2)] -join "`n"
                         Write-Log -Message "Robocopy output:`n$RobocopyOutput" -Source ${CmdletName}
 
                         Set-ItemProperty -LiteralPath $RobocopyDestination -Name Attributes -Value ($DestFolderAttributes -band (-bnot [System.IO.FileAttributes]::Directory))


### PR DESCRIPTION
# Pull Request

## Description

Update `Copy-File` function to use a PowerShell 2 compatible alternative to `Select-Object -SkipLast 1` 

The `-SkipLast` parameter was added to `Select-Object` in PowerShell 5
https://learn.microsoft.com/en-us/previous-versions/powershell/module/microsoft.powershell.utility/select-object?view=powershell-4.0

https://learn.microsoft.com/en-us/previous-versions/powershell/module/microsoft.powershell.utility/select-object?view=powershell-5.0


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [X] I am pulling to the **develop** branch
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have tested my changes to prove my fix is effective
- [X] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Dot-sourced AppDeployToolkitMain.ps1 and used `Copy-File` to copy a folder from one location to another.
