### PR TITLE
Fix `OutOfMemoryException` issues within `Resolve-ADTErrorRecord`.

### DIFF
--- a/src/PSAppDeployToolkit/Public/Resolve-ADTErrorRecord.ps1
+++ b/src/PSAppDeployToolkit/Public/Resolve-ADTErrorRecord.ps1
@@ -165,8 +165,7 @@ function Resolve-ADTErrorRecord
             {
                 if ($propName -eq 'TargetObject')
                 {
-                    $osParams = if ($errorObject.$propName -isnot [System.Collections.IDictionary]) { @{ Width = [System.Int32]::MaxValue } } else { @{} }
-                    $logErrorProperties.Add($propName, [PSADT.Utilities.MiscUtilities]::TrimLeadingTrailingLines(($errorObject.$propName | Out-String @osParams)))
+                    $logErrorProperties.Add($propName, [System.String]::Join("`n", [PSADT.Utilities.MiscUtilities]::TrimLeadingTrailingLines([System.String[]]($errorObject.$propName | Out-String -Width ([System.Int16]::MaxValue) -Stream))))
                 }
                 else
                 {


### PR DESCRIPTION
There's bugs in `Out-String` that can lead to strings with infinitely long trailing lines depending on how wide the output is to be. We resolve this by streaming the output to reduce memory load, and by reducing the width maximum 16-bit value, as we don't need 2147483647 columns here.