### PR TITLE
Fix #1261. PSADT windows can be closed from taskbar

### DIFF
--- a/src/PSADT.UserInterface/PSADT.UserInterface/UserInterface/PSADT.UserInterface.ADTApplication.cs
+++ b/src/PSADT.UserInterface/PSADT.UserInterface/UserInterface/PSADT.UserInterface.ADTApplication.cs
@@ -386,6 +386,10 @@ namespace PSADT.UserInterface
 
             _app!.Dispatcher.Invoke(() =>
             {
+                if (_currentWindow is ProgressDialog progressDialog)
+                {
+                    progressDialog.AllowToClose();
+                }
                 _currentWindow?.Close();
                 _currentWindow = null;
             });

--- a/src/PSADT.UserInterface/PSADT.UserInterface/UserInterface/PSADT.UserInterface.BaseDialog.cs
+++ b/src/PSADT.UserInterface/PSADT.UserInterface/UserInterface/PSADT.UserInterface.BaseDialog.cs
@@ -5,6 +5,7 @@ using Microsoft.Win32;
 using PSADT.UserInterface.Utilities;
 using System.Windows.Interop;
 using Wpf.Ui.Controls;
+using System.ComponentModel;
 
 namespace PSADT.UserInterface
 {
@@ -16,6 +17,7 @@ namespace PSADT.UserInterface
         private readonly CancellationTokenSource _cancellationTokenSource;
         private readonly Timer? _timer;
         private bool _disposed = false;
+        protected bool _canClose = false;
 
         /// <summary>
         /// Constructor for BaseDialog
@@ -38,6 +40,7 @@ namespace PSADT.UserInterface
             Loaded += BaseDialog_Loaded;
 
             SizeChanged += BaseDialog_SizeChanged;
+            Closing += BaseDialog_Closing;
 
         }
 
@@ -46,8 +49,14 @@ namespace PSADT.UserInterface
         /// </summary>
         protected CancellationToken CancellationToken => _cancellationTokenSource.Token;
 
+        private void BaseDialog_Closing(object? sender, CancelEventArgs e)
+        {
+            e.Cancel = !_canClose; // Prevent the window from closing
+        }
+
         private void CloseDialog(object? state)
         {
+            _canClose = true;
             Dispatcher.Invoke(() =>
             {
                 _cancellationTokenSource.Cancel();
@@ -183,6 +192,7 @@ namespace PSADT.UserInterface
             {
                 Loaded -= BaseDialog_Loaded;
                 SizeChanged -= BaseDialog_SizeChanged;
+                Closing += BaseDialog_Closing;
             }
 
             _disposed = true;

--- a/src/PSADT.UserInterface/PSADT.UserInterface/UserInterface/PSADT.UserInterface.CustomDialog.xaml.cs
+++ b/src/PSADT.UserInterface/PSADT.UserInterface/UserInterface/PSADT.UserInterface.CustomDialog.xaml.cs
@@ -104,7 +104,7 @@ namespace PSADT.UserInterface
 
         private void CloseDialog()
         {
-
+            _canClose = true;
             Close();
             Dispose();
         }

--- a/src/PSADT.UserInterface/PSADT.UserInterface/UserInterface/PSADT.UserInterface.ProgressDialog.xaml.cs
+++ b/src/PSADT.UserInterface/PSADT.UserInterface/UserInterface/PSADT.UserInterface.ProgressDialog.xaml.cs
@@ -97,6 +97,11 @@ namespace PSADT.UserInterface
             });
         }
 
+        public void AllowToClose()
+        {
+            _canClose = true;
+        }
+
         /// <summary>
         /// Override the OnClosed event to dispose of the dialog
         /// </summary>

--- a/src/PSADT.UserInterface/PSADT.UserInterface/UserInterface/PSADT.UserInterface.RestartDialog.xaml.cs
+++ b/src/PSADT.UserInterface/PSADT.UserInterface/UserInterface/PSADT.UserInterface.RestartDialog.xaml.cs
@@ -143,6 +143,7 @@ namespace PSADT.UserInterface
 
         private void CloseDialog()
         {
+            _canClose = true;
             _timer.Stop();
             Close();
             Dispose();

--- a/src/PSADT.UserInterface/PSADT.UserInterface/UserInterface/PSADT.UserInterface.WelcomeDialog.xaml.cs
+++ b/src/PSADT.UserInterface/PSADT.UserInterface/UserInterface/PSADT.UserInterface.WelcomeDialog.xaml.cs
@@ -320,6 +320,7 @@ namespace PSADT.UserInterface
 
         private void CloseDialog()
         {
+            _canClose = true;
             Close();
             Dispose();
         }


### PR DESCRIPTION
PSADT windows can be closed by right-clicking taskbar icon and selecting "Close Window".