### PR TITLE
Ensure log lines from `Show-ADTInstallationProgress` reflect all inputs.

### DIFF
--- a/src/PSAppDeployToolkit/Public/Show-ADTInstallationProgress.ps1
+++ b/src/PSAppDeployToolkit/Public/Show-ADTInstallationProgress.ps1
@@ -252,14 +252,14 @@ function Show-ADTInstallationProgress
                     [PSADT.UserInterface.DialogOptions.ProgressDialogOptions]$dialogOptions = $dialogOptions
 
                     # Create the new progress dialog.
-                    Write-ADTLogEntry -Message "Creating the progress dialog in a separate thread with message: [$($PSBoundParameters.StatusMessage)]."
+                    Write-ADTLogEntry -Message "Creating the progress dialog in a separate thread with $([System.String]::Join(', ', ('StatusMessage', 'StatusMessageDetail', 'StatusBarPercentage').ForEach({ if ($PSBoundParameters.ContainsKey($_)) { "[$($_): $($PSBoundParameters.$_)]" } })))."
                     Invoke-ADTClientServerOperation -ShowProgressDialog -User $runAsActiveUser -DialogStyle $adtConfig.UI.DialogStyle -Options $dialogOptions
                     Add-ADTModuleCallback -Hookpoint OnFinish -Callback $Script:CommandTable.'Close-ADTInstallationProgress'
                 }
                 else
                 {
                     # Update the dialog as required.
-                    Write-ADTLogEntry -Message "Updating the progress dialog with message: [$($PSBoundParameters.StatusMessage)]."
+                    Write-ADTLogEntry -Message "Updating the progress dialog with $([System.String]::Join(', ', ('StatusMessage', 'StatusMessageDetail', 'StatusBarPercentage').ForEach({ if ($PSBoundParameters.ContainsKey($_)) { "[$($_): $($PSBoundParameters.$_)]" } })))."
                     $iacsoParams = @{
                         UpdateProgressDialog = $true
                         User = $runAsActiveUser


### PR DESCRIPTION
^