### PR TITLE
No need to be so restrictive on `Start-ADTMsiProcess -LogFileName`.

### DIFF
--- a/src/PSAppDeployToolkit/Public/Start-ADTMsiProcess.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTMsiProcess.ps1
@@ -247,10 +247,6 @@ function Start-ADTMsiProcess
                 {
                     $PSCmdlet.ThrowTerminatingError((New-ADTValidateScriptErrorRecord -ParameterName LogFileName -ProvidedValue $_ -ExceptionMessage 'The specified input is null or white space.'))
                 }
-                if ([System.IO.Path]::GetExtension($_) -match '^\.(log|txt)$')
-                {
-                    $PSCmdlet.ThrowTerminatingError((New-ADTValidateScriptErrorRecord -ParameterName LogFileName -ProvidedValue $_ -ExceptionMessage 'The specified input cannot have an extension.'))
-                }
                 return $true
             })]
         [System.String]$LogFileName = [System.Management.Automation.Language.NullString]::Value,


### PR DESCRIPTION
Fixes #1629.