### PR TITLE
Remove `-MessageAlignment` from commented out `Show-ADTInstallationPrompt` example in template.

### DIFF
--- a/src/PSAppDeployToolkit/Frontend/v4/Invoke-AppDeployToolkit.ps1
+++ b/src/PSAppDeployToolkit/Frontend/v4/Invoke-AppDeployToolkit.ps1
@@ -352,7 +352,7 @@ catch
     # Show-ADTDialogBox -Text $mainErrorMessage -Icon Stop -NoWait
 
     ## Or, a themed dialog with basic error message:
-    # Show-ADTInstallationPrompt -Message "$($adtSession.DeploymentType) failed at line $($_.InvocationInfo.ScriptLineNumber), char $($_.InvocationInfo.OffsetInLine):`n$($_.InvocationInfo.Line.Trim())`n`nMessage:`n$($_.Exception.Message)" -MessageAlignment Left -ButtonRightText OK -Icon Error -NoWait
+    # Show-ADTInstallationPrompt -Message "$($adtSession.DeploymentType) failed at line $($_.InvocationInfo.ScriptLineNumber), char $($_.InvocationInfo.OffsetInLine):`n$($_.InvocationInfo.Line.Trim())`n`nMessage:`n$($_.Exception.Message)" -ButtonRightText OK -Icon Error -NoWait
 
     Close-ADTSession -ExitCode 60001
 }


### PR DESCRIPTION
Fixes #1732.