### PR TITLE
Properly test for `$adtSession.DirFiles` availability within `Start-ADTMsiProcess` and `Start-ADTMspProcess`.

### DIFF
--- a/src/PSAppDeployToolkit/Public/Start-ADTMsiProcess.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTMsiProcess.ps1
@@ -419,7 +419,6 @@ function Start-ADTMsiProcess
                         }
                         else
                         {
-                            Write-ADTLogEntry -Message "Failed to find the file [$FilePath]." -Severity 3
                             $naerParams = @{
                                 Exception = [System.IO.FileNotFoundException]::new("Failed to find the file [$FilePath].")
                                 Category = [System.Management.Automation.ErrorCategory]::ObjectNotFound

--- a/src/PSAppDeployToolkit/Public/Start-ADTMsiProcess.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTMsiProcess.ps1
@@ -413,7 +413,7 @@ function Start-ADTMsiProcess
                         {
                             (Get-Item -LiteralPath $FilePath).FullName
                         }
-                        elseif ($adtSession -and (Test-Path -LiteralPath ($dirFilesPath = (Join-Path -Path $adtSession.DirFiles -ChildPath $FilePath).Trim()) -PathType Leaf))
+                        elseif ($adtSession -and ![System.String]::IsNullOrWhiteSpace($adtSession.DirFiles) -and (Test-Path -LiteralPath ($dirFilesPath = (Join-Path -Path $adtSession.DirFiles -ChildPath $FilePath).Trim()) -PathType Leaf))
                         {
                             $dirFilesPath
                         }

--- a/src/PSAppDeployToolkit/Public/Start-ADTMspProcess.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTMspProcess.ps1
@@ -128,7 +128,7 @@ function Start-ADTMspProcess
             try
             {
                 # If the MSP is in the Files directory, set the full path to the MSP.
-                $mspFile = if ($adtSession -and (Test-Path -LiteralPath ($dirFilesPath = (Join-Path -Path $adtSession.DirFiles -ChildPath $FilePath).Trim()) -PathType Leaf))
+                $mspFile = if ($adtSession -and ![System.String]::IsNullOrWhiteSpace($adtSession.DirFiles) -and (Test-Path -LiteralPath ($dirFilesPath = (Join-Path -Path $adtSession.DirFiles -ChildPath $FilePath).Trim()) -PathType Leaf))
                 {
                     $dirFilesPath
                 }

--- a/src/PSAppDeployToolkit/Public/Start-ADTMspProcess.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTMspProcess.ps1
@@ -138,11 +138,10 @@ function Start-ADTMspProcess
                 }
                 else
                 {
-                    Write-ADTLogEntry -Message "Failed to find MSP file [$FilePath]." -Severity 3
                     $naerParams = @{
                         Exception = [System.IO.FileNotFoundException]::new("Failed to find MSP file [$FilePath].")
                         Category = [System.Management.Automation.ErrorCategory]::ObjectNotFound
-                        ErrorId = 'MsiFileNotFound'
+                        ErrorId = 'MspFileNotFound'
                         TargetObject = $FilePath
                         RecommendedAction = "Please confirm the path of the MSP file and try again."
                     }


### PR DESCRIPTION
Fixes #1779.