### PR TITLE
Ensure all callbacks removed via `Remove-ADTModuleCallback` are referenced by the CommandTable entry.

### DIFF
--- a/src/PSAppDeployToolkit/Private/Close-ADTClientServerProcess.ps1
+++ b/src/PSAppDeployToolkit/Private/Close-ADTClientServerProcess.ps1
@@ -33,6 +33,6 @@ function Private:Close-ADTClientServerProcess
     finally
     {
         $Script:ADT.ClientServerProcess = $null
-        Remove-ADTModuleCallback -Hookpoint OnFinish -Callback $MyInvocation.MyCommand
+        Remove-ADTModuleCallback -Hookpoint OnFinish -Callback $Script:CommandTable.($MyInvocation.MyCommand.Name)
     }
 }

--- a/src/PSAppDeployToolkit/Public/Close-ADTInstallationProgress.ps1
+++ b/src/PSAppDeployToolkit/Public/Close-ADTInstallationProgress.ps1
@@ -81,7 +81,7 @@ function Close-ADTInstallationProgress
                 # Call the underlying function to close the progress window.
                 Write-ADTLogEntry -Message 'Closing the installation progress dialog.'
                 Invoke-ADTClientServerOperation -CloseProgressDialog -User $runAsActiveUser
-                Remove-ADTModuleCallback -Hookpoint OnFinish -Callback $MyInvocation.MyCommand
+                Remove-ADTModuleCallback -Hookpoint OnFinish -Callback $Script:CommandTable.($MyInvocation.MyCommand.Name)
 
                 # We only send balloon tips when a session is active.
                 if (!$adtSession)

--- a/src/PSAppDeployToolkit/Public/Unblock-ADTAppExecution.ps1
+++ b/src/PSAppDeployToolkit/Public/Unblock-ADTAppExecution.ps1
@@ -75,7 +75,7 @@ function Unblock-ADTAppExecution
             try
             {
                 Unblock-ADTAppExecutionInternal @uaaeiParams -Verbose 4>&1 | Write-ADTLogEntry
-                Remove-ADTModuleCallback -Hookpoint OnFinish -Callback $MyInvocation.MyCommand
+                Remove-ADTModuleCallback -Hookpoint OnFinish -Callback $Script:CommandTable.($MyInvocation.MyCommand.Name)
             }
             catch
             {


### PR DESCRIPTION
The result of `$MyInvocation.MyCommand` is referentially different to what's obtained via `Get-Command` when used to populate the CommandTable during module import.