### PR TITLE
Fix parameter set grouping for `-Description` in `Set-ADTActiveSetup`.

### DIFF
--- a/src/PSAppDeployToolkit/Public/Set-ADTActiveSetup.ps1
+++ b/src/PSAppDeployToolkit/Public/Set-ADTActiveSetup.ps1
@@ -183,6 +183,7 @@ function Set-ADTActiveSetup
         $paramDictionary.Add('Description', [System.Management.Automation.RuntimeDefinedParameter]::new(
                 'Description', [System.String], $(
                     [System.Management.Automation.ParameterAttribute]@{ Mandatory = !$adtSession; HelpMessage = 'Description for the Active Setup. Users will see "Setting up personalized settings for: $Description" at logon. Defaults to active session InstallName.'; ParameterSetName = 'Create' }
+                    [System.Management.Automation.ParameterAttribute]@{ Mandatory = !$adtSession; HelpMessage = 'Description for the Active Setup. Users will see "Setting up personalized settings for: $Description" at logon. Defaults to active session InstallName.'; ParameterSetName = 'CreateNoExecute' }
                     [System.Management.Automation.ValidateNotNullOrEmptyAttribute]::new()
                 )
             ))


### PR DESCRIPTION
Fixes #1786.