### PR TITLE
Change default DeferExitCode to 1602

### DIFF
--- a/src/PSAppDeployToolkit/Config/config.psd1
+++ b/src/PSAppDeployToolkit/Config/config.psd1
@@ -123,7 +123,7 @@
         DefaultTimeout = 3300
 
         # Exit code used when a user opts to defer.
-        DeferExitCode = 60012
+        DeferExitCode = 1602
 
         <# Specify a static UI language using the one of the Language Codes listed below to override the language culture detected on the system.
             Language Code    Language


### PR DESCRIPTION
The default exit code of 60012 when a user hits defer is not recognised by Intune or ConfigMgr, so it just shows the status as Failed with the details as '0x8007EA6C':

![image](https://github.com/user-attachments/assets/291383ac-f51b-4aa3-a098-1e6e7adbc621)

Changing this to 1602, which is the standard MSI exit code for 'user cancelled the installation', means that both Intune and ConfigMgr are able to interpret this and provide a more informative error message:

![image](https://github.com/user-attachments/assets/28886e13-c3cf-4da0-9932-a0abd741c15b)

A short poll was put on the Discord community and the idea was well received:

![image](https://github.com/user-attachments/assets/53d0fd70-696d-47d5-a1d7-b02865f88497)

