### PR TITLE
Avoid `Get-Acl`/`Set-Acl` cmdlets in PowerShell as they have inappropriate permissions testing.

### DIFF
--- a/src/PSAppDeployToolkit/Public/Set-ADTItemPermission.ps1
+++ b/src/PSAppDeployToolkit/Public/Set-ADTItemPermission.ps1
@@ -53,7 +53,7 @@ function Set-ADTItemPermission
         * RemoveAccessRuleSpecific - Removes specific permissions.
 
     .PARAMETER EnableInheritance
-        Enables inheritance, which removes explicit permissions.
+        Enables inheritance on the files/folders.
 
     .PARAMETER DisableInheritance
         Disables inheritance, preserving permissions before doing so.
@@ -148,7 +148,7 @@ function Set-ADTItemPermission
         [Parameter(Mandatory = $false, HelpMessage = 'Disables inheritance, preserving permissions before doing so.', ParameterSetName = 'DisableInheritance')]
         [System.Management.Automation.SwitchParameter]$DisableInheritance,
 
-        [Parameter(Mandatory = $true, HelpMessage = 'Enables inheritance, which removes explicit permissions.', ParameterSetName = 'EnableInheritance')]
+        [Parameter(Mandatory = $true, HelpMessage = 'Enables inheritance on the files/folders.', ParameterSetName = 'EnableInheritance')]
         [System.Management.Automation.SwitchParameter]$EnableInheritance
     )
 


### PR DESCRIPTION
Fixes #1691.