### PR TITLE
Explicitly call `.ToString()` for TargetName within `New-ADTValidateScriptErrorRecord` as some types won't implicitly do this.

### DIFF
--- a/src/PSAppDeployToolkit/Public/New-ADTValidateScriptErrorRecord.ps1
+++ b/src/PSAppDeployToolkit/Public/New-ADTValidateScriptErrorRecord.ps1
@@ -89,7 +89,7 @@ function New-ADTValidateScriptErrorRecord
         Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
         ErrorId = "Invalid$($ParameterName)ParameterValue"
         TargetObject = $ProvidedValue
-        TargetName = $ProvidedValue
+        TargetName = $ProvidedValue.ToString()
         TargetType = $(if ($null -ne $ProvidedValue) { $ProvidedValue.GetType().Name })
         RecommendedAction = "Review the supplied $($ParameterName) parameter value and try again."
     }


### PR DESCRIPTION
Resolves https://discord.com/channels/618712310185197588/627204361545842688/1418245355081957406.

Before
```
PS C:\Repos\PSAppDeployToolkit\src> & .\PSAppDeployToolkit\Frontend\v4\Invoke-AppDeployToolkit.ps1
New-ADTValidateScriptErrorRecord : Cannot process argument transformation on parameter 'TargetName'. Cannot convert value to type System.String.
At C:\Repos\PSAppDeployToolkit\src\PSAppDeployToolkit\Public\Open-ADTSession.ps1:375 char:46
+ ... atingError((New-ADTValidateScriptErrorRecord -ParameterName AppProces ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [New-ADTValidateScriptErrorRecord], ParameterBindingArgumentTransformationException
    + FullyQualifiedErrorId : ParameterArgumentTransformationError,New-ADTValidateScriptErrorRecord
```
After
```
PS C:\Repos\PSAppDeployToolkit\src> & .\PSAppDeployToolkit\Frontend\v4\Invoke-AppDeployToolkit.ps1
Open-ADTSession : The specified AppProcessesToClose array contains duplicate processes.
Parameter name: AppProcessesToClose
At C:\Repos\PSAppDeployToolkit\src\PSAppDeployToolkit\Frontend\v4\Invoke-AppDeployToolkit.ps1:313 char:19
+     $adtSession = Open-ADTSession @adtSession @iadtParams -PassThru
+                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (PSADT.ProcessMa...essDefinition[]:ProcessDefinition[]) [Open-ADTSession], ArgumentException
    + FullyQualifiedErrorId : InvalidAppProcessesToCloseParameterValue,Open-ADTSession
```