### PR TITLE
Set-ADTItemPermission - Correct typo on $LiteralPath variable and update help

### DIFF
--- a/src/PSAppDeployToolkit/Public/Set-ADTItemPermission.ps1
+++ b/src/PSAppDeployToolkit/Public/Set-ADTItemPermission.ps1
@@ -191,7 +191,7 @@ function Set-ADTItemPermission
                 # Disable inheritance if asked to do so.
                 if ($DisableInheritance)
                 {
-                    $Acl.SetAccessRuleProtection($true, $true); $null = Set-Acl -LiteralPath $Path -AclObject $Acl
+                    $Acl.SetAccessRuleProtection($true, $true); $null = Set-Acl -LiteralPath $LiteralPath -AclObject $Acl
                     $Acl = Get-Acl -LiteralPath $LiteralPath
                 }
 

--- a/src/PSAppDeployToolkit/Public/Set-ADTItemPermission.ps1
+++ b/src/PSAppDeployToolkit/Public/Set-ADTItemPermission.ps1
@@ -53,7 +53,10 @@ function Set-ADTItemPermission
         * RemoveAccessRuleSpecific - Removes specific permissions.
 
     .PARAMETER EnableInheritance
-        Enables inheritance on the files/folders.
+        Enables inheritance, which removes explicit permissions.
+
+    .PARAMETER DisableInheritance
+        Disables inheritance, preserving permissions before doing so.
 
     .INPUTS
         None


### PR DESCRIPTION
Last push to this function (https://github.com/PSAppDeployToolkit/PSAppDeployToolkit/pull/1686) used a non-existent $Path variable that triggered an error when using the newly added `-DisableInheritance` parameter. Simple typo, it should've been $LiteralPath. This new param was also missing from the built-in help (which I would've expected to cause a build failure?).