### PR TITLE
Correct parameter set issue in Set-ADTActiveSetup

### DIFF
--- a/src/PSAppDeployToolkit/Public/Set-ADTActiveSetup.ps1
+++ b/src/PSAppDeployToolkit/Public/Set-ADTActiveSetup.ps1
@@ -100,6 +100,7 @@ function Set-ADTActiveSetup
     param
     (
         [Parameter(Mandatory = $true, ParameterSetName = 'Create')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'CreateNoExecute')]
         [ValidateScript({
                 if (('.exe', '.vbs', '.cmd', '.bat', '.ps1', '.js') -notcontains ($StubExeExt = [System.IO.Path]::GetExtension($_)))
                 {


### PR DESCRIPTION
Corrects a reported issue where it was impossible to use -StubPath in combination with -NoExecuteForCurrentUser.