### PR TITLE
Add missing `-ErrorRecord` value against `Invoke-ADTFunctionErrorHandler` in `Set-ADTServiceStartMode`.

### DIFF
--- a/src/PSAppDeployToolkit/Public/Set-ADTServiceStartMode.ps1
+++ b/src/PSAppDeployToolkit/Public/Set-ADTServiceStartMode.ps1
@@ -110,7 +110,7 @@ function Set-ADTServiceStartMode
         }
         catch
         {
-            Invoke-ADTFunctionErrorHandler -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+            Invoke-ADTFunctionErrorHandler -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState -ErrorRecord $_
         }
     }
 


### PR DESCRIPTION
Fixes #1787.