### PR TITLE
Fix return type for `Get-ADTUserNotificationState`.

### DIFF
--- a/src/PSAppDeployToolkit/Public/Get-ADTUserNotificationState.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTUserNotificationState.ps1
@@ -41,6 +41,7 @@ function Get-ADTUserNotificationState
     #>
 
     [CmdletBinding()]
+    [OutputType([PSADT.LibraryInterfaces.QUERY_USER_NOTIFICATION_STATE])]
     param
     (
     )
@@ -65,7 +66,7 @@ function Get-ADTUserNotificationState
             try
             {
                 Write-ADTLogEntry -Message "Detected user notification state [$(($UserNotificationState = Invoke-ADTClientServerOperation -GetUserNotificationState -User $runAsActiveUser))]."
-                return $UserNotificationState
+                return [PSADT.LibraryInterfaces.QUERY_USER_NOTIFICATION_STATE]$UserNotificationState
             }
             catch
             {


### PR DESCRIPTION
Enum type didn't survive the serialisation round trip.