### PR TITLE
Update Get-ADTConfig.ps1

### DIFF
--- a/src/PSAppDeployToolkit/Public/Get-ADTConfig.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTConfig.ps1
@@ -29,7 +29,9 @@ function Get-ADTConfig
         This example retrieves the configuration data for the ADT module and stores it in the $config variable.
 
     .NOTES
-        An active ADT session is NOT required to use this function.
+        An active ADT session is NOT required to use this function 
+        But you must run Initialize-ADTModule function before using Get-ADTConfig
+        
 
         Tags: psadt<br />
         Website: https://psappdeploytoolkit.com<br />


### PR DESCRIPTION
Mention how to avoid 
Get-ADTConfig : Please ensure that [Initialize-ADTModule] is called before using any PSAppDeployToolkit functions.