### PR TITLE
Use PSVariableIntrinsics for variable to session state export

### DIFF
--- a/src/PSAppDeployToolkit/Public/Export-ADTEnvironmentTableToSessionState.ps1
+++ b/src/PSAppDeployToolkit/Public/Export-ADTEnvironmentTableToSessionState.ps1
@@ -48,6 +48,7 @@ function Export-ADTEnvironmentTableToSessionState
         https://psappdeploytoolkit.com/docs/reference/functions/Export-ADTEnvironmentTableToSessionState
     #>
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'SessionState', Justification = 'SessionState is used.')]
     [CmdletBinding()]
     param
     (
@@ -77,14 +78,12 @@ function Export-ADTEnvironmentTableToSessionState
             try
             {
                 $adtEnv.GetEnumerator() | & {
-                    process
-                    {
+                    process {
                         # Prior removal is required for ReadOnly variables
-                        $SessionState.PSVariable.Get($_.Key) | & { 
-                            process
-                            { 
+                        $SessionState.PSVariable.Get($_.Key) | & {
+                            process {
                                 $SessionState.PSVaraible.Remove($_)
-                            } 
+                            }
                         }
 
                         $SessionState.PSVariable.Set(

--- a/src/PSAppDeployToolkit/Public/Export-ADTEnvironmentTableToSessionState.ps1
+++ b/src/PSAppDeployToolkit/Public/Export-ADTEnvironmentTableToSessionState.ps1
@@ -82,7 +82,7 @@ function Export-ADTEnvironmentTableToSessionState
                         # Prior removal is required for ReadOnly variables
                         $SessionState.PSVariable.Get($_.Key) | & {
                             process {
-                                $SessionState.PSVaraible.Remove($_)
+                                $SessionState.PSVariable.Remove($_)
                             }
                         }
 


### PR DESCRIPTION
This results in a way more readable format and we are not reliant on running script blocks in the caller session state.
Should also be faster :)