### PR TITLE
Add `-MaximumElapsedTime` parameter to `Invoke-ADTCommandWithRetries`

### DIFF
--- a/docs/Invoke-ADTCommandWithRetries.mdx
+++ b/docs/Invoke-ADTCommandWithRetries.mdx
@@ -28,7 +28,21 @@ This function invokes the specified cmdlet/function, accepting all of its parame
 Invoke-ADTCommandWithRetries -Command Invoke-WebRequest -Uri https://aka.ms/getwinget -OutFile "$($adtSession.DirSupportFiles)\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle"
 ```
 
-Downloads the latest WinGet installer to the SupportFiles directory.
+Downloads the latest WinGet installer to the SupportFiles directory. If the command fails, it will retry 3 times with 5 seconds between each attempt.
+
+### EXAMPLE 2
+```powershell
+Invoke-ADTCommandWithRetries -Command Get-FileHash -Path '\\MyShare\MyFile' -MaximumElapsedTime (New-TimeSpan -Seconds 90) -SleepSeconds 2
+```
+
+Gets the hash of a file on an SMB share. If the connection to the SMB share drops, it will retry the command every 2 seconds until it successfully gets the hash or 90 seconds have passed since the initial attempt.
+
+### EXAMPLE 3
+```powershell
+Invoke-ADTCommandWithRetries Copy-ADTFile -Path \\MyShare\MyFile -Destination C:\Windows\Temp -Retries 5 -MaximumElapsedTime (New-TimeSpan -Minutes 5)
+```
+
+Copies a file from an SMB share to C:\Windows\Temp. If the connection to the SMB share drops, it will retry the command once every 5 seconds until either 5 attempts have been made or 5 minutes have passed since the initial attempt.
 
 ## PARAMETERS
 
@@ -58,7 +72,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 2
+Position: Named
 Default value: 3
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -74,8 +88,23 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: Named
 Default value: 5
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaximumElapsedTime
+
+The maximum elapsed time allowed to passed while attempting retries. If the maximum elapsted time has passed and there are still attempts remaining they will be disgarded. If this parameter is supplied and the `-Retries` parameter isn't, this command will continue to retry the provided command until the time limit runs out.
+
+```yaml
+Type: TimeSpan
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -92,7 +121,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/src/PSAppDeployToolkit/Public/Invoke-ADTCommandWithRetries.ps1
+++ b/src/PSAppDeployToolkit/Public/Invoke-ADTCommandWithRetries.ps1
@@ -22,6 +22,11 @@ function Invoke-ADTCommandWithRetries
     .PARAMETER SleepSeconds
         How many seconds to sleep between retries.
 
+    .PARAMETER MaximumElapsedTime
+        The maximum elapsed time allowed to passed while attempting retries.
+        If the maximum elapsted time has passed and there are still attempts remaining they will be disgarded.
+        If this parameter is supplied and the `-Retries` parameter isn't, this command will continue to retry the provided command until the time limit runs out.
+
     .PARAMETER Parameters
         A 'ValueFromRemainingArguments' parameter to collect the parameters as would be passed to the provided Command.
 
@@ -40,7 +45,19 @@ function Invoke-ADTCommandWithRetries
     .EXAMPLE
         Invoke-ADTCommandWithRetries -Command Invoke-WebRequest -Uri https://aka.ms/getwinget -OutFile "$($adtSession.DirSupportFiles)\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle"
 
-        Downloads the latest WinGet installer to the SupportFiles directory.
+        Downloads the latest WinGet installer to the SupportFiles directory. If the command fails, it will retry 3 times with 5 seconds between each attempt.
+
+    .EXAMPLE
+        Invoke-ADTCommandWithRetries Get-FileHash -Path '\\MyShare\MyFile' -MaximumElapsedTime (New-TimeSpan -Seconds 90) -SleepSeconds 1
+
+        Gets the hash of a file on an SMB share.
+        If the connection to the SMB share drops, it will retry the command every 2 seconds until it successfully gets the hash or 90 seconds have passed since the initial attempt.
+
+    .EXAMPLE
+        Invoke-ADTCommandWithRetries Copy-ADTFile -Path \\MyShare\MyFile -Destination C:\Windows\Temp -Retries 5 -MaximumElapsedTime (New-TimeSpan -Minutes 5)
+
+        Copies a file from an SMB share to C:\Windows\Temp.
+        If the connection to the SMB share drops, it will retry the command once every 5 seconds until either 5 attempts have been made or 5 minutes have passed since the initial attempt.
 
     .NOTES
         An active ADT session is NOT required to use this function.
@@ -58,7 +75,7 @@ function Invoke-ADTCommandWithRetries
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, Position = 0)]
         [ValidateNotNullOrEmpty()]
         [System.Object]$Command,
 
@@ -69,6 +86,10 @@ function Invoke-ADTCommandWithRetries
         [Parameter(Mandatory = $false)]
         [ValidateRange(1, 60)]
         [System.UInt32]$SleepSeconds = 5,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateScript({ $_ -gt [System.TimeSpan]::New(0) })]
+        [System.TimeSpan]$MaximumElapsedTime,
 
         [Parameter(Mandatory = $false, ValueFromRemainingArguments = $true, DontShow = $true)]
         [ValidateNotNullOrEmpty()]
@@ -106,17 +127,35 @@ function Invoke-ADTCommandWithRetries
                 $callerName = (Get-PSCallStack)[1].Command
 
                 # Perform the request, and retry it as per the configured values.
-                for ($i = 0; $i -lt $Retries; $i++)
+                $i = 0
+                $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+                while ($true)
                 {
+                    $i++
                     try
                     {
                         return (& $commandObj @boundParams)
                     }
                     catch
                     {
+                        $errorRecord = $_
+                        if ($PSBoundParameters.ContainsKey('MaximumElapsedTime') -and ($stopwatch.ElapsedMilliseconds -ge $MaximumElapsedTime.TotalMilliseconds))
+                        {
+                            # Time limit has been reached
+                            break
+                        }
+                        elseif ($PSBoundParameters.ContainsKey('MaximumElapsedTime') -and (!$PSBoundParameters.ContainsKey('Retries')))
+                        {
+                            # Timelimit has not been reached and a maximum retry limit has not been supplied. Will continue to retry until timelimit has been reached.
+                        }
+                        elseif ($i -ge $Retries)
+                        {
+                            # Retry limit has been reached
+                            break
+                        }
+
                         Write-ADTLogEntry -Message "The invocation to '$($commandObj.Name)' failed with message: $($_.Exception.Message.TrimEnd('.')). Trying again in $SleepSeconds second$(if (!$SleepSeconds.Equals(1)) {'s'})." -Severity 2 -Source $callerName
                         [System.Threading.Thread]::Sleep($SleepSeconds * 1000)
-                        $errorRecord = $_
                     }
                 }
 


### PR DESCRIPTION
This parameter will allow you to retry a command until a given timespan has passed. If both a timespan and a retry limit have been provided it will continue until either one is met.