### PR TITLE
Add AI translations via DeepL for all missing language strings.

### DIFF
--- a/src/PSAppDeployToolkit/Strings/ar/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/ar/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "جاري التثبيت. يرجى الانتظار..."
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "سيتم إغلاق هذه النافذة تلقائياً عند اكتمال التثبيت."
         MessageRepair = "جارٍ إصلاح. يرجى الانتظار..."
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "سيتم إغلاق هذه النافذة تلقائياً عند اكتمال الإصلاح."
         MessageUninstall = "جارٍ إزالة التثبيت. يرجى الانتظار..."
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "سيتم إغلاق هذه النافذة تلقائياً عند اكتمال إلغاء التثبيت."
     }
     RestartPrompt = @{
         ButtonRestartLater = "تقليل"
@@ -50,7 +50,18 @@
         Title = "مطلوب إعادة التشغيل"
     }
     WelcomePrompt = @{
-        CountdownMessage = "سيستمر {0} تلقائيا في:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "سيستمر {0} تلقائيا في:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployDeployToolkit - التطبيق {0}'
+            DialogMessage = 'يرجى حفظ عملك قبل المتابعة حيث سيتم إغلاق التطبيقات التالية تلقائيًا.'
+            DialogMessageNoProcesses = 'الرجاء تحديد تثبيت لمتابعة التثبيت. إذا كان لديك أي تأجيلات متبقية، يمكنك أيضاً اختيار تأخير التثبيت.'
+            ButtonDeferRemaining = 'تبقى'
+            ButtonLeftText = 'التأجيل'
+            ButtonRightText = 'إغلاق التطبيقات وتثبيتها'
+            ButtonRightTextNoProcesses = 'التثبيت'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/cz/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/cz/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "Instalace právě probíhá. Prosím čekejte..."
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "Toto okno se po dokončení instalace automaticky zavře."
         MessageRepair = "Oprava právě probíhá. Prosím čekejte..."
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "Toto okno se po dokončení opravy automaticky zavře."
         MessageUninstall = "Probíhá odinstalace. Prosím čekejte..."
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "Po dokončení odinstalace se toto okno automaticky zavře."
     }
     RestartPrompt = @{
         ButtonRestartLater = "Minimalizovat"
@@ -50,7 +50,18 @@
         Title = "Je nutné restartovat počítač."
     }
     WelcomePrompt = @{
-        CountdownMessage = "{0} bude automaticky pokračovat za:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "{0} bude automaticky pokračovat za:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - Aplikace {0}'
+            DialogMessage = 'Před pokračováním v práci ji uložte, protože následující aplikace budou automaticky uzavřeny.'
+            DialogMessageNoProcesses = 'Chcete-li pokračovat v instalaci, vyberte možnost Instalovat. Pokud vám zbývají nějaké odklady, můžete také zvolit odložení instalace.'
+            ButtonDeferRemaining = 'zůstat'
+            ButtonLeftText = 'Odložení'
+            ButtonRightText = 'Zavření aplikací a instalace'
+            ButtonRightTextNoProcesses = 'Instalace'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/da/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/da/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "Installation i gang. Vent venligst..."
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "Dette vindue lukker automatisk, når installationen er færdig."
         MessageRepair = "Reparere i gang. Vent venligst..."
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "Dette vindue lukkes automatisk, når reparationen er færdig."
         MessageUninstall = "Afinstallation i gang. Vent venligst..."
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "Dette vindue lukkes automatisk, når afinstallationen er færdig."
     }
     RestartPrompt = @{
         ButtonRestartLater = "Minimere"
@@ -50,7 +50,18 @@
         Title = "Genstart Nødvendig"
     }
     WelcomePrompt = @{
-        CountdownMessage = "{0} vil automatisk fortsætte i:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "{0} vil automatisk fortsætte i:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - App {0}'
+            DialogMessage = 'Gem venligst dit arbejde, før du fortsætter, da de følgende applikationer lukkes automatisk.'
+            DialogMessageNoProcesses = 'Vælg Installer for at fortsætte med installationen. Hvis du har udsættelser tilbage, kan du også vælge at udskyde installationen.'
+            ButtonDeferRemaining = 'forblive'
+            ButtonLeftText = 'Udskyde'
+            ButtonRightText = 'Luk apps og installer'
+            ButtonRightTextNoProcesses = 'Installer'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/de/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/de/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "Installation wird durchgeführt. Bitte warten..."
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "Dieses Fenster wird automatisch geschlossen, wenn die Installation abgeschlossen ist."
         MessageRepair = "Reparatur wird durchgeführt. Bitte warten..."
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "Dieses Fenster wird automatisch geschlossen, wenn die Reparatur abgeschlossen ist."
         MessageUninstall = "Deinstallation wird durchgeführt. Bitte warten..."
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "Dieses Fenster wird automatisch geschlossen, wenn die Deinstallation abgeschlossen ist."
     }
     RestartPrompt = @{
         ButtonRestartLater = "Minimieren"
@@ -50,7 +50,18 @@
         Title = "Neustart Erforderlich"
     }
     WelcomePrompt = @{
-        CountdownMessage = "Die {0} wird automatisch fortgesetzt in:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "Die {0} wird automatisch fortgesetzt in:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - Anwendung {0}'
+            DialogMessage = 'Bitte speichern Sie Ihre Arbeit, bevor Sie fortfahren, da die folgenden Anwendungen automatisch geschlossen werden.'
+            DialogMessageNoProcesses = 'Bitte wählen Sie Installieren, um mit der Installation fortzufahren. Wenn Sie noch Aufschübe haben, können Sie die Installation auch aufschieben.'
+            ButtonDeferRemaining = 'bleiben'
+            ButtonLeftText = 'Aufschieben'
+            ButtonRightText = 'Apps schließen & installieren'
+            ButtonRightTextNoProcesses = 'Installieren Sie'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/el/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/el/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "Εγκατάσταση σε εξέλιξη. Παρακαλούμε περιμένετε..."
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "Αυτό το παράθυρο θα κλείσει αυτόματα όταν ολοκληρωθεί η εγκατάσταση."
         MessageRepair = "Επιδιόρθωση σε εξέλιξη. Παρακαλούμε περιμένετε..."
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "Αυτό το παράθυρο θα κλείσει αυτόματα όταν ολοκληρωθεί η επισκευή."
         MessageUninstall = "Απεγκατάσταση σε εξέλιξη. Παρακαλούμε περιμένετε..."
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "Αυτό το παράθυρο θα κλείσει αυτόματα όταν ολοκληρωθεί η απεγκατάσταση."
     }
     RestartPrompt = @{
         ButtonRestartLater = "Ελαχιστοποίηση"
@@ -50,7 +50,18 @@
         Title = "Απαιτείται επανεκκίνηση"
     }
     WelcomePrompt = @{
-        CountdownMessage = "{0} θα συνεχίσει αυτόματα σε:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "{0} θα συνεχίσει αυτόματα σε:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - Εφαρμογή {0}'
+            DialogMessage = 'Αποθηκεύστε την εργασία σας πριν συνεχίσετε, καθώς οι ακόλουθες εφαρμογές θα κλείσουν αυτόματα.'
+            DialogMessageNoProcesses = 'Επιλέξτε Εγκατάσταση για να συνεχίσετε την εγκατάσταση. Εάν σας έχουν απομείνει αναβολές, μπορείτε επίσης να επιλέξετε να καθυστερήσετε την εγκατάσταση.'
+            ButtonDeferRemaining = 'παραμένουν'
+            ButtonLeftText = 'Αναβολή'
+            ButtonRightText = 'Κλείσιμο εφαρμογών & εγκατάσταση'
+            ButtonRightTextNoProcesses = 'Εγκαταστήστε το'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/es/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/es/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "Instalación en curso. Por favor, espere..."
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "Esta ventana se cerrará automáticamente cuando finalice la instalación."
         MessageRepair = "Reparación en curso. Por favor, espere..."
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "Esta ventana se cerrará automáticamente cuando finalice la reparación."
         MessageUninstall = "Desinstalación en curso. Por favor, espere..."
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "Esta ventana se cerrará automáticamente cuando finalice la desinstalación."
     }
     RestartPrompt = @{
         ButtonRestartLater = "Minimizar"
@@ -50,7 +50,18 @@
         Title = "Reinicio Requerido"
     }
     WelcomePrompt = @{
-        CountdownMessage = "La {0} continuará automáticamente en:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "La {0} continuará automáticamente en:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - Aplicación {0}'
+            DialogMessage = 'Guarde su trabajo antes de continuar, ya que las siguientes aplicaciones se cerrarán automáticamente.'
+            DialogMessageNoProcesses = 'Seleccione Instalar para continuar con la instalación. Si le queda algún aplazamiento, también puede optar por retrasar la instalación.'
+            ButtonDeferRemaining = 'permanezca en'
+            ButtonLeftText = 'Aplazar'
+            ButtonRightText = 'Cerrar aplicaciones e instalar'
+            ButtonRightTextNoProcesses = 'Instale'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/fi/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/fi/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "Asentaa. Odota..."
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "Tämä ikkuna sulkeutuu automaattisesti, kun asennus on valmis."
         MessageRepair = "Korjaus käynnissä. Odota..."
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "Tämä ikkuna sulkeutuu automaattisesti, kun korjaus on valmis."
         MessageUninstall = "Ohjelmistoa poistetaan. Odota..."
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "Tämä ikkuna sulkeutuu automaattisesti, kun asennuksen poisto on valmis."
     }
     RestartPrompt = @{
         ButtonRestartLater = "Käynnistä uudelleen myöhemmin"
@@ -50,7 +50,18 @@
         Title = "Tietokone on käynnistettävä uudelleen"
     }
     WelcomePrompt = @{
-        CountdownMessage = "{0} jatkaa automaattisesti:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "{0} jatkaa automaattisesti:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - Sovellus {0}'
+            DialogMessage = 'Tallenna työsi ennen kuin jatkat, sillä seuraavat sovellukset suljetaan automaattisesti.'
+            DialogMessageNoProcesses = 'Jatka asennusta valitsemalla Asenna. Jos sinulla on vielä lykkäyksiä jäljellä, voit myös lykätä asennusta.'
+            ButtonDeferRemaining = 'pysyä'
+            ButtonLeftText = 'Siirrä'
+            ButtonRightText = 'Sulje sovellukset & asenna'
+            ButtonRightTextNoProcesses = 'Asenna'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/fr/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/fr/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "Installation en cours, merci de patienter..."
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "Cette fenêtre se fermera automatiquement lorsque la désinstallation sera terminée."
         MessageRepair = "Réparation en cours, merci de patienter..."
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "Cette fenêtre se fermera automatiquement lorsque la réparation sera terminée."
         MessageUninstall = "Désinstallation en cours, merci de patienter..."
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "Cette fenêtre se fermera automatiquement lorsque la désinstallation sera terminée."
     }
     RestartPrompt = @{
         ButtonRestartLater = "Minimiser"
@@ -50,7 +50,18 @@
         Title = "Redémarrage Requis"
     }
     WelcomePrompt = @{
-        CountdownMessage = "L'{0} va continuer automatiquement:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "L'{0} va continuer automatiquement:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - App {0}'
+            DialogMessage = 'Veuillez sauvegarder votre travail avant de continuer, car les applications suivantes seront automatiquement fermées.'
+            DialogMessageNoProcesses = "Veuillez sélectionner Installer pour poursuivre l'installation. S'il vous reste des reports, vous pouvez également choisir de retarder l'installation."
+            ButtonDeferRemaining = 'rester'
+            ButtonLeftText = 'Report'
+            ButtonRightText = 'Fermer les applications et installer'
+            ButtonRightTextNoProcesses = 'Installer'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/he/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/he/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "מבצע התקנה. נא להמתין."
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "חלון זה ייסגר אוטומטית עם השלמת ההתקנה."
         MessageRepair = "מבצע תיקון. נא להמתין."
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "חלון זה ייסגר אוטומטית עם השלמת התיקון."
         MessageUninstall = "מבצע הסרה. נא להמתין."
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "חלון זה ייסגר אוטומטית עם השלמת הסרת ההתקנה."
     }
     RestartPrompt = @{
         ButtonRestartLater = "מזער את"
@@ -50,7 +50,18 @@
         Title = "נדרש אתחול המחשב"
     }
     WelcomePrompt = @{
-        CountdownMessage = "ה {0} ימשיך באופן אוטומטי:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "ה {0} ימשיך באופן אוטומטי:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - אפליקציה {0}'
+            DialogMessage = 'אנא שמור את עבודתך לפני שתמשיך שכן היישומים הבאים ייסגרו אוטומטית.'
+            DialogMessageNoProcesses = 'אנא בחר התקן כדי להמשיך בהתקנה. אם נותרו לך דחיות, תוכל גם לבחור לדחות את ההתקנה.'
+            ButtonDeferRemaining = 'לְהִשָׁאֵר'
+            ButtonLeftText = 'לִדחוֹת'
+            ButtonRightText = 'סגור אפליקציות והתקן'
+            ButtonRightTextNoProcesses = 'לְהַתְקִין'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/hu/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/hu/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "Telepítés folyamatban. Kérem várjon..."
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "Ez az ablak automatikusan bezáródik, amikor a telepítés befejeződik."
         MessageRepair = "Javítás folyamatban. Kérem várjon..."
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "Ez az ablak automatikusan bezáródik, ha a javítás befejeződött."
         MessageUninstall = "Eltávolítás folyamatban. Kérem várjon..."
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "Ez az ablak automatikusan bezáródik, amikor az eltávolítás befejeződik."
     }
     RestartPrompt = @{
         ButtonRestartLater = "Minimalizál"
@@ -50,7 +50,18 @@
         Title = "Újraindítás szükséges"
     }
     WelcomePrompt = @{
-        CountdownMessage = "A(z) {0} automatikusan folytatódik:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "A(z) {0} automatikusan folytatódik:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - Alkalmazás {0}'
+            DialogMessage = 'Kérjük, mentse el a munkáját, mielőtt folytatná, mivel a következő alkalmazások automatikusan lezárulnak.'
+            DialogMessageNoProcesses = 'Please select Install to continue with the installation. If you have any deferrals remaining, you may also choose to delay the installation.'
+            ButtonDeferRemaining = 'maradjon'
+            ButtonLeftText = 'Elhalasztás'
+            ButtonRightText = 'Alkalmazások bezárása és telepítése'
+            ButtonRightTextNoProcesses = 'Telepítse a'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/it/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/it/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "Installazione in corso. Attendere prego..."
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "Questa finestra si chiude automaticamente al termine dell'installazione."
         MessageRepair = "Riparazione in corso. Attendere prego..."
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "Questa finestra si chiuderà automaticamente al termine della riparazione."
         MessageUninstall = "Disinstallazione in corso. Attendere prego..."
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "Questa finestra si chiuderà automaticamente al termine della disinstallazione."
     }
     RestartPrompt = @{
         ButtonRestartLater = "Minimizzare"
@@ -50,7 +50,18 @@
         Title = "Riavvio Richiesto"
     }
     WelcomePrompt = @{
-        CountdownMessage = "Il {0} continuerà automaticamente in:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "Il {0} continuerà automaticamente in:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - App {0}'
+            DialogMessage = 'Salvate il vostro lavoro prima di continuare, perché le applicazioni seguenti verranno chiuse automaticamente.'
+            DialogMessageNoProcesses = "Selezionare Installa per continuare l'installazione. Se sono rimasti dei rinvii, si può anche scegliere di ritardare l'installazione."
+            ButtonDeferRemaining = 'rimanere'
+            ButtonLeftText = 'Rinviare'
+            ButtonRightText = 'Chiudere le applicazioni e installare'
+            ButtonRightTextNoProcesses = 'Installare'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/ja/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/ja/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "インストール中です。 少々お待ちください。"
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "インストールが完了すると、このウィンドウは自動的に閉じます。"
         MessageRepair = "修復中です。 少々お待ちください。"
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "修復が完了すると、このウィンドウは自動的に閉じます。"
         MessageUninstall = "アンインストール中です。 少々お待ちください。"
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "アンインストールが完了すると、このウィンドウは自動的に閉じます。"
     }
     RestartPrompt = @{
         ButtonRestartLater = "最小 化"
@@ -50,7 +50,18 @@
         Title = "再起動が必要です"
     }
     WelcomePrompt = @{
-        CountdownMessage = "{0} は自動的に続きます:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "{0} は自動的に続きます:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - アプリ {0}'
+            DialogMessage = '次のアプリケーションは自動的に終了しますので、作業を続ける前に保存してください。'
+            DialogMessageNoProcesses = 'インストールを選択してインストールを続行してください。延期分が残っている場合は、インストールを延期することもできます。'
+            ButtonDeferRemaining = '残る'
+            ButtonLeftText = '延期'
+            ButtonRightText = 'アプリを閉じる＆インストール'
+            ButtonRightTextNoProcesses = 'インストール'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/ko/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/ko/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "설치 중입니다. 기다리세요..."
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "이 창은 설치가 완료되면 자동으로 닫힙니다."
         MessageRepair = "수리 중입니다. 기다리세요..."
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "이 창은 수리가 완료되면 자동으로 닫힙니다."
         MessageUninstall = "제거 중입니다. 기다리세요..."
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "이 창은 제거가 완료되면 자동으로 닫힙니다."
     }
     RestartPrompt = @{
         ButtonRestartLater = "최소화"
@@ -50,7 +50,18 @@
         Title = "다시 시작해야 합니다"
     }
     WelcomePrompt = @{
-        CountdownMessage = "{0}는 자동으로 계속됩니다:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "{0}는 자동으로 계속됩니다:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - 앱 {0}'
+            DialogMessage = '다음 애플리케이션은 자동으로 종료되므로 계속하기 전에 작업을 저장해 주세요.'
+            DialogMessageNoProcesses = '설치를 계속하려면 설치를 선택하세요. 연기할 항목이 남아 있는 경우 설치를 연기하도록 선택할 수도 있습니다.'
+            ButtonDeferRemaining = '남아있음'
+            ButtonLeftText = '연기하다'
+            ButtonRightText = '앱 닫기 및 설치'
+            ButtonRightTextNoProcesses = '설치'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/nl/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/nl/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "Installatie bezig. Even geduld..."
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "Dette vinduet lukkes automatisk når installasjonen er fullført."
         MessageRepair = "Reparatie bezig. Even geduld..."
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "Dette vinduet lukkes automatisk når reparasjonen er fullført."
         MessageUninstall = "Verwijderen bezig. Even geduld..."
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "Dette vinduet lukkes automatisk når avinstallasjonen er fullført."
     }
     RestartPrompt = @{
         ButtonRestartLater = "Minimaliseren"
@@ -50,7 +50,18 @@
         Title = "Herstart nodig"
     }
     WelcomePrompt = @{
-        CountdownMessage = "De {0} gaat automatisch door over:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "De {0} gaat automatisch door over:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - App {0}'
+            DialogMessage = 'Lagre arbeidet ditt før du fortsetter, da de følgende programmene lukkes automatisk.'
+            DialogMessageNoProcesses = 'Velg Installer for å fortsette med installasjonen. Hvis du har noen utsettelser igjen, kan du også velge å utsette installasjonen.'
+            ButtonDeferRemaining = 'forbli'
+            ButtonLeftText = 'Utsette'
+            ButtonRightText = 'Lukk apper og installer'
+            ButtonRightTextNoProcesses = 'Installere'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/pl/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/pl/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "Trwa instalacja. Proszę czekać..."
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "Okno to zamknie się automatycznie po zakończeniu instalacji."
         MessageRepair = "Trwa naprawa. Proszę czekać..."
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "Okno to zamknie się automatycznie po zakończeniu naprawy."
         MessageUninstall = "Trwa deinstalacja. Proszę czekać..."
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "Okno to zamknie się automatycznie po zakończeniu dezinstalacji."
     }
     RestartPrompt = @{
         ButtonRestartLater = "Zminimalizować"
@@ -50,7 +50,18 @@
         Title = "Wymagany Restart"
     }
     WelcomePrompt = @{
-        CountdownMessage = "{0} będzie automatycznie kontynuować w:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "{0} będzie automatycznie kontynuować w:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - aplikacja {0}'
+            DialogMessage = 'Zapisz swoją pracę przed kontynuowaniem, ponieważ następujące aplikacje zostaną automatycznie zamknięte.'
+            DialogMessageNoProcesses = 'Wybierz opcję Zainstaluj, aby kontynuować instalację. Jeśli pozostały jakieś odroczenia, możesz również opóźnić instalację.'
+            ButtonDeferRemaining = 'pozostać'
+            ButtonLeftText = 'Odroczenie'
+            ButtonRightText = 'Zamknij aplikacje i zainstaluj'
+            ButtonRightTextNoProcesses = 'Instalacja'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/pt-br/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/pt-br/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "Instalação em andamento. Aguarde..."
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "Essa janela será fechada automaticamente quando a instalação for concluída."
         MessageRepair = "Reparação em andamento. Aguarde..."
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "Essa janela será fechada automaticamente quando o reparo for concluído."
         MessageUninstall = "Desinstalação em andamento. Aguarde..."
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "Essa janela será fechada automaticamente quando a desinstalação for concluída."
     }
     RestartPrompt = @{
         ButtonRestartLater = "Minimizar"
@@ -50,7 +50,18 @@
         Title = "Reinicialização Necessária"
     }
     WelcomePrompt = @{
-        CountdownMessage = "O {0} continuará automaticamente em:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "O {0} continuará automaticamente em:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - Aplicativo {0}'
+            DialogMessage = 'Salve seu trabalho antes de continuar, pois os aplicativos a seguir serão fechados automaticamente.'
+            DialogMessageNoProcesses = 'Selecione Install para continuar com a instalação. Se houver algum adiamento restante, você também poderá optar por adiar a instalação.'
+            ButtonDeferRemaining = 'permanecer'
+            ButtonLeftText = 'Adiar'
+            ButtonRightText = 'Fechar aplicativos e instalar'
+            ButtonRightTextNoProcesses = 'Instalar'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/pt/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/pt/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "Instalação em andamento. Por favor aguarde..."
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "Esta janela fechar-se-á automaticamente quando a instalação estiver concluída."
         MessageRepair = "Reparação em andamento. Por favor aguarde..."
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "Esta janela fechar-se-á automaticamente quando a reparação estiver concluída."
         MessageUninstall = "Desinstalação em andamento. Por favor aguarde..."
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "Esta janela fechar-se-á automaticamente quando a desinstalação estiver concluída."
     }
     RestartPrompt = @{
         ButtonRestartLater = "Minimizar"
@@ -50,7 +50,18 @@
         Title = "Reinicialização Necessária"
     }
     WelcomePrompt = @{
-        CountdownMessage = "O {0} continuará automaticamente em:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "O {0} continuará automaticamente em:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - Aplicação {0}'
+            DialogMessage = 'Guarde o seu trabalho antes de continuar, pois as aplicações seguintes serão encerradas automaticamente.'
+            DialogMessageNoProcesses = 'Selecione Instalar para continuar com a instalação. Se ainda tiver algum adiamento, também pode optar por adiar a instalação.'
+            ButtonDeferRemaining = 'permanecer'
+            ButtonLeftText = 'Adiar'
+            ButtonRightText = 'Fechar aplicações e instalar'
+            ButtonRightTextNoProcesses = 'Instalar'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/ru/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/ru/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "Идет установка. Пожалуйста, подождите..."
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "Это окно закроется автоматически после завершения установки."
         MessageRepair = "Идет исправление. Пожалуйста, подождите..."
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "Это окно автоматически закроется по завершении ремонта."
         MessageUninstall = "Идет удаление. Пожалуйста, подождите..."
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "Это окно закроется автоматически после завершения удаления."
     }
     RestartPrompt = @{
         ButtonRestartLater = "Минимизировать"
@@ -50,7 +50,18 @@
         Title = "Требуется перезагрузка"
     }
     WelcomePrompt = @{
-        CountdownMessage = "{0} автоматически продолжится через:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "{0} автоматически продолжится через:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - приложение {0}'
+            DialogMessage = 'Пожалуйста, сохраните свою работу, прежде чем продолжить, так как следующие приложения будут закрыты автоматически.'
+            DialogMessageNoProcesses = 'Чтобы продолжить установку, выберите Install (Установить). Если у вас остались отсрочки, вы также можете отложить установку.'
+            ButtonDeferRemaining = 'оставаться'
+            ButtonLeftText = 'Отложить'
+            ButtonRightText = 'Закрыть приложения и установить'
+            ButtonRightTextNoProcesses = 'Установите'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/sk/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/sk/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "Inštalácia sa vykonáva. Prosím čakajte..."
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "Toto okno sa po dokončení inštalácie automaticky zatvorí."
         MessageRepair = "Vykonáva sa oprava. Prosím čakajte..."
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "Toto okno sa po dokončení opravy automaticky zatvorí."
         MessageUninstall = "Prebieha odinštalácia. Prosím čakajte..."
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "Toto okno sa po dokončení odinštalovania automaticky zatvorí."
     }
     RestartPrompt = @{
         ButtonRestartLater = "Minimalizovať"
@@ -50,7 +50,18 @@
         Title = "Je nutný reštart."
     }
     WelcomePrompt = @{
-        CountdownMessage = "{0} bude automaticky pokračovať za:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "{0} bude automaticky pokračovať za:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - Aplikácia {0}'
+            DialogMessage = 'Pred pokračovaním uložte svoju prácu, pretože nasledujúce aplikácie sa automaticky zatvoria.'
+            DialogMessageNoProcesses = 'Ak chcete pokračovať v inštalácii, vyberte možnosť Inštalovať. Ak máte ešte nejaké odklady, môžete tiež zvoliť odloženie inštalácie.'
+            ButtonDeferRemaining = 'zostať'
+            ButtonLeftText = 'Odloženie'
+            ButtonRightText = 'Zatvoriť aplikácie a nainštalovať'
+            ButtonRightTextNoProcesses = 'Inštalácia stránky'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/sv/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/sv/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "Installation pågår. Var god vänta..."
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "Detta fönster stängs automatiskt när installationen är klar."
         MessageRepair = "Reparation pågår. Var god vänta..."
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "Detta fönster stängs automatiskt när reparationen är klar."
         MessageUninstall = "Avinstallation pågår. Var god vänta..."
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "Detta fönster stängs automatiskt när avinstallationen är klar."
     }
     RestartPrompt = @{
         ButtonRestartLater = "Minimera"
@@ -50,7 +50,18 @@
         Title = "Omstart Krävs"
     }
     WelcomePrompt = @{
-        CountdownMessage = "{0} kommer att fortsätta automatiskt i:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "{0} kommer att fortsätta automatiskt i:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - App {0}'
+            DialogMessage = 'Spara ditt arbete innan du fortsätter eftersom följande applikationer kommer att stängas automatiskt.'
+            DialogMessageNoProcesses = 'Välj Install för att fortsätta med installationen. Om du har några uppskjutna betalningar kvar kan du också välja att skjuta upp installationen.'
+            ButtonDeferRemaining = 'kvarstå'
+            ButtonLeftText = 'Skjut upp'
+            ButtonRightText = 'Stäng appar och installera'
+            ButtonRightTextNoProcesses = 'Installera'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/tr/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/tr/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "Kurulum devam ediyor. Lütfen bekleyiniz..."
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "Kurulum tamamlandığında bu pencere otomatik olarak kapanacaktır."
         MessageRepair = "Onarım devam ediyor. Lütfen bekleyiniz..."
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "Onarım tamamlandığında bu pencere otomatik olarak kapanacaktır."
         MessageUninstall = "Kaldırma işlemi devam ediyor. Lütfen bekleyiniz..."
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "Kaldırma işlemi tamamlandığında bu pencere otomatik olarak kapanacaktır."
     }
     RestartPrompt = @{
         ButtonRestartLater = "Simge durumuna küçült"
@@ -50,7 +50,18 @@
         Title = "Yeniden başlatma gerekmektedir"
     }
     WelcomePrompt = @{
-        CountdownMessage = "{0} otomatik olarak devam edecektir:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "{0} otomatik olarak devam edecektir:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - Uygulama {0}'
+            DialogMessage = 'Aşağıdaki uygulamalar otomatik olarak kapatılacağından devam etmeden önce lütfen çalışmanızı kaydedin.'
+            DialogMessageNoProcesses = "Kuruluma devam etmek için lütfen Yükle'yi seçin. Kalan ertelemeleriniz varsa, kurulumu ertelemeyi de seçebilirsiniz."
+            ButtonDeferRemaining = 'kalır'
+            ButtonLeftText = 'Erteleme'
+            ButtonRightText = 'Uygulamaları Kapat ve Yükle'
+            ButtonRightTextNoProcesses = 'Kurulum'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/zh-hans/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/zh-hans/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "安装中。请稍等。。。"
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "安装完成后，该窗口将自动关闭。。。"
         MessageRepair = "修复中。请稍等。。。"
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "修复完成后，该窗口将自动关闭。。。"
         MessageUninstall = "卸载中。请稍等。。。"
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "卸载完成后，该窗口将自动关闭。。。"
     }
     RestartPrompt = @{
         ButtonRestartLater = "最小化"
@@ -50,7 +50,18 @@
         Title = "需重启"
     }
     WelcomePrompt = @{
-        CountdownMessage = "{0}会自动继续:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "{0}会自动继续:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - 应用程序 {0}'
+            DialogMessage = '请保存您的工作后再继续，因为以下应用程序将自动关闭。'
+            DialogMessageNoProcesses = '请选择 “安装 ”继续安装。如果您还有任何延迟，也可以选择延迟安装。'
+            ButtonDeferRemaining = '残留'
+            ButtonLeftText = '推迟'
+            ButtonRightText = '关闭应用程序并安装'
+            ButtonRightTextNoProcesses = '安装'
+        }
     }
 }

--- a/src/PSAppDeployToolkit/Strings/zh-hant/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/zh-hant/strings.psd1
@@ -34,11 +34,11 @@
     }
     Progress = @{
         MessageInstall = "安裝中。請稍等。。。"
-        MessageInstallDetail = "This window will close automatically when the installation is complete."
+        MessageInstallDetail = "安裝完成後，此視窗會自動關閉。。。"
         MessageRepair = "修復中。請稍等。。。"
-        MessageRepairDetail = "This window will close automatically when the repair is complete."
+        MessageRepairDetail = "修復完成後，此視窗會自動關閉。。。"
         MessageUninstall = "卸載中。請稍等。。。"
-        MessageUninstallDetail = "This window will close automatically when the uninstallation is complete."
+        MessageUninstallDetail = "卸載完成後，此視窗將自動關閉。。。"
     }
     RestartPrompt = @{
         ButtonRestartLater = "最小化"
@@ -50,7 +50,18 @@
         Title = "需重啟"
     }
     WelcomePrompt = @{
-        CountdownMessage = "{0}會自動繼續:"
-        CustomMessage = ""
+        Classic = @{
+            CountdownMessage = "{0}會自動繼續:"
+            CustomMessage = ""
+        }
+        Fluent = @{
+            Subtitle = 'PSAppDeployToolkit - 應用程式 {0}'
+            DialogMessage = '由於下列應用程式將自動關閉，請先保存您的工作再繼續。'
+            DialogMessageNoProcesses = '請選擇「安裝」繼續安裝。如果您有任何延遲安裝的剩餘時間，您也可以選擇延遲安裝。'
+            ButtonDeferRemaining = '留下'
+            ButtonLeftText = '延遲'
+            ButtonRightText = '關閉應用程式並安裝'
+            ButtonRightTextNoProcesses = '安裝'
+        }
     }
 }


### PR DESCRIPTION
# Pull Request

## Description

We're currently missing all strings for fluent dialogs in all languages other than English. This adds DeepL translations for the missing langauges. Hebrew was performed via Google Translate as it's not a language DeepL offers translation for.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **develop** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
