### PR TITLE
Fix bad comment-based help for `Get-ADTExecutableInfo`.

### DIFF
--- a/src/PSAppDeployToolkit/Public/Get-ADTExecutableInfo.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTExecutableInfo.ps1
@@ -42,7 +42,7 @@ function Get-ADTExecutableInfo
 
         Tags: psadt<br />
         Website: https://psappdeploytoolkit.com<br />
-        Copyright: © 2025 PSAppDeployToolkit Team (Sean Lillis, Dan Cunningham, Muhammad Mashwani, Mitch Richters, Dan Gough).<br />
+        Copyright: (C) 2025 PSAppDeployToolkit Team (Sean Lillis, Dan Cunningham, Muhammad Mashwani, Mitch Richters, Dan Gough).<br />
         License: https://opensource.org/license/lgpl-3-0
 
     .LINK


### PR DESCRIPTION
Fixes #1731.