### PR TITLE
Template error dialog changes

### DIFF
--- a/src/PSAppDeployToolkit/Frontend/v4/Invoke-AppDeployToolkit.ps1
+++ b/src/PSAppDeployToolkit/Frontend/v4/Invoke-AppDeployToolkit.ps1
@@ -325,6 +325,12 @@ try
 catch
 {
     Write-ADTLogEntry -Message ($mainErrorMessage = Resolve-ADTErrorRecord -ErrorRecord $_) -Severity 3
-    Show-ADTDialogBox -Text $mainErrorMessage -Icon Stop | Out-Null
+
+    # Error details hidden from the user by default, uncomment one of the options below to display them:
+    # Simple dialog with full stack trace:
+    # Show-ADTDialogBox -Text $mainErrorMessage -Icon Stop | Out-Null
+    # Themed dialog with basic error message:
+    # Show-ADTInstallationPrompt -Message "$($adtSession.DeploymentType) Failed at line $($_.InvocationInfo.ScriptLineNumber), char $($_.InvocationInfo.OffsetInLine):`n$($_.InvocationInfo.Line.Trim())`n`nMessage:`n$($_.Exception.Message)" -ButtonRightText 'OK' -Icon Error -NoWait
+
     Close-ADTSession -ExitCode 60001
 }


### PR DESCRIPTION
In v3, a failed install would not show any error details to the user.

In v4.0, a full stack trace is shown:

![image](https://github.com/user-attachments/assets/8f25dd69-9478-4e19-8345-2c4fadd52c36)

This change adds an alternative option to show a simpler message in a themed dialog box:

![image](https://github.com/user-attachments/assets/52223f4c-8a37-49dc-ba51-e834d5bb2712)

We had a number of users asking how to hide these errors from the users, so the template comments both options out by default to quieten things down as they were in v3. Users can decide to enable one or the other if they wish - and the docs should be updated to point this out.