### PR TITLE
Unofficial PSADT module cleanup

### DIFF
--- a/src/PSAppDeployToolkit/ImportsFirst.ps1
+++ b/src/PSAppDeployToolkit/ImportsFirst.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 
 .SYNOPSIS
 PSAppDeployToolkit - This module script contains the PSADT core runtime and functions using by a Invoke-AppDeployToolkit.ps1 script.
@@ -40,7 +40,6 @@ $RequiredModules = [System.Collections.ObjectModel.ReadOnlyCollection[Microsoft.
     @{ ModuleName = 'Microsoft.PowerShell.Security'; Guid = 'a94c8c7e-9810-47c0-b8af-65089c13a35a'; ModuleVersion = '1.0' }
     @{ ModuleName = 'Microsoft.PowerShell.Utility'; Guid = '1da87e53-152b-403e-98dc-74d7b4d63d59'; ModuleVersion = '1.0' }
     @{ ModuleName = 'NetAdapter'; Guid = '1042b422-63a8-4016-a6d6-293e19e8f8a6'; ModuleVersion = '1.0' }
-    @{ ModuleName = 'PowerShellGet'; Guid = '1d73a601-4a6c-43c5-ba3f-619b18bbb404'; ModuleVersion = '1.0' }
     @{ ModuleName = 'ScheduledTasks'; Guid = '5378ee8e-e349-49bb-83b9-f3d9c396c0a6'; ModuleVersion = '1.0' }
 )
 
@@ -55,17 +54,6 @@ $CommandTable = [ordered]@{}; $ExecutionContext.SessionState.InvokeCommand.GetCm
 
 # Ensure module operates under the strictest of conditions.
 & $CommandTable.'Set-StrictMode' -Version 3
-
-# Throw if any previous version of the unofficial PSADT module is found on the system.
-if (($conflicts = & $CommandTable.'Get-Module' -FullyQualifiedName @{ ModuleName = 'PSADT'; Guid = '41b2dd67-8447-4c66-b08a-f0bd0d5458b9'; ModuleVersion = '1.0' } -ListAvailable -Refresh))
-{
-    & $CommandTable.'Write-Error' -ErrorRecord ([System.Management.Automation.ErrorRecord]::new(
-            [System.NotSupportedException]::new("This module cannot be used while the PSADT module is installed. Please uninstall the PSADT module and try again."),
-            'ConflictingModulePresent',
-            [System.Management.Automation.ErrorCategory]::InvalidOperation,
-            $conflicts
-        ))
-}
 
 # Import this module's manifest via the language parser. This allows us to test with potential extra variables that are permitted in manifests.
 # https://github.com/PowerShell/PowerShell/blob/7ca7aae1d13d19e38c7c26260758f474cb9bef7f/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs#L509-L512

--- a/src/PSAppDeployToolkit/ImportsFirst.ps1
+++ b/src/PSAppDeployToolkit/ImportsFirst.ps1
@@ -40,7 +40,6 @@ $RequiredModules = [System.Collections.ObjectModel.ReadOnlyCollection[Microsoft.
     @{ ModuleName = 'Microsoft.PowerShell.Security'; Guid = 'a94c8c7e-9810-47c0-b8af-65089c13a35a'; ModuleVersion = '1.0' }
     @{ ModuleName = 'Microsoft.PowerShell.Utility'; Guid = '1da87e53-152b-403e-98dc-74d7b4d63d59'; ModuleVersion = '1.0' }
     @{ ModuleName = 'NetAdapter'; Guid = '1042b422-63a8-4016-a6d6-293e19e8f8a6'; ModuleVersion = '1.0' }
-    @{ ModuleName = 'PowerShellGet'; Guid = '1d73a601-4a6c-43c5-ba3f-619b18bbb404'; ModuleVersion = '1.0' }
     @{ ModuleName = 'ScheduledTasks'; Guid = '5378ee8e-e349-49bb-83b9-f3d9c396c0a6'; ModuleVersion = '1.0' }
 )
 

--- a/src/PSAppDeployToolkit/ImportsFirst.ps1
+++ b/src/PSAppDeployToolkit/ImportsFirst.ps1
@@ -57,7 +57,7 @@ $CommandTable = [ordered]@{}; $ExecutionContext.SessionState.InvokeCommand.GetCm
 
 # Throw if any previous version of the unofficial PSADT module is found on the system.
 if (& $CommandTable.'Get-Module' -FullyQualifiedName @{ ModuleName = 'PSADT'; Guid = '41b2dd67-8447-4c66-b08a-f0bd0d5458b9'; ModuleVersion = '1.0' } -ListAvailable -Refresh)
-# {
+{
     & $CommandTable.'Write-Warning' -Message "This module should not be used while the unofficial v3 PSADT module is installed."
 }
 

--- a/src/PSAppDeployToolkit/ImportsFirst.ps1
+++ b/src/PSAppDeployToolkit/ImportsFirst.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 
 .SYNOPSIS
 PSAppDeployToolkit - This module script contains the PSADT core runtime and functions using by a Invoke-AppDeployToolkit.ps1 script.
@@ -59,12 +59,7 @@ $CommandTable = [ordered]@{}; $ExecutionContext.SessionState.InvokeCommand.GetCm
 # Throw if any previous version of the unofficial PSADT module is found on the system.
 if (($conflicts = & $CommandTable.'Get-Module' -FullyQualifiedName @{ ModuleName = 'PSADT'; Guid = '41b2dd67-8447-4c66-b08a-f0bd0d5458b9'; ModuleVersion = '1.0' } -ListAvailable -Refresh))
 {
-    & $CommandTable.'Write-Error' -ErrorRecord ([System.Management.Automation.ErrorRecord]::new(
-            [System.NotSupportedException]::new("This module cannot be used while the PSADT module is installed. Please uninstall the PSADT module and try again."),
-            'ConflictingModulePresent',
-            [System.Management.Automation.ErrorCategory]::InvalidOperation,
-            $conflicts
-        ))
+    & $CommandTable.'Write-Warning' -Message "This module should not be used while the unofficial v3 PSADT module is installed."
 }
 
 # Import this module's manifest via the language parser. This allows us to test with potential extra variables that are permitted in manifests.

--- a/src/PSAppDeployToolkit/ImportsFirst.ps1
+++ b/src/PSAppDeployToolkit/ImportsFirst.ps1
@@ -56,8 +56,8 @@ $CommandTable = [ordered]@{}; $ExecutionContext.SessionState.InvokeCommand.GetCm
 & $CommandTable.'Set-StrictMode' -Version 3
 
 # Throw if any previous version of the unofficial PSADT module is found on the system.
-if (($conflicts = & $CommandTable.'Get-Module' -FullyQualifiedName @{ ModuleName = 'PSADT'; Guid = '41b2dd67-8447-4c66-b08a-f0bd0d5458b9'; ModuleVersion = '1.0' } -ListAvailable -Refresh))
-{
+if (& $CommandTable.'Get-Module' -FullyQualifiedName @{ ModuleName = 'PSADT'; Guid = '41b2dd67-8447-4c66-b08a-f0bd0d5458b9'; ModuleVersion = '1.0' } -ListAvailable -Refresh)
+# {
     & $CommandTable.'Write-Warning' -Message "This module should not be used while the unofficial v3 PSADT module is installed."
 }
 

--- a/src/PSAppDeployToolkit/ImportsFirst.ps1
+++ b/src/PSAppDeployToolkit/ImportsFirst.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 
 .SYNOPSIS
 PSAppDeployToolkit - This module script contains the PSADT core runtime and functions using by a Invoke-AppDeployToolkit.ps1 script.
@@ -40,6 +40,7 @@ $RequiredModules = [System.Collections.ObjectModel.ReadOnlyCollection[Microsoft.
     @{ ModuleName = 'Microsoft.PowerShell.Security'; Guid = 'a94c8c7e-9810-47c0-b8af-65089c13a35a'; ModuleVersion = '1.0' }
     @{ ModuleName = 'Microsoft.PowerShell.Utility'; Guid = '1da87e53-152b-403e-98dc-74d7b4d63d59'; ModuleVersion = '1.0' }
     @{ ModuleName = 'NetAdapter'; Guid = '1042b422-63a8-4016-a6d6-293e19e8f8a6'; ModuleVersion = '1.0' }
+    @{ ModuleName = 'PowerShellGet'; Guid = '1d73a601-4a6c-43c5-ba3f-619b18bbb404'; ModuleVersion = '1.0' }
     @{ ModuleName = 'ScheduledTasks'; Guid = '5378ee8e-e349-49bb-83b9-f3d9c396c0a6'; ModuleVersion = '1.0' }
 )
 
@@ -54,6 +55,17 @@ $CommandTable = [ordered]@{}; $ExecutionContext.SessionState.InvokeCommand.GetCm
 
 # Ensure module operates under the strictest of conditions.
 & $CommandTable.'Set-StrictMode' -Version 3
+
+# Throw if any previous version of the unofficial PSADT module is found on the system.
+if (($conflicts = & $CommandTable.'Get-Module' -FullyQualifiedName @{ ModuleName = 'PSADT'; Guid = '41b2dd67-8447-4c66-b08a-f0bd0d5458b9'; ModuleVersion = '1.0' } -ListAvailable -Refresh))
+{
+    & $CommandTable.'Write-Error' -ErrorRecord ([System.Management.Automation.ErrorRecord]::new(
+            [System.NotSupportedException]::new("This module cannot be used while the PSADT module is installed. Please uninstall the PSADT module and try again."),
+            'ConflictingModulePresent',
+            [System.Management.Automation.ErrorCategory]::InvalidOperation,
+            $conflicts
+        ))
+}
 
 # Import this module's manifest via the language parser. This allows us to test with potential extra variables that are permitted in manifests.
 # https://github.com/PowerShell/PowerShell/blob/7ca7aae1d13d19e38c7c26260758f474cb9bef7f/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs#L509-L512

--- a/src/PSAppDeployToolkit/ImportsFirst.ps1
+++ b/src/PSAppDeployToolkit/ImportsFirst.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 
 .SYNOPSIS
 PSAppDeployToolkit - This module script contains the PSADT core runtime and functions using by a Invoke-AppDeployToolkit.ps1 script.


### PR DESCRIPTION
# Pull Request

## Description

This PR adds the necessary logic to remove the unofficial PSADT module from systems where found, and handles situations whereby the caller may be in PowerShell 7 but the PSADT module was installed via Windows PowerShell 5.x, etc.

It should be noted that this PR does increase the module importation time, especially when the module _is_ present and requires removal. Typical import time for the module is ~3 seconds. Following this change, if PSADT isn't found, ~7 seconds. Following this change and PSADT is found, ~10 seconds.

The penalty of import duration is worth considering as the unofficial PSADT module has been a painful experience and often collides with users and their intention as they don't understand the clobbering aspect of having that module loaded/available while attempting to use PSADT 3.x independently of it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **develop** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

This has been tested on my device end to end in Windows PowerShell 5.x and PowerShell 7.