### PR TITLE
Tidy up app version printing in `Get-ADTApplication`/`Uninstall-ADTApplication`.

### DIFF
--- a/src/PSAppDeployToolkit/Public/Get-ADTApplication.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTApplication.ps1
@@ -288,7 +288,7 @@ function Get-ADTApplication
                     # Build out an object and return it to the pipeline if there's no filterscript or the filterscript returns something.
                     if (!$FilterScript -or (ForEach-Object -InputObject $app -Process $FilterScript -ErrorAction Ignore))
                     {
-                        Write-ADTLogEntry -Message "Found installed application [$($app.DisplayName)]$(if ($app.DisplayVersion) {" version [$($app.DisplayVersion)]"})."
+                        Write-ADTLogEntry -Message "Found installed application [$($app.DisplayName)$(if ($app.DisplayVersion -and !$app.DisplayName.Contains($app.DisplayVersion)) {" $($app.DisplayVersion)"})]."
                         $app
                     }
                 }

--- a/src/PSAppDeployToolkit/Public/Uninstall-ADTApplication.ps1
+++ b/src/PSAppDeployToolkit/Public/Uninstall-ADTApplication.ps1
@@ -273,7 +273,7 @@ function Uninstall-ADTApplication
                         Write-ADTLogEntry -Message "No ProductCode found for MSI application [$($removeApplication.DisplayName) $($removeApplication.DisplayVersion)]. Skipping removal."
                         continue
                     }
-                    Write-ADTLogEntry -Message "Removing MSI application [$($removeApplication.DisplayName) $($removeApplication.DisplayVersion)] with ProductCode [$($removeApplication.ProductCode.ToString('B'))]."
+                    Write-ADTLogEntry -Message "Removing MSI application [$($removeApplication.DisplayName)$(if ($removeApplication.DisplayVersion -and !$removeApplication.DisplayName.Contains($removeApplication.DisplayVersion)) { " $($removeApplication.DisplayVersion)" })] with ProductCode [$($removeApplication.ProductCode.ToString('B'))]."
                     try
                     {
                         if ($sampParams.ContainsKey('FilePath'))
@@ -300,7 +300,7 @@ function Uninstall-ADTApplication
                     }
                     else
                     {
-                        Write-ADTLogEntry -Message "No UninstallString found for EXE application [$($removeApplication.DisplayName) $($removeApplication.DisplayVersion)]. Skipping removal."
+                        Write-ADTLogEntry -Message "No UninstallString found for EXE application [$($removeApplication.DisplayName)$(if ($removeApplication.DisplayVersion -and !$removeApplication.DisplayName.Contains($removeApplication.DisplayVersion)) { " $($removeApplication.DisplayVersion)" })]. Skipping removal."
                         continue
                     }
                     $sapParams.FilePath = $removeApplication."$($uninstallProperty)FilePath"
@@ -343,7 +343,7 @@ function Uninstall-ADTApplication
                         }
                     }
 
-                    Write-ADTLogEntry -Message "Removing EXE application [$($removeApplication.DisplayName) $($removeApplication.DisplayVersion)]."
+                    Write-ADTLogEntry -Message "Removing EXE application [$($removeApplication.DisplayName)$(if ($removeApplication.DisplayVersion -and !$removeApplication.DisplayName.Contains($removeApplication.DisplayVersion)) { " $($removeApplication.DisplayVersion)" })]."
                     try
                     {
                         Start-ADTProcess @sapParams -ErrorAction $OriginalErrorAction


### PR DESCRIPTION
For some apps like the exe version of WinSCP, the version's in the display name.
```
[2025-09-13T14:46:47.0765197+10:00] [Uninstall] [Uninstall-ADTApplication] [Info] :: Removing EXE application [WinSCP 6.3.6 6.3.6].
```
vs
```
[2025-09-13T14:46:47.0765197+10:00] [Uninstall] [Uninstall-ADTApplication] [Info] :: Removing EXE application [WinSCP 6.3.6].
```