### PR TITLE
Update installation prompt message in Slovak

### DIFF
--- a/src/PSAppDeployToolkit/Strings/sk/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/sk/strings.psd1
@@ -130,7 +130,7 @@
                 Uninstall = 'Pred pokračovaním uložte svoju prácu, pretože nasledujúce aplikácie budú automaticky ukončené.'
             }
             DialogMessageNoProcesses = @{
-                Install = 'Prosím, vyberte Install, aby ste mohli pokračovať v inštalácii.'
+                Install = 'Prosím, vyberte Install (Inštalovať), aby ste mohli pokračovať v inštalácii.'
                 Repair = 'Prosím, vyberte Repair (Opraviť), ak chcete pokračovať v oprave.'
                 Uninstall = 'Vyberte Uninstall (Odinštalovať), ak chcete pokračovať v odinštalovaní.'
             }


### PR DESCRIPTION
Following the analogy of having "action" word in the sentence in English and (Slovak) in brackets, like on the 2 below lines for actions Repair(line134) and Uninstall(line135).  The install should be the same.