### PR TITLE
Add the config/assets/strings folders into the scaffolded template output.

### DIFF
--- a/src/PSAppDeployToolkit/Public/New-ADTTemplate.ps1
+++ b/src/PSAppDeployToolkit/Public/New-ADTTemplate.ps1
@@ -137,6 +137,14 @@ function New-ADTTemplate
                 Copy-Item -LiteralPath "$ModulePath\Config" -Destination $templatePath -Recurse -Force
                 Copy-Item -LiteralPath "$ModulePath\Strings" -Destination $templatePath -Recurse -Force
 
+                # Make the shipped module and its files read-only.
+                $(Get-Item -LiteralPath $templateModulePath; Get-ChildItem -LiteralPath $templateModulePath -Recurse) | & {
+                    process
+                    {
+                        $_.Attributes = 'ReadOnly'
+                    }
+                }
+
                 # Process the generated script to ensure the Import-Module is correct.
                 if ($Version.Equals(4))
                 {

--- a/src/PSAppDeployToolkit/Public/New-ADTTemplate.ps1
+++ b/src/PSAppDeployToolkit/Public/New-ADTTemplate.ps1
@@ -110,10 +110,7 @@ function New-ADTTemplate
         {
             try
             {
-                if (![System.IO.Directory]::Exists($Destination))
-                {
-                    $null = New-Item -Path $Destination -ItemType Directory -Force
-                }
+                # Create directories.
                 if ([System.IO.Directory]::Exists($templatePath) -and [System.IO.Directory]::GetFileSystemEntries($templatePath))
                 {
                     if (!$Force)
@@ -129,24 +126,26 @@ function New-ADTTemplate
                     }
                     $null = Remove-Item -LiteralPath $templatePath -Recurse -Force
                 }
-
                 $null = New-Item -Path "$templatePath\Files" -ItemType Directory -Force
                 $null = New-Item -Path "$templatePath\SupportFiles" -ItemType Directory -Force
                 $null = New-Item -Path $templateModulePath -ItemType Directory -Force
+
+                # Copy in the module and the frontend files.
                 Copy-Item -Path "$ModulePath\*" -Destination $templateModulePath -Recurse -Force
                 Copy-Item -Path "$ModulePath\Frontend\v$Version\*" -Destination $templatePath -Recurse -Force
 
                 # Process the generated script to ensure the Import-Module is correct.
                 if ($Version.Equals(4))
                 {
-                    $scriptText = [System.IO.File]::ReadAllText(($scriptFile = "$templateModulePath\..\Invoke-AppDeployToolkit.ps1"))
+                    $scriptText = [System.IO.File]::ReadAllText(($scriptFile = "$templatePath\Invoke-AppDeployToolkit.ps1"))
                     $scriptText = $scriptText.Replace("`$PSScriptRoot\..\..\..\$moduleName", "`$PSScriptRoot\$moduleName")
                     [System.IO.File]::WriteAllText($scriptFile, $scriptText, [System.Text.UTF8Encoding]::new($true))
                 }
 
+                # Return a DirectoryInfo object if passing through.
                 if ($PassThru)
                 {
-                    Get-Item -LiteralPath $templatePath
+                    return (Get-Item -LiteralPath $templatePath)
                 }
             }
             catch

--- a/src/PSAppDeployToolkit/Public/New-ADTTemplate.ps1
+++ b/src/PSAppDeployToolkit/Public/New-ADTTemplate.ps1
@@ -130,9 +130,12 @@ function New-ADTTemplate
                 $null = New-Item -Path "$templatePath\SupportFiles" -ItemType Directory -Force
                 $null = New-Item -Path $templateModulePath -ItemType Directory -Force
 
-                # Copy in the module and the frontend files.
+                # Copy in the module, the frontend files, and the config/assets/strings.
                 Copy-Item -Path "$ModulePath\*" -Destination $templateModulePath -Recurse -Force
                 Copy-Item -Path "$ModulePath\Frontend\v$Version\*" -Destination $templatePath -Recurse -Force
+                Copy-Item -LiteralPath "$ModulePath\Assets" -Destination $templatePath -Recurse -Force
+                Copy-Item -LiteralPath "$ModulePath\Config" -Destination $templatePath -Recurse -Force
+                Copy-Item -LiteralPath "$ModulePath\Strings" -Destination $templatePath -Recurse -Force
 
                 # Process the generated script to ensure the Import-Module is correct.
                 if ($Version.Equals(4))


### PR DESCRIPTION
# Pull Request

## Description

Without shipping copies of these in the frontend, people are going to (and have been) modifying the module that's shipped with the template.

We also now make the module and its files read-only as an attempt to ward off people from modifying the files.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **develop** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Tested the template generation locally, all working well.

![image](https://github.com/user-attachments/assets/fa4e1713-2247-426b-b717-aeb9ce2a52fb)