### PR TITLE
Added support for Link Descriptions in URL tags, as well as nested tags

### DIFF
--- a/src/PSADT/PSADT.UserInterface.TestHarness/Program.cs
+++ b/src/PSADT/PSADT.UserInterface.TestHarness/Program.cs
@@ -11,6 +11,7 @@ using PSADT.UserInterface.DialogOptions;
 using PSADT.UserInterface.DialogResults;
 using PSADT.UserInterface.Dialogs;
 using PSADT.UserInterface.DialogState;
+using System.Globalization;
 
 namespace PSADT.UserInterface.TestHarness
 {
@@ -74,7 +75,7 @@ namespace PSADT.UserInterface.TestHarness
 
             TimeSpan countdownDuration = TimeSpan.FromSeconds(580);
 
-            //string customMessageText = "Oh yeah. You can do [italic]italics[/italic] now. And [bold]bold text strings[/bold]. And [accent]accent colored text strings![/accent] This is a custom message that can be added using the [bold]-CustomText[/bold] parameter on [bold]Show-ADTInstallationWelcome[/bold] and [bold]Show-ADTInstallationRestartPrompt[/bold].";
+            string customMessageText = "You can find the security policy at [url]https://psappdeploytoolkit.com[/url]. But you can also find it [url=https://psappdeploytoolkit.com]at this URL description clickable link[/url]. And a side note, I know you've seen [italic]italics[/italic] now. And [bold]bold text strings[/bold]. And even [accent]accent colored text strings![/accent]. But have you seen [bold][italic]bold italics before? How about [accent]bold accent italics?[/accent][/italic][/bold].";
 
             uint deferralsRemaining = 3;
             DateTime deferralDeadline = DateTime.Parse("2025-09-20T13:00:00");
@@ -86,7 +87,7 @@ namespace PSADT.UserInterface.TestHarness
             TimeSpan restartCountdownDuration = TimeSpan.FromSeconds(80);
             TimeSpan restartCountdownNoMinimizeDuration = TimeSpan.FromSeconds(70);
 
-            string customDialogMessageText = "The installation requires you to have an exceptional amount of patience, as well an almost superhuman ability to not lose your temper. Given that you have not had much and seem to be super-cranky, are you sure you want to proceed? And don't forget to visit this website [url]https://psappdeploytoolkit.com[/url]";
+            string customDialogMessageText = "The installation requires you to have an exceptional amount of patience, as well an almost superhuman ability to not lose your temper. Given that you have not had much and seem to be super-cranky, are you sure you want to proceed? [bold]URL Formatting Tests:[/bold] Visit [url]https://psappdeploytoolkit.com[/url] or check our [url=https://github.com/PSAppDeployToolkit/PSAppDeployToolkit]GitHub Repository[/url] for support.";
 
             string inputDialogMessageText = "Enter the server name e.g. [italic]remotesvr1.psadt.ca[/italic]";
             string inputDialogTextBox = "YouCompleteMe";
@@ -114,7 +115,8 @@ namespace PSADT.UserInterface.TestHarness
                 { "CountdownDuration", countdownDuration },
                 { "DeferralsRemaining", deferralsRemaining },
                 { "DeferralDeadline", deferralDeadline },
-                //{ "CustomMessageText", customMessageText },
+                { "CustomMessageText", customMessageText },
+                { "Language", CultureInfo.CurrentCulture },
                 { "Strings", (Hashtable)stringTable["CloseAppsPrompt"]! },
             };
             var progressDialogOptions = new ProgressDialogOptions(new Hashtable
@@ -131,6 +133,7 @@ namespace PSADT.UserInterface.TestHarness
                 { "AppBannerImage", appBannerImage },
                 { "ProgressMessageText", progressMessageText },
                 { "ProgressDetailMessageText", progressDetailMessageText },
+                { "Language", CultureInfo.CurrentCulture },
                 { "AdditionalOption", true }
             });
             var customDialogOptions = new CustomDialogOptions(new Hashtable
@@ -151,6 +154,7 @@ namespace PSADT.UserInterface.TestHarness
                 { "ButtonRightText", ButtonRightText },
                 { "Icon", DialogSystemIcon.Information },
                 { "MinimizeWindows", false },
+                { "Language", CultureInfo.CurrentCulture },
                 { "MessageAlignment", DialogMessageAlignment.Left }
             });
 
@@ -172,6 +176,7 @@ namespace PSADT.UserInterface.TestHarness
                 { "ButtonRightText", inputDialogButtonRightText },
                 { "Icon", DialogSystemIcon.Information },
                 { "MinimizeWindows", false },
+                { "Language", CultureInfo.CurrentCulture },
                 { "MessageAlignment", DialogMessageAlignment.Left }
             })
             {
@@ -191,6 +196,7 @@ namespace PSADT.UserInterface.TestHarness
                 { "CountdownDuration", restartCountdownDuration },
                 { "CountdownNoMinimizeDuration", restartCountdownNoMinimizeDuration },
                 // { "CustomMessageText", customMessageText },
+                { "Language", CultureInfo.CurrentCulture },
                 { "Strings", (Hashtable)stringTable["RestartPrompt"]! },
             };
 

--- a/src/PSADT/PSADT.UserInterface/Dialogs/DialogTools.cs
+++ b/src/PSADT/PSADT.UserInterface/Dialogs/DialogTools.cs
@@ -22,17 +22,18 @@ namespace PSADT.UserInterface.Dialogs
         /// </summary>
         /// <remarks>This regular expression matches the following custom formatting tags: <list
         /// type="bullet"> <item> <description><c>[url]</c>: Matches a URL link enclosed in <c>[url]</c> and
-        /// <c>[/url]</c> tags.</description> </item> <item> <description><c>[accent]</c>: Matches text enclosed in
-        /// <c>[accent]</c> and <c>[/accent]</c> tags.</description> </item> <item> <description><c>[bold]</c>: Matches
-        /// text enclosed in <c>[bold]</c> and <c>[/bold]</c> tags.</description> </item> <item>
-        /// <description><c>[italic]</c>: Matches text enclosed in <c>[italic]</c> and <c>[/italic]</c>
-        /// tags.</description> </item> </list> The regular expression is compiled for improved performance during
-        /// repeated use.</remarks>
+        /// <c>[/url]</c> tags.</description> </item> <item> <description><c>[accent]</c>, <c>[bold]</c>, <c>[italic]</c>:
+        /// Matches opening and closing tags for accent, bold, and italic formatting. These tags can be nested and combined
+        /// for cumulative formatting effects.</description> </item> </list> The regular expression is compiled for improved
+        /// performance during repeated use and supports nested tag combinations.</remarks>
         internal static readonly Regex TextFormattingRegex = new(
             @"(?<UrlLink>\[url\](?<UrlLinkContent>.+?)\[/url\])" + @"|" +
-            @"(?<Accent>\[accent\](?<AccentText>.+?)\[/accent\])" + @"|" +
-            @"(?<Bold>\[bold\](?<BoldText>.+?)\[/bold\])" + @"|" +
-            @"(?<Italic>\[italic\](?<ItalicText>.+?)\[/italic\])",
+            @"(?<OpenAccent>\[accent\])" + @"|" +
+            @"(?<CloseAccent>\[/accent\])" + @"|" +
+            @"(?<OpenBold>\[bold\])" + @"|" +
+            @"(?<CloseBold>\[/bold\])" + @"|" +
+            @"(?<OpenItalic>\[italic\])" + @"|" +
+            @"(?<CloseItalic>\[/italic\])",
             RegexOptions.Compiled);
     }
 }

--- a/src/PSADT/PSADT.UserInterface/Dialogs/DialogTools.cs
+++ b/src/PSADT/PSADT.UserInterface/Dialogs/DialogTools.cs
@@ -21,13 +21,15 @@ namespace PSADT.UserInterface.Dialogs
         /// [url], [accent], [bold], and [italic].
         /// </summary>
         /// <remarks>This regular expression matches the following custom formatting tags: <list
-        /// type="bullet"> <item> <description><c>[url]</c>: Matches a URL link enclosed in <c>[url]</c> and
-        /// <c>[/url]</c> tags.</description> </item> <item> <description><c>[accent]</c>, <c>[bold]</c>, <c>[italic]</c>:
-        /// Matches opening and closing tags for accent, bold, and italic formatting. These tags can be nested and combined
-        /// for cumulative formatting effects.</description> </item> </list> The regular expression is compiled for improved
-        /// performance during repeated use and supports nested tag combinations.</remarks>
+        /// type="bullet"> <item> <description><c>[url]</c>: Matches URL links in two formats: <c>[url]URL[/url]</c> for
+        /// simple links, and <c>[url=URL]Description[/url]</c> for descriptive links.</description> </item> <item>
+        /// <description><c>[accent]</c>, <c>[bold]</c>, <c>[italic]</c>: Matches opening and closing tags for accent,
+        /// bold, and italic formatting. These tags can be nested and combined for cumulative formatting effects.</description>
+        /// </item> </list> The regular expression is compiled for improved performance during repeated use and supports
+        /// nested tag combinations.</remarks>
         internal static readonly Regex TextFormattingRegex = new(
-            @"(?<UrlLink>\[url\](?<UrlLinkContent>.+?)\[/url\])" + @"|" +
+            @"(?<UrlLinkSimple>\[url\](?<UrlLinkSimpleContent>.+?)\[/url\])" + @"|" +
+            @"(?<UrlLinkDescriptive>\[url=(?<UrlLinkUrl>[^\]]+)\](?<UrlLinkDescription>.+?)\[/url\])" + @"|" +
             @"(?<OpenAccent>\[accent\])" + @"|" +
             @"(?<CloseAccent>\[/accent\])" + @"|" +
             @"(?<OpenBold>\[bold\])" + @"|" +

--- a/src/PSADT/PSADT.UserInterface/Dialogs/Fluent/FluentDialog.xaml.cs
+++ b/src/PSADT/PSADT.UserInterface/Dialogs/Fluent/FluentDialog.xaml.cs
@@ -376,9 +376,13 @@ namespace PSADT.UserInterface.Dialogs.Fluent
         /// <param name="formattingStack">The current formatting context stack.</param>
         private void ProcessFormattingTag(TextBlock textBlock, Match match, Stack<FormattingContext> formattingStack)
         {
-            if (match.Groups["UrlLink"].Success)
+            if (match.Groups["UrlLinkSimple"].Success)
             {
-                ProcessUrlLink(textBlock, match.Groups["UrlLinkContent"].Value);
+                ProcessUrlLink(textBlock, match.Groups["UrlLinkSimpleContent"].Value, match.Groups["UrlLinkSimpleContent"].Value);
+            }
+            else if (match.Groups["UrlLinkDescriptive"].Success)
+            {
+                ProcessUrlLink(textBlock, match.Groups["UrlLinkUrl"].Value, match.Groups["UrlLinkDescription"].Value);
             }
             else if (match.Groups["OpenAccent"].Success)
             {
@@ -474,11 +478,12 @@ namespace PSADT.UserInterface.Dialogs.Fluent
 
 
         /// <summary>
-        /// Creates a hyperlink with the specified URL.
+        /// Creates a hyperlink with the specified URL and display text.
         /// </summary>
-        /// <param name="textBlock"></param>
-        /// <param name="url"></param>
-        private void ProcessUrlLink(TextBlock textBlock, string url)
+        /// <param name="textBlock">The TextBlock to add the hyperlink to.</param>
+        /// <param name="url">The URL to navigate to when clicked.</param>
+        /// <param name="displayText">The text to display for the hyperlink.</param>
+        private void ProcessUrlLink(TextBlock textBlock, string url, string displayText)
         {
             // Ensure the URL has a scheme for Process.Start
             string navigateUrl = url;
@@ -494,7 +499,7 @@ namespace PSADT.UserInterface.Dialogs.Fluent
             // Add the URL as a proper hyperlink
             if (!AccountUtilities.CallerIsSystemInteractive && Uri.TryCreate(navigateUrl, UriKind.Absolute, out var uri))
             {
-                Hyperlink link = new(new Run(url))
+                Hyperlink link = new(new Run(displayText))
                 {
                     NavigateUri = uri,
                     ToolTip = $"Open link: {url}"
@@ -505,7 +510,7 @@ namespace PSADT.UserInterface.Dialogs.Fluent
             else
             {
                 // If it's not a valid URI, just add as plain text
-                textBlock.Inlines.Add(url);
+                textBlock.Inlines.Add(displayText);
             }
         }
 


### PR DESCRIPTION
- Added support for providing a Link Description when specifying a URL tag. This is done using the same method as BBCode - the format is: [url=https://mysite.com]MySite Description[/url]. Addresses #1639 
- This allows for richer formatting options in dialogs, and remains backwards compatible with the existing [url]https://mysite.com[/url] tag.
- Updated text formatting logic to support nested and combined tags for accent, bold, and italic styles. Addresses second part of #1639 
- Brought back CustomText as a way to test each tag type and nested tags in the Test Harness.
- Fixed issue in Test Harness caused by introduction of Language parameter to Dialogs (to support RTL text).
