### PR TITLE
Partial re-write of `Start-ADTMsiProcess`.

### DIFF
--- a/src/PSAppDeployToolkit/Public/Start-ADTMsiProcess.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTMsiProcess.ps1
@@ -241,7 +241,7 @@ function Start-ADTMsiProcess
                 Write-ADTLogEntry -Message "Executing MSI action [$Action]..."
 
                 # If the MSI is in the Files directory, set the full path to the MSI.
-                $msiFile = if ($adtSession -and [System.IO.File]::Exists(($dirFilesPath = [System.IO.Path]::Combine($adtSession.DirFiles, $FilePath))))
+                $msiProduct = if ($adtSession -and [System.IO.File]::Exists(($dirFilesPath = [System.IO.Path]::Combine($adtSession.DirFiles, $FilePath))))
                 {
                     $dirFilesPath
                 }
@@ -279,9 +279,9 @@ function Start-ADTMsiProcess
                 {
                     $InstalledApplication.ProductCode
                 }
-                elseif ([System.IO.Path]::GetExtension($msiFile) -eq '.msi')
+                elseif ([System.IO.Path]::GetExtension($msiProduct) -eq '.msi')
                 {
-                    $GetMsiTablePropertySplat = @{ Path = $msiFile; Table = 'Property' }; if ($Transforms) { $GetMsiTablePropertySplat.Add('TransformPath', $transforms) }
+                    $GetMsiTablePropertySplat = @{ Path = $msiProduct; Table = 'Property' }; if ($Transforms) { $GetMsiTablePropertySplat.Add('TransformPath', $transforms) }
                     [System.Guid]::new((Get-ADTMsiTableProperty @GetMsiTablePropertySplat).ProductCode)
                 }
 
@@ -423,7 +423,7 @@ function Start-ADTMsiProcess
                 # Set the working directory of the MSI.
                 if ($PSCmdlet.ParameterSetName.Equals('FilePath') -and !$workingDirectory)
                 {
-                    $WorkingDirectory = [System.IO.Path]::GetDirectoryName($msiFile)
+                    $WorkingDirectory = [System.IO.Path]::GetDirectoryName($msiProduct)
                 }
 
                 # Enumerate all transforms specified, qualify the full path if possible and enclose in quotes.
@@ -432,7 +432,7 @@ function Start-ADTMsiProcess
                     # Fix up any bad file paths.
                     for ($i = 0; $i -lt $Transforms.Length; $i++)
                     {
-                        if (($FullPath = Join-Path -Path (Split-Path -Path $msiFile -Parent) -ChildPath $Transforms[$i].Replace('.\', '')) -and [System.IO.File]::Exists($FullPath))
+                        if (($FullPath = Join-Path -Path (Split-Path -Path $msiProduct -Parent) -ChildPath $Transforms[$i].Replace('.\', '')) -and [System.IO.File]::Exists($FullPath))
                         {
                             $Transforms[$i] = $FullPath
                         }
@@ -448,7 +448,7 @@ function Start-ADTMsiProcess
                     # Fix up any bad file paths.
                     for ($i = 0; $i -lt $patches.Length; $i++)
                     {
-                        if (($FullPath = Join-Path -Path (Split-Path -Path $msiFile -Parent) -ChildPath $patches[$i].Replace('.\', '')) -and [System.IO.File]::Exists($FullPath))
+                        if (($FullPath = Join-Path -Path (Split-Path -Path $msiProduct -Parent) -ChildPath $patches[$i].Replace('.\', '')) -and [System.IO.File]::Exists($FullPath))
                         {
                             $Patches[$i] = $FullPath
                         }
@@ -459,7 +459,7 @@ function Start-ADTMsiProcess
                 }
 
                 # Start building the MsiExec command line starting with the base action and file.
-                $argsMSI = "$option `"$msiFile`""
+                $argsMSI = "$option `"$msiProduct`""
 
                 # Add MST.
                 if ($mstFile)

--- a/src/PSAppDeployToolkit/Public/Start-ADTMsiProcess.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTMsiProcess.ps1
@@ -227,6 +227,18 @@ function Start-ADTMsiProcess
 
     begin
     {
+        # The use of a ProductCode with an Install action is not supported.
+        if ($ProductCode -and ($Action -eq 'Install'))
+        {
+            $naerParams = @{
+                Exception = [System.InvalidOperationException]::new("The ProductCode parameter can only be used with non-install actions.")
+                Category = [System.Management.Automation.ErrorCategory]::InvalidOperation
+                ErrorId = 'ProductCodeInstallActionNotSupported'
+                TargetObject = $PSBoundParameters
+                RecommendedAction = "Please review the supplied parameters and try again."
+            }
+            $PSCmdlet.ThrowTerminatingError((New-ADTErrorRecord @naerParams))
+        }
         $adtSession = Initialize-ADTModuleIfUnitialized -Cmdlet $PSCmdlet; $adtConfig = Get-ADTConfig
         Initialize-ADTFunction -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
     }

--- a/src/PSAppDeployToolkit/Public/Start-ADTMsiProcess.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTMsiProcess.ps1
@@ -270,6 +270,34 @@ function Start-ADTMsiProcess
                     throw (New-ADTErrorRecord @naerParams)
                 }
 
+                # Fix up any bad file paths.
+                if ([System.IO.Path]::GetExtension($msiProduct) -eq '.msi')
+                {
+                    # Iterate transforms.
+                    if ($Transforms)
+                    {
+                        for ($i = 0; $i -lt $Transforms.Length; $i++)
+                        {
+                            if ([System.IO.File]::Exists(($fullPath = Join-Path -Path (Split-Path -Path $msiProduct -Parent) -ChildPath $Transforms[$i].Replace('.\', ''))))
+                            {
+                                $Transforms[$i] = $fullPath
+                            }
+                        }
+                    }
+
+                    # Iterate patches.
+                    if ($Patches)
+                    {
+                        for ($i = 0; $i -lt $Patches.Length; $i++)
+                        {
+                            if ([System.IO.File]::Exists(($fullPath = Join-Path -Path (Split-Path -Path $msiProduct -Parent) -ChildPath $Patches[$i].Replace('.\', ''))))
+                            {
+                                $Patches[$i] = $fullPath
+                            }
+                        }
+                    }
+                }
+
                 # If the provided MSI was a file path, get the Property table and store it.
                 $msiPropertyTable = if ([System.IO.Path]::GetExtension($msiProduct) -eq '.msi')
                 {
@@ -416,32 +444,12 @@ function Start-ADTMsiProcess
                 # Enumerate all transforms specified, qualify the full path if possible and enclose in quotes.
                 $mstFile = if ($Transforms)
                 {
-                    # Fix up any bad file paths.
-                    for ($i = 0; $i -lt $Transforms.Length; $i++)
-                    {
-                        if (($FullPath = Join-Path -Path (Split-Path -Path $msiProduct -Parent) -ChildPath $Transforms[$i].Replace('.\', '')) -and [System.IO.File]::Exists($FullPath))
-                        {
-                            $Transforms[$i] = $FullPath
-                        }
-                    }
-
-                    # Echo an msiexec.exe compatible string back out with all transforms.
                     "`"$($Transforms -join ';')`""
                 }
 
                 # Enumerate all patches specified, qualify the full path if possible and enclose in quotes.
                 $mspFile = if ($Patches)
                 {
-                    # Fix up any bad file paths.
-                    for ($i = 0; $i -lt $patches.Length; $i++)
-                    {
-                        if (($FullPath = Join-Path -Path (Split-Path -Path $msiProduct -Parent) -ChildPath $patches[$i].Replace('.\', '')) -and [System.IO.File]::Exists($FullPath))
-                        {
-                            $Patches[$i] = $FullPath
-                        }
-                    }
-
-                    # Echo an msiexec.exe compatible string back out with all patches.
                     "`"$($Patches -join ';')`""
                 }
 

--- a/src/PSAppDeployToolkit/Public/Start-ADTMsiProcess.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTMsiProcess.ps1
@@ -281,15 +281,8 @@ function Start-ADTMsiProcess
                 }
                 elseif ([System.IO.Path]::GetExtension($msiFile) -eq '.msi')
                 {
-                    try
-                    {
-                        $GetMsiTablePropertySplat = @{ Path = $msiFile; Table = 'Property' }; if ($Transforms) { $GetMsiTablePropertySplat.Add('TransformPath', $transforms) }
-                        [System.Guid]::new((Get-ADTMsiTableProperty @GetMsiTablePropertySplat).ProductCode)
-                    }
-                    catch
-                    {
-                        Write-ADTLogEntry -Message "Failed to get the ProductCode from the MSI file. Continue with requested action [$Action]..."
-                    }
+                    $GetMsiTablePropertySplat = @{ Path = $msiFile; Table = 'Property' }; if ($Transforms) { $GetMsiTablePropertySplat.Add('TransformPath', $transforms) }
+                    [System.Guid]::new((Get-ADTMsiTableProperty @GetMsiTablePropertySplat).ProductCode)
                 }
 
                 # Check if the MSI is already installed. If no valid ProductCode to check or SkipMSIAlreadyInstalledCheck supplied, then continue with requested MSI action.

--- a/src/PSAppDeployToolkit/Public/Start-ADTMsiProcess.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTMsiProcess.ps1
@@ -286,7 +286,7 @@ function Start-ADTMsiProcess
                 }
 
                 # Check if the MSI is already installed. If no valid ProductCode to check or SkipMSIAlreadyInstalledCheck supplied, then continue with requested MSI action.
-                $IsMsiInstalled = if ($msiProductCode -and !$SkipMSIAlreadyInstalledCheck)
+                $msiInstalled = if ($msiProductCode -and !$SkipMSIAlreadyInstalledCheck)
                 {
                     if (!$InstalledApplication -and ($installedApps = Get-ADTApplication -FilterScript { $_.ProductCode -eq $msiProductCode } -IncludeUpdatesAndHotfixes:$IncludeUpdatesAndHotfixes))
                     {
@@ -506,12 +506,12 @@ function Start-ADTMsiProcess
                 }
 
                 # Bypass if we're installing and the MSI is already installed, otherwise proceed.
-                $ExecuteResults = if ($IsMsiInstalled -and ($Action -eq 'Install'))
+                $ExecuteResults = if ($msiInstalled -and ($Action -eq 'Install'))
                 {
                     Write-ADTLogEntry -Message "The MSI is already installed on this system. Skipping action [$Action]..."
                     [PSADT.Types.ProcessResult]::new(1638, $null, $null)
                 }
-                elseif ((!$IsMsiInstalled -and ($Action -eq 'Install')) -or $IsMsiInstalled)
+                elseif ((!$msiInstalled -and ($Action -eq 'Install')) -or $msiInstalled)
                 {
                     # Build the hashtable with the options that will be passed to Start-ADTProcess using splatting.
                     $ExecuteProcessSplat = @{

--- a/src/PSAppDeployToolkit/Public/Start-ADTMsiProcess.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTMsiProcess.ps1
@@ -271,7 +271,7 @@ function Start-ADTMsiProcess
                 }
 
                 # Get the ProductCode of the MSI.
-                $MSIProductCode = if ($ProductCode)
+                $msiProductCode = if ($ProductCode)
                 {
                     $ProductCode
                 }
@@ -286,9 +286,9 @@ function Start-ADTMsiProcess
                 }
 
                 # Check if the MSI is already installed. If no valid ProductCode to check or SkipMSIAlreadyInstalledCheck supplied, then continue with requested MSI action.
-                $IsMsiInstalled = if ($MSIProductCode -and !$SkipMSIAlreadyInstalledCheck)
+                $IsMsiInstalled = if ($msiProductCode -and !$SkipMSIAlreadyInstalledCheck)
                 {
-                    if (!$InstalledApplication -and ($installedApps = Get-ADTApplication -FilterScript { $_.ProductCode -eq $MSIProductCode } -IncludeUpdatesAndHotfixes:$IncludeUpdatesAndHotfixes))
+                    if (!$InstalledApplication -and ($installedApps = Get-ADTApplication -FilterScript { $_.ProductCode -eq $msiProductCode } -IncludeUpdatesAndHotfixes:$IncludeUpdatesAndHotfixes))
                     {
                         $InstalledApplication = $installedApps
                     }


### PR DESCRIPTION
* Return earlier when attempting to install an already-installed MSI, or performing any other action against a non-installed MSI.
* Ensure that ProductCode throws if used with an Install action.
* Improve setup for `$msiFile` (now renamed to `$msiProduct`).
* Rework log filename setup within function to better prevent null accesses. Fixes #1105n
* Rework log filename setup for consistency when deriving a filename from an InstalledApplication object vs an .msi FilePath.
* Rearrange where transformations and patches have their paths fully resolved since transforms are sent through to `Get-ADTMsiTableProperty`.
* Rename a few internal variables for clarity.