### PR TITLE
Parallelize code signing

### DIFF
--- a/src/PSAppDeployToolkit.build.ps1
+++ b/src/PSAppDeployToolkit.build.ps1
@@ -815,10 +815,8 @@ Add-BuildTask Build {
             throw 'AzureSignTool not found.'
         }
         Write-Build Gray '        Signing module...'
-        Get-ChildItem -Path $Script:BuildModuleRoot -Include '*.ps*1', 'PSADT*.dll', 'PSADT*.exe', 'iNKORE.UI.WPF*.dll', 'Deploy-Application.exe', 'Invoke-AppDeployToolkit.exe' -Recurse | ForEach-Object {
-            & azuresigntool sign -s -kvu https://psadt-kv-prod-codesign.vault.azure.net -kvc PSADT -kvm -tr http://timestamp.digicert.com -td sha256 "$_"
-            if ($LASTEXITCODE -ne 0) { throw "Failed to sign file `"$_`". Exit code: $LASTEXITCODE" }
-        }
+        Get-ChildItem -Path $Script:BuildModuleRoot -Include '*.ps*1', 'PSADT*.dll', 'PSADT*.exe', 'iNKORE.UI.WPF*.dll', 'Deploy-Application.exe', 'Invoke-AppDeployToolkit.exe' -Recurse | Select-Object -ExpandProperty FullName | Out-File "FilesToSign.txt"
+        & azuresigntool sign -s -kvu https://psadt-kv-prod-codesign.vault.azure.net -kvc PSADT -kvm -tr http://timestamp.digicert.com -td sha256 -ifl FilesToSign.txt
     }
     else
     {


### PR DESCRIPTION
Code signing in CI currently takes ~9 minutes, likely because it's signing each file synchronously. Let's use AzureSignTool's native parallelism to try and speed it up

Untested, but I've used a similar pattern elsewhere