### PR TITLE
Allow PSAppDeployToolkit v4.0 config options to be specified via the registry as administrative overrides

### DIFF
--- a/src/PSAppDeployToolkit/Config/config.psd1
+++ b/src/PSAppDeployToolkit/Config/config.psd1
@@ -37,7 +37,7 @@
         # Specify if the log files should be bundled together in a compressed zip file.
         CompressLogs = $false
 
-        # Choose from either 'Native' for native PowerShell file copy via Copy-Item, or 'Robocopy' to use robocopy.exe.
+        # Choose from either 'Native' for native PowerShell file copy via Copy-ADTItem, or 'Robocopy' to use robocopy.exe.
         FileCopyMode = 'Native'
 
         # Specify if an existing log file should be appended to.
@@ -77,7 +77,7 @@
         # Same as RegPath but used when RequireAdmin is False. Bear in mind that since this Registry Key should be writable without admin permission, regular users can modify it also.
         RegPathNoAdminRights = 'HKCU:\SOFTWARE'
 
-        # Specify if Administrator Rights are required. NB: Some functions won't work if this is set to false, such as deferral, blockexecution, file & registry RW access and potentially logging.
+        # Specify if Administrator Rights are required. Note: Some functions won't work if this is set to false, such as deferral, block execution, file & registry RW access and potentially logging.
         RequireAdmin = $true
 
         # Automatically changes DeployMode for session zero (SYSTEM) operations.
@@ -100,7 +100,7 @@
         # Choose from either 'Fluent' for contemporary dialogs, or 'Classic' for PSAppDeployToolkit 3.x WinForms dialogs.
         DialogStyle = 'Fluent'
 
-        # Exit code used when a UI prompt times out or the user opts to defer.
+        # Exit code used when a UI prompt times out.
         DefaultExitCode = 1618
 
         # Time in seconds after which the prompt should be repositioned centre screen when the -PersistPrompt parameter is used. Default is 60 seconds.

--- a/src/PSAppDeployToolkit/Private/Convert-RegistryKeyToHashtable.ps1
+++ b/src/PSAppDeployToolkit/Private/Convert-RegistryKeyToHashtable.ps1
@@ -1,0 +1,65 @@
+﻿#-----------------------------------------------------------------------------
+#
+# MARK: Convert-RegistryKeyToHashtable
+#
+#-----------------------------------------------------------------------------
+
+function Convert-RegistryKeyToHashtable
+{
+    begin
+    {
+        # Open collector to store all converted keys.
+        $data = @{}
+    }
+
+    process
+    {
+        # Process potential subkeys first.
+        $subdata = $_ | Get-ChildItem | & $MyInvocation.MyCommand
+
+        # Open a new subdata hashtable if we had no subkeys.
+        if ($null -eq $subdata)
+        {
+            $subdata = @{}
+        }
+
+        # Process this item and store its values.
+        $_ | Get-ItemProperty | & {
+            process
+            {
+                $_.PSObject.Properties | & {
+                    process
+                    {
+                        if (($_.Name -notmatch '^PS((Parent)?Path|ChildName|Provider)$') -and ![System.String]::IsNullOrWhiteSpace((Out-String -InputObject $_.Value)))
+                        {
+                            # Handle bools as string values.
+                            if ($_.Value -match '^(True|False)$')
+                            {
+                                $subdata.Add($_.Name, [System.Boolean]::Parse($_.Value))
+                            }
+                            else
+                            {
+                                $subdata.Add($_.Name, $_.Value)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        # Add the subdata to the sections if it's got a count.
+        if ($subdata.Count)
+        {
+            $data.Add($_.PSPath -replace '^.+\\', $subdata)
+        }
+    }
+
+    end
+    {
+        # If there's something in the collector, return it.
+        if ($data.Count)
+        {
+            return $data
+        }
+    }
+}

--- a/src/PSAppDeployToolkit/Private/Import-ADTModuleDataFile.ps1
+++ b/src/PSAppDeployToolkit/Private/Import-ADTModuleDataFile.ps1
@@ -103,7 +103,7 @@ function Import-ADTModuleDataFile
     }
 
     # Super-impose registry values if they exist.
-    if (!$NoAdmxParsing -and ($admxSettings = Get-ChildItem -LiteralPath "Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SOFTWARE\PSAppDeployToolkit\$([System.IO.Path]::GetFileNameWithoutExtension($FileName))" -ErrorAction Ignore | Convert-RegistryKeyToHashtable))
+    if (!$NoAdmxParsing -and ($admxSettings = Get-ChildItem -LiteralPath "Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\PSAppDeployToolkit\$([System.IO.Path]::GetFileNameWithoutExtension($FileName))" -ErrorAction Ignore | Convert-RegistryKeyToHashtable))
     {
         Update-ImportedDataValues -DataFile $importedData -NewData $admxSettings
     }

--- a/src/PSAppDeployToolkit/Private/Import-ADTModuleDataFile.ps1
+++ b/src/PSAppDeployToolkit/Private/Import-ADTModuleDataFile.ps1
@@ -33,7 +33,7 @@ function Import-ADTModuleDataFile
         [System.String]$UICulture,
 
         [Parameter(Mandatory = $false)]
-        [System.Management.Automation.SwitchParameter]$NoAdmxParsing
+        [System.Management.Automation.SwitchParameter]$IgnorePolicy
     )
 
     # Internal function to process the imported data.
@@ -72,7 +72,7 @@ function Import-ADTModuleDataFile
     }
 
     # Remove parameters not compatible with Import-LocalizedData from $PSBoundParameters.
-    $null = $PSBoundParameters.Remove('NoAdmxParsing')
+    $null = $PSBoundParameters.Remove('IgnorePolicy')
 
     # Establish directory paths for the specified input.
     $moduleDirectory = $Script:ADT.Directories.Defaults.([regex]::Replace($BaseDirectory, '^.+\\', [System.String]::Empty))
@@ -103,7 +103,7 @@ function Import-ADTModuleDataFile
     }
 
     # Super-impose registry values if they exist.
-    if (!$NoAdmxParsing -and ($admxSettings = Get-ChildItem -LiteralPath "Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\PSAppDeployToolkit\$([System.IO.Path]::GetFileNameWithoutExtension($FileName))" -ErrorAction Ignore | Convert-RegistryKeyToHashtable))
+    if (!$IgnorePolicy -and ($admxSettings = Get-ChildItem -LiteralPath "Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\PSAppDeployToolkit\$([System.IO.Path]::GetFileNameWithoutExtension($FileName))" -ErrorAction Ignore | Convert-RegistryKeyToHashtable))
     {
         Update-ImportedDataValues -DataFile $importedData -NewData $admxSettings
     }

--- a/src/PSAppDeployToolkit/Private/Import-ADTModuleDataFile.ps1
+++ b/src/PSAppDeployToolkit/Private/Import-ADTModuleDataFile.ps1
@@ -103,9 +103,9 @@ function Import-ADTModuleDataFile
     }
 
     # Super-impose registry values if they exist.
-    if (!$IgnorePolicy -and ($admxSettings = Get-ChildItem -LiteralPath "Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\PSAppDeployToolkit\$([System.IO.Path]::GetFileNameWithoutExtension($FileName))" -ErrorAction Ignore | Convert-RegistryKeyToHashtable))
+    if (!$IgnorePolicy -and ($policySettings = Get-ChildItem -LiteralPath "Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\PSAppDeployToolkit\$([System.IO.Path]::GetFileNameWithoutExtension($FileName))" -ErrorAction Ignore | Convert-RegistryKeyToHashtable))
     {
-        Update-ImportedDataValues -DataFile $importedData -NewData $admxSettings
+        Update-ImportedDataValues -DataFile $importedData -NewData $policySettings
     }
 
     # Return the built out data to the caller.

--- a/src/PSAppDeployToolkit/Public/Initialize-ADTModule.ps1
+++ b/src/PSAppDeployToolkit/Public/Initialize-ADTModule.ps1
@@ -121,7 +121,7 @@ function Initialize-ADTModule
                 $Script:ADT.Environment = New-ADTEnvironmentTable
                 $Script:ADT.Config = Import-ADTConfig -BaseDirectory $Script:ADT.Directories.Config
                 $Script:ADT.Language = Get-ADTStringLanguage
-                $Script:ADT.Strings = Import-ADTModuleDataFile -BaseDirectory $Script:ADT.Directories.Strings -FileName strings.psd1 -UICulture $Script:ADT.Language -NoAdmxParsing
+                $Script:ADT.Strings = Import-ADTModuleDataFile -BaseDirectory $Script:ADT.Directories.Strings -FileName strings.psd1 -UICulture $Script:ADT.Language -IgnorePolicy
                 $Script:ADT.TerminalServerMode = $false
                 $Script:ADT.LastExitCode = 0
 

--- a/src/PSAppDeployToolkit/Public/Initialize-ADTModule.ps1
+++ b/src/PSAppDeployToolkit/Public/Initialize-ADTModule.ps1
@@ -121,7 +121,7 @@ function Initialize-ADTModule
                 $Script:ADT.Environment = New-ADTEnvironmentTable
                 $Script:ADT.Config = Import-ADTConfig -BaseDirectory $Script:ADT.Directories.Config
                 $Script:ADT.Language = Get-ADTStringLanguage
-                $Script:ADT.Strings = Import-ADTModuleDataFile -BaseDirectory $Script:ADT.Directories.Strings -FileName strings.psd1 -UICulture $Script:ADT.Language
+                $Script:ADT.Strings = Import-ADTModuleDataFile -BaseDirectory $Script:ADT.Directories.Strings -FileName strings.psd1 -UICulture $Script:ADT.Language -NoAdmxParsing
                 $Script:ADT.TerminalServerMode = $false
                 $Script:ADT.LastExitCode = 0
 


### PR DESCRIPTION
# Pull Request

## Description

In support of https://github.com/PSAppDeployToolkit/PSAppDeployToolkit4-devel/issues/55, configuration parsing now works in the following fashion:

* Module's default config is imported.
* Caller's config adjacent to their `Invoke-AppDeployToolkit.ps1` script is superimposed over the top.
* Now, registry values defined via Intune or Group Policy are superimposed over the top of those.

This will facilitate mass deployment changes such as dialog styles, etc, without necessarily having to repackage all applications.

Fixes: https://github.com/PSAppDeployToolkit/PSAppDeployToolkit4-devel/issues/55

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **develop** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

This has been tested with the relevant registry settings defined in HKEY_LOCAL_MACHINE\SOFTWARE\PSAppDeployToolkit\Config and works as expected.

![image](https://github.com/user-attachments/assets/156b8172-0457-4723-879c-b4dc32b18414)

Supporting ADMX files should be created to support the administrator and allow for natural management without resorting to scripts, etc.