### PR TITLE
Add DeferRunInterval to Improve Intune Retry Handling and User Experience with Show-ADTInstallationWelcome Prompt

### DIFF
--- a/src/PSADT/PSADT/Module/PSADT.Module.Class.DeploymentSession.cs
+++ b/src/PSADT/PSADT/Module/PSADT.Module.Class.DeploymentSession.cs
@@ -1076,9 +1076,9 @@ namespace PSADT.Module
         /// </summary>
         /// <param name="deferDeadline">The deferral deadline.</param>
         /// <param name="deferTimesRemaining">The deferral times remaining.</param>
-        /// <param name="deferRunInterval">The interval in minutes before prompting the user again after a deferral.</param>
+        /// <param name="deferRunInterval">The interval as a TimeSpan before prompting the user again after a deferral.</param>
         /// <param name="deferRunIntervalLastTime">The timestamp of the last deferRunInterval.</param>
-        public void SetDeferHistory(int? deferTimesRemaining, string deferDeadline, int? deferRunInterval = null, string? deferRunIntervalLastTime = null)
+        public void SetDeferHistory(int? deferTimesRemaining, string deferDeadline, TimeSpan? deferRunInterval = null, string? deferRunIntervalLastTime = null)
         {
             // Get the module's session state before proceeding.
             var moduleSessionState = InternalDatabase.GetSessionState();

--- a/src/PSADT/PSADT/Module/PSADT.Module.Class.DeploymentSession.cs
+++ b/src/PSADT/PSADT/Module/PSADT.Module.Class.DeploymentSession.cs
@@ -1078,7 +1078,7 @@ namespace PSADT.Module
         /// <param name="deferTimesRemaining">The deferral times remaining.</param>
         /// <param name="deferRunInterval">The interval in minutes before prompting the user again after a deferral.</param>
         /// <param name="deferRunIntervalLastTime">The timestamp of the last deferRunInterval.</param>
-        public void SetDeferHistory(int? deferTimesRemaining, string deferDeadline, int? deferRunInterval = null, string deferRunIntervalLastTime = null)
+        public void SetDeferHistory(int? deferTimesRemaining, string deferDeadline, int? deferRunInterval = null, string? deferRunIntervalLastTime = null)
         {
             // Get the module's session state before proceeding.
             var moduleSessionState = InternalDatabase.GetSessionState();

--- a/src/PSADT/PSADT/Module/PSADT.Module.Class.DeploymentSession.cs
+++ b/src/PSADT/PSADT/Module/PSADT.Module.Class.DeploymentSession.cs
@@ -1076,7 +1076,9 @@ namespace PSADT.Module
         /// </summary>
         /// <param name="deferDeadline">The deferral deadline.</param>
         /// <param name="deferTimesRemaining">The deferral times remaining.</param>
-        public void SetDeferHistory(int? deferTimesRemaining, string deferDeadline)
+        /// <param name="deferRunInterval">The interval in minutes before prompting the user again after a deferral.</param>
+        /// <param name="deferRunIntervalLastTime">The timestamp of the last deferRunInterval.</param>
+        public void SetDeferHistory(int? deferTimesRemaining, string deferDeadline, int? deferRunInterval = null, string deferRunIntervalLastTime = null)
         {
             // Get the module's session state before proceeding.
             var moduleSessionState = InternalDatabase.GetSessionState();
@@ -1098,6 +1100,24 @@ namespace PSADT.Module
                     CreateDeferHistoryPath();
                 }
                 moduleSessionState.InvokeProvider.Property.New([RegKeyDeferHistory], "DeferDeadline", "String", deferDeadline, true, true);
+            }
+            if (null != deferRunInterval)
+            {
+                WriteLogEntry($"Setting deferral history: [DeferRunInterval = {deferRunInterval}].");
+                if (!TestDeferHistoryPath())
+                {
+                    CreateDeferHistoryPath();
+                }
+                moduleSessionState.InvokeProvider.Property.New([RegKeyDeferHistory], "DeferRunInterval", "String", deferRunInterval.ToString(), true, true);
+            }
+            if (!string.IsNullOrWhiteSpace(deferRunIntervalLastTime))
+            {
+                WriteLogEntry($"Setting deferral history: [DeferRunIntervalLastTime = {deferRunIntervalLastTime}].");
+                if (!TestDeferHistoryPath())
+                {
+                    CreateDeferHistoryPath();
+                }
+                moduleSessionState.InvokeProvider.Property.New([RegKeyDeferHistory], "DeferRunIntervalLastTime", "String", deferRunIntervalLastTime, true, true);
             }
         }
 

--- a/src/PSAppDeployToolkit/Public/Set-ADTDeferHistory.ps1
+++ b/src/PSAppDeployToolkit/Public/Set-ADTDeferHistory.ps1
@@ -70,7 +70,14 @@ function Set-ADTDeferHistory
 
     try
     {
-        (Get-ADTSession).SetDeferHistory($(if ($PSBoundParameters.ContainsKey('DeferTimesRemaining')) { $DeferTimesRemaining }), $DeferDeadline, $(if ($PSBoundParameters.ContainsKey('DeferRunInterval')) { $DeferRunInterval }), $(if ($PSBoundParameters.ContainsKey('DeferRunInterval')) { (Get-ADTUniversalDate) }))
+        if ($PSBoundParameters.ContainsKey('DeferRunInterval'))
+        {
+            (Get-ADTSession).SetDeferHistory($(if ($PSBoundParameters.ContainsKey('DeferTimesRemaining')) { $DeferTimesRemaining }), $DeferDeadline, $DeferRunInterval, (Get-ADTUniversalDate))
+        }
+        else
+        {
+            (Get-ADTSession).SetDeferHistory($(if ($PSBoundParameters.ContainsKey('DeferTimesRemaining')) { $DeferTimesRemaining }), $DeferDeadline, $null, $null)
+        }
     }
     catch
     {

--- a/src/PSAppDeployToolkit/Public/Set-ADTDeferHistory.ps1
+++ b/src/PSAppDeployToolkit/Public/Set-ADTDeferHistory.ps1
@@ -19,6 +19,13 @@ function Set-ADTDeferHistory
     .PARAMETER DeferDeadline
         Specify the deadline for the deferral.
 
+    .PARAMETER DeferRunInterval
+        Specifies the number of minutes that must elapse before prompting the user again if a process listed in 'CloseProcesses' is still running after a deferral.
+
+        This helps address the issue where Intune retries installations shortly after a user defers, preventing multiple immediate prompts and improving the user experience.
+
+        This parameter is specifically utilized within the `Show-ADTInstallationWelcome` function, and if specified, the current date and time will be used for the DeferRunIntervalLastTime.
+
     .INPUTS
         None
 
@@ -54,12 +61,16 @@ function Set-ADTDeferHistory
 
         [Parameter(Mandatory = $false)]
         [AllowEmptyString()]
-        [System.String]$DeferDeadline
+        [System.String]$DeferDeadline,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [System.UInt32]$DeferRunInterval
     )
 
     try
     {
-        (Get-ADTSession).SetDeferHistory($(if ($PSBoundParameters.ContainsKey('DeferTimesRemaining')) { $DeferTimesRemaining }), $DeferDeadline)
+        (Get-ADTSession).SetDeferHistory($(if ($PSBoundParameters.ContainsKey('DeferTimesRemaining')) { $DeferTimesRemaining }), $DeferDeadline, $(if ($PSBoundParameters.ContainsKey('DeferRunInterval')) { $DeferRunInterval }), $(if ($PSBoundParameters.ContainsKey('DeferRunInterval')) { (Get-ADTUniversalDate) }))
     }
     catch
     {

--- a/src/PSAppDeployToolkit/Public/Set-ADTDeferHistory.ps1
+++ b/src/PSAppDeployToolkit/Public/Set-ADTDeferHistory.ps1
@@ -20,7 +20,7 @@ function Set-ADTDeferHistory
         Specify the deadline for the deferral.
 
     .PARAMETER DeferRunInterval
-        Specifies the number of minutes that must elapse before prompting the user again if a process listed in 'CloseProcesses' is still running after a deferral.
+        Specifies the time span that must elapse before prompting the user again if a process listed in 'CloseProcesses' is still running after a deferral.
 
         This helps address the issue where Intune retries installations shortly after a user defers, preventing multiple immediate prompts and improving the user experience.
 
@@ -65,7 +65,7 @@ function Set-ADTDeferHistory
 
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
-        [System.UInt32]$DeferRunInterval
+        [System.TimeSpan]$DeferRunInterval
     )
 
     try

--- a/src/PSAppDeployToolkit/Public/Show-ADTInstallationWelcome.ps1
+++ b/src/PSAppDeployToolkit/Public/Show-ADTInstallationWelcome.ps1
@@ -486,7 +486,7 @@ function Show-ADTInstallationWelcome
                                     if (-not ([String]::IsNullOrEmpty($deferHistoryRunIntervalLastTime)))
                                     {
                                         $deferRunIntervalLastTime = Get-ADTUniversalDate -DateTime $deferHistoryRunIntervalLastTime
-                                        $deferRunIntervalNextTime = Get-ADTUniversalDate -DateTime ([System.DateTime]::Parse($deferRunIntervalLastTime).Add($DeferRunInterval).ToString([System.Globalization.DateTimeFormatInfo]::CurrentInfo.UniversalSortableDateTimePattern))
+                                        $deferRunIntervalNextTime = Get-ADTUniversalDate -DateTime ([System.DateTime]::Parse($deferRunIntervalLastTime).ToUniversalTime().Add($DeferRunInterval).ToString([System.Globalization.DateTimeFormatInfo]::CurrentInfo.UniversalSortableDateTimePattern))
                                         if ([System.DateTime]::Parse($deferRunIntervalNextTime) -gt [System.DateTime]::Parse((Get-ADTUniversalDate)))
                                         {
                                             Write-ADTLogEntry -Message "DeferRunInterval has not elapsed. Exiting gracefully."

--- a/src/PSAppDeployToolkit/Public/Show-ADTInstallationWelcome.ps1
+++ b/src/PSAppDeployToolkit/Public/Show-ADTInstallationWelcome.ps1
@@ -67,8 +67,8 @@ function Show-ADTInstallationWelcome
         This addresses the issue where Intune retries installations shortly after a user defers, preventing multiple immediate prompts and improving the user experience.
 
         Example:
-        - To specify 30 minutes, use: `[System.TimeSpan]::FromMinutes(30)`.
-        - To specify 24 hours, use: `[System.TimeSpan]::FromHours(24)`.
+        - To specify 30 minutes, use: `([System.TimeSpan]::FromMinutes(30))`.
+        - To specify 24 hours, use: `([System.TimeSpan]::FromHours(24))`.
 
     .PARAMETER CheckDiskSpace
         Specify whether to check if there is enough disk space for the installation to proceed.

--- a/src/PSAppDeployToolkit/Public/Show-ADTInstallationWelcome.ps1
+++ b/src/PSAppDeployToolkit/Public/Show-ADTInstallationWelcome.ps1
@@ -61,6 +61,11 @@ function Show-ADTInstallationWelcome
 
         The deadline date will be displayed to the user in the format of their culture.
 
+    .PARAMETER DeferRunInterval
+        Specifies the number of minutes that must elapse before prompting the user again if a process listed in 'CloseProcesses' is still running after a deferral.
+
+        This helps address the issue where Intune retries installations shortly after a user defers, preventing multiple immediate prompts and improving the user experience.
+
     .PARAMETER CheckDiskSpace
         Specify whether to check if there is enough disk space for the installation to proceed.
 
@@ -190,6 +195,10 @@ function Show-ADTInstallationWelcome
         [Parameter(Mandatory = $false, HelpMessage = 'Specify the deadline (in format dd/mm/yyyy) for which deferral will expire as an option.')]
         [ValidateNotNullOrEmpty()]
         [System.String]$DeferDeadline,
+
+        [Parameter(Mandatory = $false, HelpMessage = 'Specifies the number of minutes that must elapse before prompting the user again if a process listed in "CloseProcesses" is still running after a deferral.')]
+        [ValidateNotNullOrEmpty()]
+        [System.UInt32]$DeferRunInterval,
 
         [Parameter(Mandatory = $true, HelpMessage = 'Specify whether to check if there is enough disk space for the installation to proceed. If this parameter is specified without the RequiredDiskSpace parameter, the required disk space is calculated automatically based on the size of the script source and associated files.', ParameterSetName = 'CheckDiskSpace')]
         [System.Management.Automation.SwitchParameter]$CheckDiskSpace,
@@ -346,6 +355,7 @@ function Show-ADTInstallationWelcome
                     $deferHistory = if ($adtSession) { Get-ADTDeferHistory }
                     $deferHistoryTimes = $deferHistory | Select-Object -ExpandProperty DeferTimesRemaining -ErrorAction Ignore
                     $deferHistoryDeadline = $deferHistory | Select-Object -ExpandProperty DeferDeadline -ErrorAction Ignore
+                    $deferHistoryRunIntervalLastTime = $deferHistory | Select-Object -ExpandProperty DeferRunIntervalLastTime -ErrorAction Ignore
 
                     # Reset switches.
                     $checkDeferDays = $DeferDays -ne 0
@@ -464,6 +474,22 @@ function Show-ADTInstallationWelcome
                             {
                                 # Otherwise, as long as the user has not selected to close the apps or the processes are still running and the user has not selected to continue, prompt user to close running processes with deferral.
                                 $deferParams = @{ AllowDefer = $true; DeferTimes = $DeferTimes }; if ($deferDeadlineUniversal) { $deferParams.Add('DeferDeadline', $deferDeadlineUniversal) }
+
+                                # Exit gracefully if DeferRunInterval is set, a last deferral time exists, and the interval has not yet elapsed.
+                                if ($DeferRunInterval -gt 0)
+                                {
+                                    Write-ADTLogEntry -Message "DeferRunInterval of [$DeferRunInterval] minutes is specified. Checking deferral interval."
+                                    if (-not ([String]::IsNullOrEmpty($deferHistoryRunIntervalLastTime)))
+                                    {
+                                        $deferRunIntervalLastTime = Get-ADTUniversalDate -DateTime $deferHistoryRunIntervalLastTime
+                                        $deferRunIntervalNextTime = Get-ADTUniversalDate -DateTime ([System.DateTime]::Parse($deferRunIntervalLastTime).AddMinutes($DeferRunInterval).ToString([System.Globalization.DateTimeFormatInfo]::CurrentInfo.UniversalSortableDateTimePattern))
+                                        if ([System.DateTime]::Parse($deferRunIntervalNextTime) -gt [System.DateTime]::Parse((Get-ADTUniversalDate)))
+                                        {
+                                            Write-ADTLogEntry -Message "DeferRunInterval has not elapsed. Exiting gracefully."
+                                            Close-ADTSession -ExitCode $adtConfig.UI.DefaultExitCode
+                                        }
+                                    }
+                                }
                                 $promptResult = & $Script:CommandTable."Show-ADTWelcomePrompt$($adtConfig.UI.DialogStyle)" @promptParams @deferParams
                             }
                         }
@@ -605,7 +631,16 @@ function Show-ADTInstallationWelcome
                             #  Stop the script (user chose to defer)
                             Write-ADTLogEntry -Message 'Installation deferred by the user.'
                             $BlockExecution = $false
-                            Set-ADTDeferHistory -DeferTimesRemaining $DeferTimes -DeferDeadline $deferDeadlineUniversal
+
+                            # Update defer history, including DeferRunInterval if specified.
+                            if ($DeferRunInterval)
+                            {
+                                Set-ADTDeferHistory -DeferTimesRemaining $DeferTimes -DeferDeadline $deferDeadlineUniversal -DeferRunInterval $DeferRunInterval
+                            }
+                            else
+                            {
+                                Set-ADTDeferHistory -DeferTimesRemaining $DeferTimes -DeferDeadline $deferDeadlineUniversal
+                            }
 
                             # Restore minimized windows.
                             if (!$NoMinimizeWindows)


### PR DESCRIPTION
#### **Overview**
This PR introduces a new parameter, `-DeferRunInterval`, to the `PSAppDeployToolkit` (`Show-ADTInstallationWelcome` and related functions). The feature aims to mitigate repetitive installation attempts by Intune after a user defers an installation, enhancing the overall user experience.

This is a minimally invasive but effective way that addresses the issue.

#### **Key Changes**
1. **New Parameter Added:**
   - `DeferRunInterval` (as **_System.TimeSpan_**): Specifies the interval before re-prompting the user after a deferral.
   - Improves user experience by avoiding multiple immediate retries caused by Intune's default behavior.
   - Seamlessly integrates with the existing deferral workflow in `Show-ADTInstallationWelcome`.

2. **Updated Functions:**
   - **`Set-ADTDeferHistory`**: Supports saving and retrieving the `DeferRunInterval` and the last deferral timestamp (`DeferRunIntervalLastTime`).
   - **`Show-ADTInstallationWelcome`**: Logic added to:
     - Check if the deferral interval has elapsed.
     - Exit gracefully if the interval has not yet elapsed.

3. **Changes in `PSADT.Module.Class.DeploymentSession.cs`:**
   - Added logic to handle the new parameters: `DeferRunInterval` and `DeferRunIntervalLastTime`.

#### **Test Cases**
All test scenarios were validated successfully:
1. **With `DeferRunInterval` Specified**:
   - Prevents repeated prompts during the specified interval.
2. **Without `DeferRunInterval` Specified**:
   - Falls back to default deferral logic without affecting the user experience.
3. **Emergency Update Scenario**:
   - If `-DeferRunInterval` is not specified in a subsequent deployment, existing entries in the registry do not interfere with prompting users.
4. **TestLocal**:
   - The 'TestLocal' test in VSCode passed successfully.
5. **Local Build**:
   - Module built and tested locally with expected results successfully.

#### **Behavioral Improvements**
- Enhanced flexibility for deployments managed through Intune.
- Significant reduction in redundant prompts, leading to better user satisfaction.

#### **Log Outputs**
Clear and actionable log messages added to track `DeferRunInterval` behavior:
- Recording of `DeferRunInterval` and `DeferRunIntervalLastTime`.
- Logging checks for elapsed intervals and graceful exits.

#### **Backward Compatibility**
The changes are fully backward-compatible:
- If `-DeferRunInterval` is not specified, the toolkit functions as before.

---

Let me know if you'd like further tweaks or have any questions!

---

Examples used for logs below:
```powershell
Show-ADTInstallationWelcome -CloseProcesses 'code' -Subtitle 'Application Update' -AllowDeferCloseProcesses -CheckDiskSpace -ForceCloseProcessesCountdown 3270 -NoMinimizeWindows -DeferDays 5 -DeferRunInterval ([System.TimeSpan]::FromHours(24))

Show-ADTInstallationWelcome -CloseProcesses 'code' -Subtitle 'Application Update' -AllowDeferCloseProcesses -CheckDiskSpace -ForceCloseProcessesCountdown 3270 -NoMinimizeWindows -DeferDays 5
```

---

Logging examples:
```
# Test Case: (First run with `-DeferRunInterval ([System.TimeSpan]::FromHours(24))` specified)
<![LOG[[Pre-Install] :: The following processes are running: [Code].]LOG]!>
<![LOG[[Pre-Install] :: DeferRunInterval of [1.00:00:00] is specified. Checking DeferRunIntervalLastTime.]LOG]!>
<![LOG[[Pre-Install] :: Installation deferred by the user.]LOG]!>
<![LOG[[Pre-Install] :: Converting the date [2025-01-13 12:30:52] to a universal sortable date time pattern based on the current culture [en-US].]LOG]!>
<![LOG[[Pre-Install] :: Setting deferral history: [DeferTimesRemaining = 0].]LOG]!>
<![LOG[[Pre-Install] :: Setting deferral history: [DeferDeadline = 2025-01-18 12:30:46Z].]LOG]!>
<![LOG[[Pre-Install] :: Setting deferral history: [DeferRunInterval = 1.00:00:00].]LOG]!>
<![LOG[[Pre-Install] :: Setting deferral history: [DeferRunIntervalLastTime = 2025-01-13 20:30:52Z].]LOG]!>
<![LOG[[Finalization] :: [PSAppDeployToolkit_4.1.0_EN_01] install completed with exit code [60012].]LOG]!>


# Test Case: (Immediate subsequent run mimicking Intune retry after user deferral)
<![LOG[[Pre-Install] :: The following processes are running: [Code].]LOG]!>
<![LOG[[Pre-Install] :: DeferRunInterval of [1.00:00:00] is specified. Checking DeferRunIntervalLastTime.]LOG]!>
<![LOG[[Pre-Install] :: Converting the date [2025-01-13 20:30:52Z] to a universal sortable date time pattern based on the current culture [en-US].]LOG]!>
<![LOG[[Pre-Install] :: Converting the date [2025-01-14 12:30:52Z] to a universal sortable date time pattern based on the current culture [en-US].]LOG]!>
<![LOG[[Pre-Install] :: Converting the date [2025-01-13 12:31:08] to a universal sortable date time pattern based on the current culture [en-US].]LOG]!>
<![LOG[[Pre-Install] :: DeferRunInterval has not elapsed. Exiting gracefully.]LOG]!>
<![LOG[[Finalization] :: [PSAppDeployToolkit_4.1.0_EN_01] install completed with exit code [1618].]LOG]!>


# Test Case: (User deferral without `-DeferRunInterval ([System.TimeSpan]::FromHours(24))` specified)
<![LOG[[Pre-Install] :: The following processes are running: [Code].]LOG]!>
<![LOG[[Pre-Install] :: Installation deferred by the user.]LOG]!>
<![LOG[[Pre-Install] :: Setting deferral history: [DeferTimesRemaining = 0].]LOG]!>
<![LOG[[Pre-Install] :: Setting deferral history: [DeferDeadline = 2025-01-18 12:30:46Z].]LOG]!>
<![LOG[[Finalization] :: [PSAppDeployToolkit_4.1.0_EN_01] install completed with exit code [60012].]LOG]!>


# Test Case: (`-DeferRunInterval ([System.TimeSpan]::FromHours(24))` is specified but process is not running)
<![LOG[[Pre-Install] :: Specified applications are not running.]LOG]!>
<![LOG[[Pre-Install] :: Creating the progress dialog in a separate thread with message: [Installation in progress. Please wait...].]LOG]!>
<![LOG[[Post-Install] :: Displaying custom installation prompt asynchronously with the parameters: [-Message:'You can customize...].]LOG]!>
<![LOG[[Finalization] :: Closing the installation progress dialog.]LOG]!>
<![LOG[[Finalization] :: Removing deferral history...]LOG]!>
<![LOG[[Finalization] :: [PSAppDeployToolkit_4.1.0_EN_01] install completed with exit code [0].]LOG]!>
```