### PR TITLE
Add LogMaxFolderCount setting  and log folder pruning 

### DIFF
--- a/src/PSAppDeployToolkit/Config/config.psd1
+++ b/src/PSAppDeployToolkit/Config/config.psd1
@@ -52,6 +52,9 @@
         # Specify maximum file size limit for log file in megabytes (MB).
         LogMaxSize = 10
 
+        # Specify maximum number of previous log folders to retain (applies when LogToSubfolder or LogToHierarchy is enabled).
+        LogMaxFolderCount = 5
+
         # Log path used for Toolkit logging.
         LogPath = '$envWinDir\Logs\Software'
 


### PR DESCRIPTION
Fixes some parts of issue #1476 
Any and all feedback is really appreciated.

Details

- Reads Toolkit.LogMaxFolderCount from config.

- On the first log write, removes oldest log folders so that total (including the current) does not exceed the limit.

- Uses creation time to determine oldest folders.

- Skips pruning if the limit is 0 or undefined.