### PR TITLE
Change default msiexec.exe parameters from `/qb-!` to `/qn`

### DIFF
--- a/src/PSAppDeployToolkit/ADMX/en-US/PSAppDeployToolkit.adml
+++ b/src/PSAppDeployToolkit/ADMX/en-US/PSAppDeployToolkit.adml
@@ -15,7 +15,7 @@
 			<string id="Banner_Explain">Specify filename of the banner (Classic-only).</string>
 			<string id="MSI_Category">MSI</string>
 			<string id="InstallParams_Display">InstallParams</string>
-			<string id="InstallParams_Explain">Installation parameters used for non-silent MSI actions.</string>
+			<string id="InstallParams_Explain">MSI install parameters used in interactive mode.</string>
 			<string id="LoggingOptions_Display">LoggingOptions</string>
 			<string id="LoggingOptions_Explain">Logging level used for MSI logging.</string>
 			<string id="LogPath_MSI_Display">LogPath</string>
@@ -25,9 +25,9 @@
 			<string id="MutexWaitTime_Display">MutexWaitTime</string>
 			<string id="MutexWaitTime_Explain">The length of time in seconds to wait for the MSI installer service to become available.</string>
 			<string id="SilentParams_Display">SilentParams</string>
-			<string id="SilentParams_Explain">Installation parameters used for silent MSI actions.</string>
+			<string id="SilentParams_Explain">MSI install parameters used in silent mode.</string>
 			<string id="UninstallParams_Display">UninstallParams</string>
-			<string id="UninstallParams_Explain">Installation parameters used for MSI uninstall actions.</string>
+			<string id="UninstallParams_Explain">MSI uninstall parameters.</string>
 			<string id="Toolkit_Category">Toolkit</string>
 			<string id="CachePath_Display">CachePath</string>
 			<string id="CachePath_Explain">Specify the path for the cache folder.</string>

--- a/src/PSAppDeployToolkit/Config/config.psd1
+++ b/src/PSAppDeployToolkit/Config/config.psd1
@@ -11,7 +11,7 @@
     }
 
     MSI = @{
-        # Installation parameters used for non-silent MSI actions.
+        # Installation parameters used in interactive mode.
         InstallParams = 'REBOOT=ReallySuppress /QN'
 
         # Logging level used for MSI logging.
@@ -26,7 +26,7 @@
         # The length of time in seconds to wait for the MSI installer service to become available. Default is 600 seconds (10 minutes).
         MutexWaitTime = 600
 
-        # Installation parameters used for silent MSI actions.
+        # Installation parameters used in silent mode.
         SilentParams = 'REBOOT=ReallySuppress /QN'
 
         # Installation parameters used for MSI uninstall actions.

--- a/src/PSAppDeployToolkit/Config/config.psd1
+++ b/src/PSAppDeployToolkit/Config/config.psd1
@@ -12,7 +12,7 @@
 
     MSI = @{
         # Installation parameters used for non-silent MSI actions.
-        InstallParams = 'REBOOT=ReallySuppress /QB-!'
+        InstallParams = 'REBOOT=ReallySuppress /QN'
 
         # Logging level used for MSI logging.
         LoggingOptions = '/L*V'

--- a/src/PSAppDeployToolkit/Config/config.psd1
+++ b/src/PSAppDeployToolkit/Config/config.psd1
@@ -11,7 +11,7 @@
     }
 
     MSI = @{
-        # Installation parameters used in interactive mode.
+        # MSI install parameters used in interactive mode.
         InstallParams = 'REBOOT=ReallySuppress /QN'
 
         # Logging level used for MSI logging.
@@ -26,10 +26,10 @@
         # The length of time in seconds to wait for the MSI installer service to become available. Default is 600 seconds (10 minutes).
         MutexWaitTime = 600
 
-        # Installation parameters used in silent mode.
+        # MSI install parameters used in silent mode.
         SilentParams = 'REBOOT=ReallySuppress /QN'
 
-        # Installation parameters used for MSI uninstall actions.
+        # MSI uninstall parameters.
         UninstallParams = 'REBOOT=ReallySuppress /QN'
     }
 


### PR DESCRIPTION
The previous value, while cool by showing a msiexec.exe progress bar without the ability to cancel/stop in any way, is not always properly honoured by vendors who can still display modal dialogs in this mode. This is only truly addressed by using `/qn` to fully silence a deployment.