### PR TITLE
Change MinimizeWindows from switch to boolean in Show-InstallationPrompt wrapper

### DIFF
--- a/src/PSAppDeployToolkit/Frontend/v3/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/src/PSAppDeployToolkit/Frontend/v3/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1099,7 +1099,7 @@ function Show-InstallationPrompt
         [System.Management.Automation.SwitchParameter]$PersistPrompt,
 
         [Parameter(Mandatory = $false)]
-        [System.Management.Automation.SwitchParameter]$MinimizeWindows,
+        [System.Boolean]$MinimizeWindows = $false,
 
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]


### PR DESCRIPTION
MinimizeWindows is a switch in Show-InstallationWelcome, but actually a boolean in Show-InstallationPrompt. This corrects the wrapper param block to match the actual v3 function.