### PR TITLE
Deprecate `Show-ADTInstallationWelcome`'s `-NoMinimizeWindows` and replace with `-MinimizeWindows` to match `Show-ADTInstallationPrompt`.

### DIFF
--- a/docs/Show-ADTInstallationWelcome.mdx
+++ b/docs/Show-ADTInstallationWelcome.mdx
@@ -14,8 +14,8 @@ Show a welcome dialog prompting the user with information about the deployment a
 ### Interactive (Default)
 
 ```powershell
-Show-ADTInstallationWelcome [-PersistPrompt] [-NoMinimizeWindows] [-NotTopMost] [-CustomText] -Title <String>
- -Subtitle <String> [<CommonParameters>]
+Show-ADTInstallationWelcome [-PersistPrompt] [-MinimizeWindows] [-NoMinimizeWindows] [-NotTopMost]
+ [-CustomText] -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
 ### SilentCloseProcessesCheckDiskSpace
@@ -37,9 +37,9 @@ Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-Silent] [-BlockE
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDeferCloseProcesses]
  -ForceCloseProcessesCountdown <UInt32> [-DeferTimes <UInt32>] [-DeferDays <UInt32>] [-DeferDeadline <String>]
- [-DeferRunInterval <TimeSpan>] [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-NoMinimizeWindows]
- [-NotTopMost] [-CustomText] [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String>
- [<CommonParameters>]
+ [-DeferRunInterval <TimeSpan>] [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-MinimizeWindows]
+ [-NoMinimizeWindows] [-NotTopMost] [-CustomText] [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>]
+ -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
 ### InteractiveCloseProcessesAllowDeferCloseProcessesForceCloseProcessesCountdown
@@ -47,8 +47,8 @@ Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDeferCloseP
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDeferCloseProcesses]
  -ForceCloseProcessesCountdown <UInt32> [-DeferTimes <UInt32>] [-DeferDays <UInt32>] [-DeferDeadline <String>]
- [-DeferRunInterval <TimeSpan>] [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-NoMinimizeWindows]
- [-NotTopMost] [-CustomText] -Title <String> -Subtitle <String> [<CommonParameters>]
+ [-DeferRunInterval <TimeSpan>] [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-MinimizeWindows]
+ [-NoMinimizeWindows] [-NotTopMost] [-CustomText] -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
 ### InteractiveCloseProcessesAllowDeferCloseProcessesCloseProcessesCountdownCheckDiskSpace
@@ -56,9 +56,9 @@ Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDeferCloseP
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDeferCloseProcesses]
  -CloseProcessesCountdown <UInt32> [-DeferTimes <UInt32>] [-DeferDays <UInt32>] [-DeferDeadline <String>]
- [-DeferRunInterval <TimeSpan>] [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-NoMinimizeWindows]
- [-NotTopMost] [-CustomText] [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String>
- [<CommonParameters>]
+ [-DeferRunInterval <TimeSpan>] [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-MinimizeWindows]
+ [-NoMinimizeWindows] [-NotTopMost] [-CustomText] [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>]
+ -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
 ### InteractiveCloseProcessesAllowDeferCloseProcessesCloseProcessesCountdown
@@ -66,8 +66,8 @@ Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDeferCloseP
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDeferCloseProcesses]
  -CloseProcessesCountdown <UInt32> [-DeferTimes <UInt32>] [-DeferDays <UInt32>] [-DeferDeadline <String>]
- [-DeferRunInterval <TimeSpan>] [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-NoMinimizeWindows]
- [-NotTopMost] [-CustomText] -Title <String> -Subtitle <String> [<CommonParameters>]
+ [-DeferRunInterval <TimeSpan>] [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-MinimizeWindows]
+ [-NoMinimizeWindows] [-NotTopMost] [-CustomText] -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
 ### InteractiveCloseProcessesAllowDeferCloseProcessesForceCountdownCheckDiskSpace
@@ -75,9 +75,9 @@ Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDeferCloseP
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDeferCloseProcesses]
  -ForceCountdown <UInt32> [-DeferTimes <UInt32>] [-DeferDays <UInt32>] [-DeferDeadline <String>]
- [-DeferRunInterval <TimeSpan>] [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-NoMinimizeWindows]
- [-NotTopMost] [-CustomText] [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String>
- [<CommonParameters>]
+ [-DeferRunInterval <TimeSpan>] [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-MinimizeWindows]
+ [-NoMinimizeWindows] [-NotTopMost] [-CustomText] [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>]
+ -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
 ### InteractiveCloseProcessesAllowDeferCloseProcessesForceCountdown
@@ -85,8 +85,8 @@ Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDeferCloseP
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDeferCloseProcesses]
  -ForceCountdown <UInt32> [-DeferTimes <UInt32>] [-DeferDays <UInt32>] [-DeferDeadline <String>]
- [-DeferRunInterval <TimeSpan>] [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-NoMinimizeWindows]
- [-NotTopMost] [-CustomText] -Title <String> -Subtitle <String> [<CommonParameters>]
+ [-DeferRunInterval <TimeSpan>] [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-MinimizeWindows]
+ [-NoMinimizeWindows] [-NotTopMost] [-CustomText] -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
 ### InteractiveCloseProcessesAllowDeferCloseProcessesCheckDiskSpace
@@ -94,8 +94,9 @@ Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDeferCloseP
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDeferCloseProcesses]
  [-DeferTimes <UInt32>] [-DeferDays <UInt32>] [-DeferDeadline <String>] [-DeferRunInterval <TimeSpan>]
- [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-NoMinimizeWindows] [-NotTopMost] [-CustomText]
- [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String> [<CommonParameters>]
+ [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-MinimizeWindows] [-NoMinimizeWindows] [-NotTopMost]
+ [-CustomText] [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String>
+ [<CommonParameters>]
 ```
 
 ### InteractiveCloseProcessesAllowDeferCloseProcesses
@@ -103,8 +104,8 @@ Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDeferCloseP
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDeferCloseProcesses]
  [-DeferTimes <UInt32>] [-DeferDays <UInt32>] [-DeferDeadline <String>] [-DeferRunInterval <TimeSpan>]
- [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-NoMinimizeWindows] [-NotTopMost] [-CustomText]
- -Title <String> -Subtitle <String> [<CommonParameters>]
+ [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-MinimizeWindows] [-NoMinimizeWindows] [-NotTopMost]
+ [-CustomText] -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
 ### InteractiveCloseProcessesAllowDeferForceCloseProcessesCountdownCheckDiskSpace
@@ -112,9 +113,9 @@ Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDeferCloseP
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDefer]
  -ForceCloseProcessesCountdown <UInt32> [-DeferTimes <UInt32>] [-DeferDays <UInt32>] [-DeferDeadline <String>]
- [-DeferRunInterval <TimeSpan>] [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-NoMinimizeWindows]
- [-NotTopMost] [-CustomText] [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String>
- [<CommonParameters>]
+ [-DeferRunInterval <TimeSpan>] [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-MinimizeWindows]
+ [-NoMinimizeWindows] [-NotTopMost] [-CustomText] [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>]
+ -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
 ### InteractiveCloseProcessesAllowDeferForceCloseProcessesCountdown
@@ -122,8 +123,8 @@ Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDefer]
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDefer]
  -ForceCloseProcessesCountdown <UInt32> [-DeferTimes <UInt32>] [-DeferDays <UInt32>] [-DeferDeadline <String>]
- [-DeferRunInterval <TimeSpan>] [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-NoMinimizeWindows]
- [-NotTopMost] [-CustomText] -Title <String> -Subtitle <String> [<CommonParameters>]
+ [-DeferRunInterval <TimeSpan>] [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-MinimizeWindows]
+ [-NoMinimizeWindows] [-NotTopMost] [-CustomText] -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
 ### InteractiveCloseProcessesAllowDeferCloseProcessesCountdownCheckDiskSpace
@@ -131,8 +132,9 @@ Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDefer]
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDefer] -CloseProcessesCountdown <UInt32>
  [-DeferTimes <UInt32>] [-DeferDays <UInt32>] [-DeferDeadline <String>] [-DeferRunInterval <TimeSpan>]
- [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-NoMinimizeWindows] [-NotTopMost] [-CustomText]
- [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String> [<CommonParameters>]
+ [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-MinimizeWindows] [-NoMinimizeWindows] [-NotTopMost]
+ [-CustomText] [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String>
+ [<CommonParameters>]
 ```
 
 ### InteractiveCloseProcessesAllowDeferCloseProcessesCountdown
@@ -140,8 +142,8 @@ Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDefer] -Clo
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDefer] -CloseProcessesCountdown <UInt32>
  [-DeferTimes <UInt32>] [-DeferDays <UInt32>] [-DeferDeadline <String>] [-DeferRunInterval <TimeSpan>]
- [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-NoMinimizeWindows] [-NotTopMost] [-CustomText]
- -Title <String> -Subtitle <String> [<CommonParameters>]
+ [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-MinimizeWindows] [-NoMinimizeWindows] [-NotTopMost]
+ [-CustomText] -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
 ### InteractiveCloseProcessesAllowDeferForceCountdownCheckDiskSpace
@@ -149,8 +151,9 @@ Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDefer] -Clo
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDefer] -ForceCountdown <UInt32>
  [-DeferTimes <UInt32>] [-DeferDays <UInt32>] [-DeferDeadline <String>] [-DeferRunInterval <TimeSpan>]
- [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-NoMinimizeWindows] [-NotTopMost] [-CustomText]
- [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String> [<CommonParameters>]
+ [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-MinimizeWindows] [-NoMinimizeWindows] [-NotTopMost]
+ [-CustomText] [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String>
+ [<CommonParameters>]
 ```
 
 ### InteractiveCloseProcessesAllowDeferForceCountdown
@@ -158,8 +161,8 @@ Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDefer] -For
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDefer] -ForceCountdown <UInt32>
  [-DeferTimes <UInt32>] [-DeferDays <UInt32>] [-DeferDeadline <String>] [-DeferRunInterval <TimeSpan>]
- [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-NoMinimizeWindows] [-NotTopMost] [-CustomText]
- -Title <String> -Subtitle <String> [<CommonParameters>]
+ [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-MinimizeWindows] [-NoMinimizeWindows] [-NotTopMost]
+ [-CustomText] -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
 ### InteractiveCloseProcessesAllowDeferCheckDiskSpace
@@ -167,8 +170,8 @@ Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDefer] -For
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDefer] [-DeferTimes <UInt32>]
  [-DeferDays <UInt32>] [-DeferDeadline <String>] [-DeferRunInterval <TimeSpan>] [-BlockExecution]
- [-PromptToSave] [-PersistPrompt] [-NoMinimizeWindows] [-NotTopMost] [-CustomText] [-CheckDiskSpace]
- [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String> [<CommonParameters>]
+ [-PromptToSave] [-PersistPrompt] [-MinimizeWindows] [-NoMinimizeWindows] [-NotTopMost] [-CustomText]
+ [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
 ### InteractiveCloseProcessesAllowDefer
@@ -176,47 +179,49 @@ Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDefer] [-De
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-AllowDefer] [-DeferTimes <UInt32>]
  [-DeferDays <UInt32>] [-DeferDeadline <String>] [-DeferRunInterval <TimeSpan>] [-BlockExecution]
- [-PromptToSave] [-PersistPrompt] [-NoMinimizeWindows] [-NotTopMost] [-CustomText] -Title <String>
- -Subtitle <String> [<CommonParameters>]
+ [-PromptToSave] [-PersistPrompt] [-MinimizeWindows] [-NoMinimizeWindows] [-NotTopMost] [-CustomText]
+ -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
 ### InteractiveCloseProcessesForceCloseProcessesCountdownCheckDiskSpace
 
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> -ForceCloseProcessesCountdown <UInt32>
- [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-NoMinimizeWindows] [-NotTopMost] [-CustomText]
- [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String> [<CommonParameters>]
+ [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-MinimizeWindows] [-NoMinimizeWindows] [-NotTopMost]
+ [-CustomText] [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String>
+ [<CommonParameters>]
 ```
 
 ### InteractiveCloseProcessesForceCloseProcessesCountdown
 
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> -ForceCloseProcessesCountdown <UInt32>
- [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-NoMinimizeWindows] [-NotTopMost] [-CustomText]
- -Title <String> -Subtitle <String> [<CommonParameters>]
+ [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-MinimizeWindows] [-NoMinimizeWindows] [-NotTopMost]
+ [-CustomText] -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
 ### InteractiveCloseProcessesCloseProcessesCountdownCheckDiskSpace
 
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> -CloseProcessesCountdown <UInt32>
- [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-NoMinimizeWindows] [-NotTopMost] [-CustomText]
- [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String> [<CommonParameters>]
+ [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-MinimizeWindows] [-NoMinimizeWindows] [-NotTopMost]
+ [-CustomText] [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String>
+ [<CommonParameters>]
 ```
 
 ### InteractiveCloseProcessesCloseProcessesCountdown
 
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> -CloseProcessesCountdown <UInt32>
- [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-NoMinimizeWindows] [-NotTopMost] [-CustomText]
- -Title <String> -Subtitle <String> [<CommonParameters>]
+ [-BlockExecution] [-PromptToSave] [-PersistPrompt] [-MinimizeWindows] [-NoMinimizeWindows] [-NotTopMost]
+ [-CustomText] -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
 ### InteractiveCloseProcessesCheckDiskSpace
 
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-BlockExecution] [-PromptToSave]
- [-PersistPrompt] [-NoMinimizeWindows] [-NotTopMost] [-CustomText] [-CheckDiskSpace]
+ [-PersistPrompt] [-MinimizeWindows] [-NoMinimizeWindows] [-NotTopMost] [-CustomText] [-CheckDiskSpace]
  [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
@@ -224,40 +229,40 @@ Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-BlockExecution] 
 
 ```powershell
 Show-ADTInstallationWelcome -CloseProcesses <ProcessObject[]> [-BlockExecution] [-PromptToSave]
- [-PersistPrompt] [-NoMinimizeWindows] [-NotTopMost] [-CustomText] -Title <String> -Subtitle <String>
- [<CommonParameters>]
+ [-PersistPrompt] [-MinimizeWindows] [-NoMinimizeWindows] [-NotTopMost] [-CustomText] -Title <String>
+ -Subtitle <String> [<CommonParameters>]
 ```
 
 ### InteractiveAllowDeferForceCountdownCheckDiskSpace
 
 ```powershell
-Show-ADTInstallationWelcome [-AllowDefer] -ForceCountdown <UInt32> [-PersistPrompt] [-NoMinimizeWindows]
- [-NotTopMost] [-CustomText] [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String>
- [<CommonParameters>]
+Show-ADTInstallationWelcome [-AllowDefer] -ForceCountdown <UInt32> [-PersistPrompt] [-MinimizeWindows]
+ [-NoMinimizeWindows] [-NotTopMost] [-CustomText] [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>]
+ -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
 ### InteractiveAllowDeferForceCountdown
 
 ```powershell
-Show-ADTInstallationWelcome [-AllowDefer] -ForceCountdown <UInt32> [-PersistPrompt] [-NoMinimizeWindows]
- [-NotTopMost] [-CustomText] -Title <String> -Subtitle <String> [<CommonParameters>]
+Show-ADTInstallationWelcome [-AllowDefer] -ForceCountdown <UInt32> [-PersistPrompt] [-MinimizeWindows]
+ [-NoMinimizeWindows] [-NotTopMost] [-CustomText] -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
 ### InteractiveAllowDeferCheckDiskSpace
 
 ```powershell
 Show-ADTInstallationWelcome [-AllowDefer] [-DeferTimes <UInt32>] [-DeferDays <UInt32>]
- [-DeferDeadline <String>] [-DeferRunInterval <TimeSpan>] [-PersistPrompt] [-NoMinimizeWindows] [-NotTopMost]
- [-CustomText] [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String>
- [<CommonParameters>]
+ [-DeferDeadline <String>] [-DeferRunInterval <TimeSpan>] [-PersistPrompt] [-MinimizeWindows]
+ [-NoMinimizeWindows] [-NotTopMost] [-CustomText] [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>]
+ -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
 ### InteractiveAllowDefer
 
 ```powershell
 Show-ADTInstallationWelcome [-AllowDefer] [-DeferTimes <UInt32>] [-DeferDays <UInt32>]
- [-DeferDeadline <String>] [-DeferRunInterval <TimeSpan>] [-PersistPrompt] [-NoMinimizeWindows] [-NotTopMost]
- [-CustomText] -Title <String> -Subtitle <String> [<CommonParameters>]
+ [-DeferDeadline <String>] [-DeferRunInterval <TimeSpan>] [-PersistPrompt] [-MinimizeWindows]
+ [-NoMinimizeWindows] [-NotTopMost] [-CustomText] -Title <String> -Subtitle <String> [<CommonParameters>]
 ```
 
 ### SilentCheckDiskSpace
@@ -276,8 +281,9 @@ Show-ADTInstallationWelcome [-Silent] -Title <String> -Subtitle <String> [<Commo
 ### InteractiveCheckDiskSpace
 
 ```powershell
-Show-ADTInstallationWelcome [-PersistPrompt] [-NoMinimizeWindows] [-NotTopMost] [-CustomText] [-CheckDiskSpace]
- [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String> [<CommonParameters>]
+Show-ADTInstallationWelcome [-PersistPrompt] [-MinimizeWindows] [-NoMinimizeWindows] [-NotTopMost]
+ [-CustomText] [-CheckDiskSpace] [-RequiredDiskSpace <UInt32>] -Title <String> -Subtitle <String>
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -600,9 +606,25 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -NoMinimizeWindows
+### -MinimizeWindows
 
 Specifies whether to minimize other windows when displaying prompt.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Interactive, InteractiveCloseProcessesAllowDeferCloseProcessesForceCloseProcessesCountdownCheckDiskSpace, InteractiveCloseProcessesAllowDeferCloseProcessesForceCloseProcessesCountdown, InteractiveCloseProcessesAllowDeferCloseProcessesCloseProcessesCountdownCheckDiskSpace, InteractiveCloseProcessesAllowDeferCloseProcessesCloseProcessesCountdown, InteractiveCloseProcessesAllowDeferCloseProcessesForceCountdownCheckDiskSpace, InteractiveCloseProcessesAllowDeferCloseProcessesForceCountdown, InteractiveCloseProcessesAllowDeferCloseProcessesCheckDiskSpace, InteractiveCloseProcessesAllowDeferCloseProcesses, InteractiveCloseProcessesAllowDeferForceCloseProcessesCountdownCheckDiskSpace, InteractiveCloseProcessesAllowDeferForceCloseProcessesCountdown, InteractiveCloseProcessesAllowDeferCloseProcessesCountdownCheckDiskSpace, InteractiveCloseProcessesAllowDeferCloseProcessesCountdown, InteractiveCloseProcessesAllowDeferForceCountdownCheckDiskSpace, InteractiveCloseProcessesAllowDeferForceCountdown, InteractiveCloseProcessesAllowDeferCheckDiskSpace, InteractiveCloseProcessesAllowDefer, InteractiveCloseProcessesForceCloseProcessesCountdownCheckDiskSpace, InteractiveCloseProcessesForceCloseProcessesCountdown, InteractiveCloseProcessesCloseProcessesCountdownCheckDiskSpace, InteractiveCloseProcessesCloseProcessesCountdown, InteractiveCloseProcessesCheckDiskSpace, InteractiveCloseProcesses, InteractiveAllowDeferForceCountdownCheckDiskSpace, InteractiveAllowDeferForceCountdown, InteractiveAllowDeferCheckDiskSpace, InteractiveAllowDefer, InteractiveCheckDiskSpace
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoMinimizeWindows
+
+This parameter will be removed in PSAppDeployToolkit 4.2.0.
 
 ```yaml
 Type: SwitchParameter

--- a/examples/VLC/Invoke-AppDeployToolkit.ps1
+++ b/examples/VLC/Invoke-AppDeployToolkit.ps1
@@ -119,7 +119,7 @@ function Install-ADTDeployment
     $adtSession.InstallPhase = "Pre-$($adtSession.DeploymentType)"
 
     ## Show Welcome Message, close VLC if required, allow up to 3 deferrals, and persist the prompt
-    Show-ADTInstallationWelcome -CloseProcesses @{ Name = 'vlc'; Description = $adtSession.AppName } -AllowDeferCloseProcesses -DeferTimes 3 -PersistPrompt -NoMinimizeWindows
+    Show-ADTInstallationWelcome -CloseProcesses @{ Name = 'vlc'; Description = $adtSession.AppName } -AllowDeferCloseProcesses -DeferTimes 3 -PersistPrompt
 
     ## Show Progress Message (with the default message).
     Show-ADTInstallationProgress

--- a/examples/VLC/README.md
+++ b/examples/VLC/README.md
@@ -10,7 +10,7 @@ This application requires a config file to be placed in each user's AppData\Roam
 
 ```ps
 ## Show Welcome Message, close VLC if required, allow up to 3 deferrals, and persist the prompt
-Show-InstallationWelcome -CloseProcesses 'vlc' -AllowDeferCloseProcesses -DeferTimes 3 -PersistPrompt -NoMinimizeWindows
+Show-InstallationWelcome -CloseProcesses 'vlc' -AllowDeferCloseProcesses -DeferTimes 3 -PersistPrompt
 ```
 
 If VLC is running, the user will be prompted to either close the app or defer the installation.

--- a/examples/WinSCP/Invoke-AppDeployToolkit.ps1
+++ b/examples/WinSCP/Invoke-AppDeployToolkit.ps1
@@ -119,7 +119,7 @@ function Install-ADTDeployment
     $adtSession.InstallPhase = "Pre-$($adtSession.DeploymentType)"
 
     ## Show Welcome Message, close WinSCP if required, allow up to 3 deferrals, verify there is enough disk space to complete the install, and persist the prompt.
-    Show-ADTInstallationWelcome -CloseProcesses @{ Name = 'WinSCP'; Description = $adtSession.AppName } -AllowDeferCloseProcesses -DeferTimes 3 -PersistPrompt -NoMinimizeWindows
+    Show-ADTInstallationWelcome -CloseProcesses @{ Name = 'WinSCP'; Description = $adtSession.AppName } -AllowDeferCloseProcesses -DeferTimes 3 -PersistPrompt
 
     ## Show Progress Message (with the default message).
     Show-ADTInstallationProgress

--- a/examples/WinSCP/README.md
+++ b/examples/WinSCP/README.md
@@ -10,7 +10,7 @@ This application requires registry keys to be set for every user to disable auto
 
 ```ps
 ## Show Welcome Message, close WinSCP if required, allow up to 3 deferrals, and persist the prompt
-Show-InstallationWelcome -CloseProcesses 'WinSCP' -AllowDeferCloseProcesses -DeferTimes 3 -PersistPrompt -NoMinimizeWindows
+Show-InstallationWelcome -CloseProcesses 'WinSCP' -AllowDeferCloseProcesses -DeferTimes 3 -PersistPrompt
 ```
 
 If WinSCP is running, the user will be prompted to either close the app or defer the installation.

--- a/src/PSAppDeployToolkit/Frontend/v3/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/src/PSAppDeployToolkit/Frontend/v3/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1379,15 +1379,14 @@ function Show-InstallationWelcome
                 $PSBoundParameters.Remove($oldParam)
             }
         })
-    if ($PSBoundParameters.ContainsKey('MinimizeWindows'))
-    {
-        $PSBoundParameters.Add('NoMinimizeWindows', !$PSBoundParameters.MinimizeWindows)
-        $null = $PSBoundParameters.Remove('MinimizeWindows')
-    }
     if ($PSBoundParameters.ContainsKey('TopMost'))
     {
         $PSBoundParameters.Add('NotTopMost', !$PSBoundParameters.TopMost)
         $null = $PSBoundParameters.Remove('TopMost')
+    }
+    if ($MinimizeWindows)
+    {
+        $PSBoundParameters.Add('MinimizeWindows', $MinimizeWindows)
     }
 
     # Invoke function with amended parameters.

--- a/src/PSAppDeployToolkit/Private/Show-ADTWelcomePromptClassic.ps1
+++ b/src/PSAppDeployToolkit/Private/Show-ADTWelcomePromptClassic.ps1
@@ -54,7 +54,7 @@ function Show-ADTWelcomePromptClassic
         [System.Management.Automation.SwitchParameter]$AllowDefer,
 
         [Parameter(Mandatory = $false)]
-        [System.Management.Automation.SwitchParameter]$NoMinimizeWindows,
+        [System.Management.Automation.SwitchParameter]$MinimizeWindows,
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.SwitchParameter]$NotTopMost,
@@ -600,7 +600,7 @@ function Show-ADTWelcomePromptClassic
     $formWelcome.ResumeLayout()
 
     # Minimize all other windows.
-    if (!$NoMinimizeWindows)
+    if ($MinimizeWindows)
     {
         $null = (Get-ADTEnvironmentTable).ShellApp.MinimizeAll()
     }

--- a/src/PSAppDeployToolkit/Private/Show-ADTWelcomePromptFluent.ps1
+++ b/src/PSAppDeployToolkit/Private/Show-ADTWelcomePromptFluent.ps1
@@ -28,7 +28,7 @@ function Show-ADTWelcomePromptFluent
         [System.Int32]$DeferTimes,
 
         [Parameter(Mandatory = $false)]
-        [System.Management.Automation.SwitchParameter]$NoMinimizeWindows,
+        [System.Management.Automation.SwitchParameter]$MinimizeWindows,
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.SwitchParameter]$NotTopMost,
@@ -75,7 +75,7 @@ function Show-ADTWelcomePromptFluent
     }
 
     # Minimize all other windows.
-    if (!$NoMinimizeWindows)
+    if ($MinimizeWindows)
     {
         $null = (Get-ADTEnvironmentTable).ShellApp.MinimizeAll()
     }

--- a/src/PSAppDeployToolkit/Public/Show-ADTInstallationWelcome.ps1
+++ b/src/PSAppDeployToolkit/Public/Show-ADTInstallationWelcome.ps1
@@ -74,8 +74,11 @@ function Show-ADTInstallationWelcome
     .PARAMETER PersistPrompt
         Specify whether to make the Show-ADTInstallationWelcome prompt persist in the center of the screen every couple of seconds, specified in the config.psd1. The user will have no option but to respond to the prompt. This only takes effect if deferral is not allowed or has expired.
 
-    .PARAMETER NoMinimizeWindows
+    .PARAMETER MinimizeWindows
         Specifies whether to minimize other windows when displaying prompt.
+
+    .PARAMETER NoMinimizeWindows
+        This parameter will be removed in PSAppDeployToolkit 4.2.0.
 
     .PARAMETER NotTopMost
         Specifies whether the windows is the topmost window.
@@ -435,6 +438,37 @@ function Show-ADTInstallationWelcome
         [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesAllowDeferCloseProcessesCloseProcessesCountdownCheckDiskSpace', HelpMessage = 'Specify whether to minimize other windows when displaying prompt.')]
         [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesAllowDeferCloseProcessesForceCloseProcessesCountdown', HelpMessage = 'Specify whether to minimize other windows when displaying prompt.')]
         [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesAllowDeferCloseProcessesForceCloseProcessesCountdownCheckDiskSpace', HelpMessage = 'Specify whether to minimize other windows when displaying prompt.')]
+        [System.Management.Automation.SwitchParameter]$MinimizeWindows,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Interactive', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCheckDiskSpace', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcesses', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesCheckDiskSpace', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveAllowDefer', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveAllowDeferCheckDiskSpace', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveAllowDeferForceCountdown', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveAllowDeferForceCountdownCheckDiskSpace', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesCloseProcessesCountdown', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesCloseProcessesCountdownCheckDiskSpace', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesForceCloseProcessesCountdown', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesForceCloseProcessesCountdownCheckDiskSpace', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesAllowDefer', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesAllowDeferCheckDiskSpace', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesAllowDeferForceCountdown', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesAllowDeferForceCountdownCheckDiskSpace', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesAllowDeferCloseProcessesCountdown', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesAllowDeferCloseProcessesCountdownCheckDiskSpace', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesAllowDeferForceCloseProcessesCountdown', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesAllowDeferForceCloseProcessesCountdownCheckDiskSpace', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesAllowDeferCloseProcesses', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesAllowDeferCloseProcessesCheckDiskSpace', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesAllowDeferCloseProcessesForceCountdown', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesAllowDeferCloseProcessesForceCountdownCheckDiskSpace', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesAllowDeferCloseProcessesCloseProcessesCountdown', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesAllowDeferCloseProcessesCloseProcessesCountdownCheckDiskSpace', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesAllowDeferCloseProcessesForceCloseProcessesCountdown', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InteractiveCloseProcessesAllowDeferCloseProcessesForceCloseProcessesCountdownCheckDiskSpace', HelpMessage = 'This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0.')]
+        [System.Obsolete("This parameter will be removed in PSAppDeployToolkit 4.2.0.")]
         [System.Management.Automation.SwitchParameter]$NoMinimizeWindows,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Interactive', HelpMessage = "Specifies whether the window shouldn't be on top of other windows.")]
@@ -772,7 +806,7 @@ function Show-ADTInstallationWelcome
                             ForceCloseProcessesCountdown = !!$ForceCloseProcessesCountdown
                             ForceCountdown = !!$ForceCountdown
                             PersistPrompt = $PersistPrompt
-                            NoMinimizeWindows = $NoMinimizeWindows
+                            MinimizeWindows = $MinimizeWindows
                             CustomText = $CustomText
                             NotTopMost = $NotTopMost
                         }
@@ -933,7 +967,7 @@ function Show-ADTInstallationWelcome
                             }
 
                             # Restore minimized windows.
-                            if (!$NoMinimizeWindows)
+                            if ($MinimizeWindows)
                             {
                                 $null = $adtEnv.ShellApp.UndoMinimizeAll()
                             }
@@ -959,7 +993,7 @@ function Show-ADTInstallationWelcome
                             }
 
                             # Restore minimized windows.
-                            if (!$NoMinimizeWindows)
+                            if ($MinimizeWindows)
                             {
                                 $null = $adtEnv.ShellApp.UndoMinimizeAll()
                             }

--- a/src/PSAppDeployToolkit/Public/Show-ADTInstallationWelcome.ps1
+++ b/src/PSAppDeployToolkit/Public/Show-ADTInstallationWelcome.ps1
@@ -609,6 +609,12 @@ function Show-ADTInstallationWelcome
         Initialize-ADTFunction -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
         $adtEnv = Get-ADTEnvironmentTable
 
+        # Log the deprecation of -NoMinimizeWindows to the log.
+        if ($PSBoundParameters.ContainsKey('NoMinimizeWindows'))
+        {
+            Write-ADTLogEntry -Message "The parameter [-NoMinimizeWindows] is obsolete and will be removed in PSAppDeployToolkit 4.2.0." -Severity 2
+        }
+
         # Set up DeploymentType if not specified.
         $DeploymentType = if ($adtSession)
         {


### PR DESCRIPTION
Currently, there is an inconsistency between the parameters of `Show-ADTInstallationWelcome` and `Show-ADTInstallationPrompt` in that the former contains a switch named `-NoMinimizeWindows` and the latter contains `-MinimizeWindows`. This situation arose during the development of v4 as `Show-ADTInstallationWelcome` had `-MinimizeWindows` defaulting to `$true`, while `Show-ADTInstallationPrompt` had `-MinimizeWindows` defaulting to `$false`.

The parameters between these functions should be in a uniform state, and because minimizing windows could be significantly undesirable to many folk, it's safer to make `Show-ADTInstallationWelcome` default to not minimizing windows instead of doing the reverse against `Show-ADTInstallationPrompt`.

This PR has been prompted by https://github.com/PSAppDeployToolkit/PSAppDeployToolkit/discussions/1165, whereby the OP has asked for a configuration option to control this globally. A configuration option is _not_ suitable for this as a caller should never be in a position where they need to negate a switch.

This discussion also came up in development between all of us. At the time we were rightfully reluctant to change defaults to minimise migration confusion for users, however I don't think any of us were aware of the mixed setup between dialog functions as if it were known, it would have likely led to this change occuring for PSAppDeployToolkit 4.0.0 from launch.

The old parameter remains in place so that people's scripts continue to function, however it is now decorated with a `[System.Obsolete]` object to advise its discontinuance and that it will be removed in PSAppDeployToolkit 4.2.0. This removal schedule is placed on the assumption that this will be merged in for the PSAppDeployToolkit 4.1.0 release window.