### PR TITLE
Allow `Start-ADT*ProcessAsUser` to operate with any valid user, such as disconnected users.

### DIFF
--- a/src/PSAppDeployToolkit/Private/Get-ADTClientServerUser.ps1
+++ b/src/PSAppDeployToolkit/Private/Get-ADTClientServerUser.ps1
@@ -14,6 +14,9 @@ function Private:Get-ADTClientServerUser
         [ValidateNotNullOrEmpty()]
         [System.Security.Principal.NTAccount]$Username,
 
+        [Parameter(Mandatory = $false, ParameterSetName = 'Username')]
+        [System.Management.Automation.SwitchParameter]$AllowAnyValidSession,
+
         [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
         [System.Management.Automation.SwitchParameter]$AllowSystemFallback
     )
@@ -50,7 +53,7 @@ function Private:Get-ADTClientServerUser
         }
 
         # Only return the calculated RunAsActiveUser if the user is still logged on and active as of right now.
-        if (($runAsUserSession = $(Get-ADTLoggedOnUser -InformationAction SilentlyContinue) | & { process { if ($runAsActiveUser.NTAccount.Equals($_.NTAccount)) { return $_ } } } | Select-Object -First 1) -and $runAsUserSession.IsActiveUserSession)
+        if (($runAsUserSession = $(Get-ADTLoggedOnUser -InformationAction SilentlyContinue) | & { process { if ($runAsActiveUser.SID.Equals($_.SID)) { return $_ } } } | Select-Object -First 1) -and ($runAsUserSession.IsActiveUserSession -or ($AllowAnyValidSession -and $runAsUserSession.IsValidUserSession)))
         {
             return $runAsActiveUser
         }

--- a/src/PSAppDeployToolkit/Public/Start-ADTMsiProcessAsUser.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTMsiProcessAsUser.ps1
@@ -304,13 +304,17 @@ function Start-ADTMsiProcessAsUser
     process
     {
         # Convert the Username field into a RunAsActiveUser object as required by the subsystem.
-        $gacsuParams = if ($PSBoundParameters.ContainsKey('Username')) { @{ Username = $Username } } else { @{} }
+        $gacsuParams = @{}; if ($PSBoundParameters.ContainsKey('Username'))
+        {
+            $gacsuParams.Add('Username', $Username)
+            $gacsuParams.Add('AllowAnyValidSession', $true)
+        }
         if (!($PSBoundParameters.RunAsActiveUser = Get-ADTClientServerUser @gacsuParams))
         {
             try
             {
                 $naerParams = @{
-                    Exception = [System.ArgumentNullException]::new("There is no logged on user to run a new process as.", $null)
+                    Exception = [System.ArgumentNullException]::new("Could not find an valid logged on user session$(if ($PSBoundParameters.ContainsKey('Username')) { " for [$Username]" }).", $null)
                     Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
                     ErrorId = 'NoActiveUserError'
                     TargetObject = $Username

--- a/src/PSAppDeployToolkit/Public/Start-ADTMsiProcessAsUser.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTMsiProcessAsUser.ps1
@@ -314,7 +314,7 @@ function Start-ADTMsiProcessAsUser
             try
             {
                 $naerParams = @{
-                    Exception = [System.ArgumentNullException]::new("Could not find an valid logged on user session$(if ($PSBoundParameters.ContainsKey('Username')) { " for [$Username]" }).", $null)
+                    Exception = [System.ArgumentNullException]::new("Could not find a valid logged on user session$(if ($PSBoundParameters.ContainsKey('Username')) { " for [$Username]" }).", $null)
                     Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
                     ErrorId = 'NoActiveUserError'
                     TargetObject = $Username

--- a/src/PSAppDeployToolkit/Public/Start-ADTMspProcessAsUser.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTMspProcessAsUser.ps1
@@ -121,7 +121,7 @@ function Start-ADTMspProcessAsUser
             try
             {
                 $naerParams = @{
-                    Exception = [System.ArgumentNullException]::new("Could not find an valid logged on user session$(if ($PSBoundParameters.ContainsKey('Username')) { " for [$Username]" }).", $null)
+                    Exception = [System.ArgumentNullException]::new("Could not find a valid logged on user session$(if ($PSBoundParameters.ContainsKey('Username')) { " for [$Username]" }).", $null)
                     Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
                     ErrorId = 'NoActiveUserError'
                     TargetObject = $Username

--- a/src/PSAppDeployToolkit/Public/Start-ADTMspProcessAsUser.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTMspProcessAsUser.ps1
@@ -111,13 +111,17 @@ function Start-ADTMspProcessAsUser
     process
     {
         # Convert the Username field into a RunAsActiveUser object as required by the subsystem.
-        $gacsuParams = if ($PSBoundParameters.ContainsKey('Username')) { @{ Username = $Username } } else { @{} }
+        $gacsuParams = @{}; if ($PSBoundParameters.ContainsKey('Username'))
+        {
+            $gacsuParams.Add('Username', $Username)
+            $gacsuParams.Add('AllowAnyValidSession', $true)
+        }
         if (!($PSBoundParameters.RunAsActiveUser = Get-ADTClientServerUser @gacsuParams))
         {
             try
             {
                 $naerParams = @{
-                    Exception = [System.ArgumentNullException]::new("There is no logged on user to run a new process as.", $null)
+                    Exception = [System.ArgumentNullException]::new("Could not find an valid logged on user session$(if ($PSBoundParameters.ContainsKey('Username')) { " for [$Username]" }).", $null)
                     Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
                     ErrorId = 'NoActiveUserError'
                     TargetObject = $Username

--- a/src/PSAppDeployToolkit/Public/Start-ADTProcessAsUser.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTProcessAsUser.ps1
@@ -308,13 +308,17 @@ function Start-ADTProcessAsUser
     process
     {
         # Convert the Username field into a RunAsActiveUser object as required by the subsystem.
-        $gacsuParams = if ($PSBoundParameters.ContainsKey('Username')) { @{ Username = $Username } } else { @{} }
+        $gacsuParams = @{}; if ($PSBoundParameters.ContainsKey('Username'))
+        {
+            $gacsuParams.Add('Username', $Username)
+            $gacsuParams.Add('AllowAnyValidSession', $true)
+        }
         if (!($PSBoundParameters.RunAsActiveUser = Get-ADTClientServerUser @gacsuParams))
         {
             try
             {
                 $naerParams = @{
-                    Exception = [System.ArgumentNullException]::new("There is no logged on user to run a new process as.", $null)
+                    Exception = [System.ArgumentNullException]::new("Could not find an valid logged on user session$(if ($PSBoundParameters.ContainsKey('Username')) { " for [$Username]" }).", $null)
                     Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
                     ErrorId = 'NoActiveUserError'
                     TargetObject = $Username

--- a/src/PSAppDeployToolkit/Public/Start-ADTProcessAsUser.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTProcessAsUser.ps1
@@ -318,7 +318,7 @@ function Start-ADTProcessAsUser
             try
             {
                 $naerParams = @{
-                    Exception = [System.ArgumentNullException]::new("Could not find an valid logged on user session$(if ($PSBoundParameters.ContainsKey('Username')) { " for [$Username]" }).", $null)
+                    Exception = [System.ArgumentNullException]::new("Could not find a valid logged on user session$(if ($PSBoundParameters.ContainsKey('Username')) { " for [$Username]" }).", $null)
                     Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
                     ErrorId = 'NoActiveUserError'
                     TargetObject = $Username


### PR DESCRIPTION
This only applies for this aspect of the code. For any other client/server process such as the UI, only an active user object would be returned.