### PR TITLE
- Resolve properties not found error in `Get-ADTApplication`

### DIFF
--- a/src/PSAppDeployToolkit/Public/Get-ADTApplication.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTApplication.ps1
@@ -144,22 +144,22 @@ function Get-ADTApplication
             {
                 Contains
                 {
-                    { foreach ($eachName in $Name) { if ($_.DisplayName -like "*$eachName*") { $true; break } } }
+                    { foreach ($eachName in $Name) { if ($appRegProps.DisplayName -like "*$eachName*") { $true; break } } }
                     break
                 }
                 Exact
                 {
-                    { foreach ($eachName in $Name) { if ($_.DisplayName -eq $eachName) { $true; break } } }
+                    { foreach ($eachName in $Name) { if ($appRegProps.DisplayName -eq $eachName) { $true; break } } }
                     break
                 }
                 Wildcard
                 {
-                    { foreach ($eachName in $Name) { if ($_.DisplayName -like $eachName) { $true; break } } }
+                    { foreach ($eachName in $Name) { if ($appRegProps.DisplayName -like $eachName) { $true; break } } }
                     break
                 }
                 Regex
                 {
-                    { foreach ($eachName in $Name) { if ($_.DisplayName -match $eachName) { $true; break } } }
+                    { foreach ($eachName in $Name) { if ($appRegProps.DisplayName -match $eachName) { $true; break } } }
                     break
                 }
             }


### PR DESCRIPTION
### **Issue**
The function `Get-ADTApplication` was failing with the following error when processing uninstall data from the registry:

```
:: Failed to process the uninstall data [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{anything}]: The property 'DisplayName' cannot be found on this object. Verify that the property exists.
Error Record:
-------------
 
Message               : The property 'DisplayName' cannot be found on this object. Verify that the property exists.
                        
FullyQualifiedErrorId : PropertyNotFoundStrict,Get-ADTApplication
ScriptStackTrace      : at <ScriptBlock>, C:\Users\path\to\PSAppDeployToolkit\PSAppDeployToolkit.psm1: line 6903
```

- The error was caused by referencing prior `$_` in the `NameMatch`.
- The `$_` reference was outdated since `d3db1d2` changes.

---

### **Fix**
- Replaced all instances of `$_` with `$appRegProps` in the name filtering logic to correctly reference the application's registry properties.

---

### **Testing**
- Verified that applications with valid `DisplayName` properties are correctly identified and matched.
- Confirmed that uninstall keys missing `DisplayName` no longer cause errors.
- Ran a local build to verify it works as expected.

---

### **Impact**
✅ Fixes `PropertyNotFoundStrict` error when retrieving installed applications.  
✅ Ensures that all uninstall reg properties such as `DisplayName` is correctly referenced, preventing unnecessary failures.  