### PR TITLE
Set default parameter set for `Start-ADTMspProcess`.

### DIFF
--- a/src/PSAppDeployToolkit/Public/Start-ADTMspProcess.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTMspProcess.ps1
@@ -71,7 +71,7 @@ function Start-ADTMspProcess
         https://psappdeploytoolkit.com/docs/reference/functions/Start-ADTMspProcess
     #>
 
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'None')]
     [OutputType([System.Int32])]
     param
     (


### PR DESCRIPTION
Fixes #1677.