### PR TITLE
Test whether an app is an is an MSI app based on UninstallString, in addition to the WindowsInstaller bool.

### DIFF
--- a/src/PSAppDeployToolkit/Public/Get-ADTApplication.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTApplication.ps1
@@ -232,21 +232,13 @@ function Get-ADTApplication
                     }
 
                     # Build hashtable of calculated properties based on their presence in the registry and the value's validity.
-                    $appProperties = 'DisplayVersion', 'UninstallString', 'QuietUninstallString', 'Publisher', 'EstimatedSize' | & {
-                        begin
-                        {
-                            $collector = @{}
-                        }
+                    $appProperties = @{}; 'DisplayVersion', 'UninstallString', 'QuietUninstallString', 'Publisher', 'EstimatedSize' | & {
                         process
                         {
                             if (![System.String]::IsNullOrWhiteSpace(($value = $item.GetValue($_, $null))))
                             {
-                                $collector.Add($_, $value)
+                                $appProperties.Add($_, $value)
                             }
-                        }
-                        end
-                        {
-                            return $collector
                         }
                     }
 

--- a/src/PSAppDeployToolkit/Public/Get-ADTApplication.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTApplication.ps1
@@ -166,6 +166,9 @@ function Get-ADTApplication
                 }
             }
         }
+
+        # Define compiled regex for use throughout main loop.
+        $updatesAndHotFixesRegex = [System.Text.RegularExpressions.Regex]::new('((?i)kb\d+|(Cumulative|Security) Update|Hotfix)', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase -bor [System.Text.RegularExpressions.RegexOptions]::Compiled)
     }
 
     process
@@ -196,7 +199,7 @@ function Get-ADTApplication
                     }
 
                     # Bypass any updates or hotfixes.
-                    if (!$IncludeUpdatesAndHotfixes -and ($appDisplayName -match '((?i)kb\d+|(Cumulative|Security) Update|Hotfix)'))
+                    if (!$IncludeUpdatesAndHotfixes -and $updatesAndHotFixesRegex.Matches($appDisplayName).Count)
                     {
                         $updatesSkippedCounter++
                         continue

--- a/src/PSAppDeployToolkit/Public/Get-ADTApplication.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTApplication.ps1
@@ -212,7 +212,8 @@ function Get-ADTApplication
                     }
 
                     # Apply application type filter if specified.
-                    $windowsInstaller = $item.GetValue('WindowsInstaller', $false)
+                    $uninstallString = $item.GetValue('UninstallString', $null); $quietUninstallString = $item.GetValue('QuietUninstallString', $null)
+                    $windowsInstaller = $item.GetValue('WindowsInstaller', $false) -or ($uninstallString -match 'msiexec') -or ($quietUninstallString -match 'msiexec')
                     if ((($ApplicationType -eq 'MSI') -and !$windowsInstaller) -or (($ApplicationType -eq 'EXE') -and $windowsInstaller))
                     {
                         continue
@@ -232,7 +233,7 @@ function Get-ADTApplication
                     }
 
                     # Build hashtable of calculated properties based on their presence in the registry and the value's validity.
-                    $appProperties = @{}; 'DisplayVersion', 'UninstallString', 'QuietUninstallString', 'Publisher', 'EstimatedSize' | & {
+                    $appProperties = @{}; 'DisplayVersion', 'Publisher', 'EstimatedSize' | & {
                         process
                         {
                             if (![System.String]::IsNullOrWhiteSpace(($value = $item.GetValue($_, $null))))
@@ -267,8 +268,8 @@ function Get-ADTApplication
                         $appMsiGuid,
                         $appDisplayName,
                         $appProperties['DisplayVersion'],
-                        $appProperties['UninstallString'],
-                        $appProperties['QuietUninstallString'],
+                        $uninstallString,
+                        $quietUninstallString,
                         $appProperties['InstallSource'],
                         $appProperties['InstallLocation'],
                         $installDate,

--- a/src/PSAppDeployToolkit/Public/Get-ADTApplication.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTApplication.ps1
@@ -202,6 +202,12 @@ function Get-ADTApplication
                         continue
                     }
 
+                    # Apply name filter if specified.
+                    if ($nameFilterScript -and !(& $nameFilterScript))
+                    {
+                        continue
+                    }
+
                     # Apply application type filter if specified.
                     $windowsInstaller = $item.GetValue('WindowsInstaller', $false)
                     if ((($ApplicationType -eq 'MSI') -and !$windowsInstaller) -or (($ApplicationType -eq 'EXE') -and $windowsInstaller))
@@ -212,12 +218,6 @@ function Get-ADTApplication
                     # Apply ProductCode filter if specified.
                     $appMsiGuid = if ($windowsInstaller -and [System.Guid]::TryParse($item.PSChildName, [ref]$defaultGuid)) { $defaultGuid }
                     if ($ProductCode -and (!$appMsiGuid -or ($ProductCode -notcontains $appMsiGuid)))
-                    {
-                        continue
-                    }
-
-                    # Apply name filter if specified.
-                    if ($nameFilterScript -and !(& $nameFilterScript))
                     {
                         continue
                     }


### PR DESCRIPTION
Apparently there's MSI-based apps out there which don't set this correctly: https://discourse.psappdeploytoolkit.com/t/msi-uninstallation-not-working-in-v4-1-5/6947/7