### PR TITLE
Start-ADTMsiProcess: Check if $msiDefaultParams exist before adding t…

### DIFF
--- a/src/PSAppDeployToolkit/Public/Start-ADTMsiProcess.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTMsiProcess.ps1
@@ -724,7 +724,7 @@ function Start-ADTMsiProcess
                         $msiArgs.AddRange($ArgumentList)
                     }
                 }
-                else
+                elseif (![System.String]::IsNullOrWhiteSpace($msiDefaultParams))
                 {
                     $msiArgs.AddRange([PSADT.ProcessManagement.CommandLineUtilities]::CommandLineToArgumentList($msiDefaultParams))
                 }


### PR DESCRIPTION
# Pull Request

## Description

Implement fix as suggested in linked issue.

Fixes #1955

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **develop** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested my changes to prove my fix is effective
- [ ] I have tested that the module can build following my changes
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

I only ran the local tests via the VSCode task to ensure I didn't break anything. Since I couldn't get the build to work and I lack the expertise to debug C#/.NET build errors, I couldn't test the fix, but it should be the correct approach. If you can provide more specific build instructions I may try again.

### Build errors
```
Task /./DotNetBuild : Compile our defined C# solutions.
At D:\PSAppDeployToolkit\src\PSAppDeployToolkit.build.ps1:270
Manifest File: D:\PSAppDeployToolkit\src\PSAppDeployToolkit\PSAppDeployToolkit.psd1
Manifest Version: 4.2.0
      Compiling C# projects...
        Determining C# solutions requiring compilation...
          No files have been modified in src\PSADT since the last commit date of src\PSAppDeployToolkit\lib\PSADT.ClientServer.Client.Launcher.exe (2025-12-27T17:25:36+01:00), debug build not required.
          No files have been modified in src\PSADT since the last commit date of src\PSAppDeployToolkit\lib\PSADT.ClientServer.Client.exe (2025-12-27T17:25:36+01:00), debug build not required.
          No files have been modified in src\PSADT since the last commit date of src\PSAppDeployToolkit\lib\PSADT.ClientServer.Server.dll (2025-12-27T17:25:36+01:00), debug build not required.
          No files have been modified in src\PSADT since the last commit date of src\PSAppDeployToolkit\lib\PSADT.dll (2025-12-27T17:25:36+01:00), debug build not required.
          No files have been modified in src\PSADT since the last commit date of src\PSAppDeployToolkit\lib\PSADT.UserInterface.dll (2025-12-27T17:25:36+01:00), debug build not required.
          No files have been modified in src\PSADT since the last commit date of src\PSAppDeployToolkit\lib\PSAppDeployToolkit.dll (2025-12-27T17:25:36+01:00), debug build not required.
            Removing previous bin and obj folders from src\PSADT...
            Building D:\PSAppDeployToolkit\src\PSADT\PSADT.slnx...
Wiederherstellung abgeschlossen (2,8s)
  iNKORE.UI.WPF net472 Erfolgreich (6,4s) → D:\PSAppDeployToolkit\lib\iNKORE.UI.WPF\source\iNKORE.UI.WPF\bin\Release\net472\iNKORE.UI.WPF.dll    
  iNKORE.UI.WPF net8.0-windows Erfolgreich (7,3s) → D:\PSAppDeployToolkit\lib\iNKORE.UI.WPF\source\iNKORE.UI.WPF\bin\Release\net8.0-windows\iNKORE.UI.WPF.dll
  PSADT.LibraryInterfaces net472 Erfolgreich (11,1s) → PSADT\PSADT.LibraryInterfaces\bin\Release\net472\PSADT.LibraryInterfaces.dll
  PSADT.LibraryInterfaces net8.0-windows10.0.18362.0 Erfolgreich (12,0s) → PSADT\PSADT.LibraryInterfaces\bin\Release\net8.0-windows10.0.18362.0\PSADT.LibraryInterfaces.dll
  iNKORE.UI.WPF.Modern net8.0-windows10.0.18362.0 Erfolgreich (17,7s) → D:\PSAppDeployToolkit\lib\iNKORE.UI.WPF.Modern\source\iNKORE.UI.WPF.Modern\bin\Release\net8.0-windows10.0.18362.0\iNKORE.UI.WPF.Modern.dll
  iNKORE.UI.WPF.Modern net472 Erfolgreich (18,4s) → D:\PSAppDeployToolkit\lib\iNKORE.UI.WPF.Modern\source\iNKORE.UI.WPF.Modern\bin\Release\net472\iNKORE.UI.WPF.Modern.dll
  PSADT net472 fehlerhaft mit 18 Fehler(n) (15,5s)                                                                                               
    D:\PSAppDeployToolkit\src\PSADT\PSADT\FileSystem\ExecutableInfo.cs(36,28): error CS1929: "byte[]" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<T>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".                                                                                                                  
    D:\PSAppDeployToolkit\src\PSADT\PSADT\FileSystem\FileHandleManager.cs(187,58): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<OBJECT_TYPES_INFORMATION>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\FileSystem\FileHandleManager.cs(193,60): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<OBJECT_TYPE_INFORMATION>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\ProcessManagement\ProcessVersionInfo.cs(172,39): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<HMODULE>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\ProcessManagement\ProcessManager.cs(631,74): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\ProcessManagement\ProcessUtilities.cs(223,60): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<SERVICE_STATUS_PROCESS>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\ProcessManagement\ProcessUtilities.cs(242,53): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<PROCESS_BASIC_INFORMATION>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\ProcessManagement\ProcessUtilities.cs(322,52): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<UNICODE_STRING>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\ProcessManagement\ProcessUtilities.cs(346,67): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<SYSTEM_PROCESS_ID_INFORMATION>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\Security\TokenManager.cs(26,54): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<TOKEN_ELEVATION>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\Security\TokenManager.cs(68,59): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<TOKEN_LINKED_TOKEN>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\Security\TokenManager.cs(140,44): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<TOKEN_USER>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\Security\PrivilegeManager.cs(69,56): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<TOKEN_PRIVILEGES>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\Security\PrivilegeManager.cs(79,56): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<LUID_AND_ATTRIBUTES>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\Security\PrivilegeManager.cs(90,56): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<LUID_AND_ATTRIBUTES>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\FileSystem\FileHandleManager.cs(232,67): error CS1929: "byte[]" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<SYSTEM_HANDLE_INFORMATION_EX>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\FileSystem\FileHandleManager.cs(239,75): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\FileSystem\FileHandleManager.cs(239,95): error CS1503: Argument "2": Konvertierung von "long" in "int" nicht möglich.
  PSADT net8.0-windows10.0.18362.0 fehlerhaft mit 18 Fehler(n) (14,7s)
    D:\PSAppDeployToolkit\src\PSADT\PSADT\FileSystem\ExecutableInfo.cs(36,28): error CS1929: "byte[]" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<T>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\FileSystem\FileHandleManager.cs(187,58): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<OBJECT_TYPES_INFORMATION>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\FileSystem\FileHandleManager.cs(193,60): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<OBJECT_TYPE_INFORMATION>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\ProcessManagement\ProcessVersionInfo.cs(172,39): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<HMODULE>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\FileSystem\FileHandleManager.cs(232,67): error CS1929: "byte[]" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<SYSTEM_HANDLE_INFORMATION_EX>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\FileSystem\FileHandleManager.cs(239,75): error CS1929: "byte[]" enthält keine Definition für "AsSpan", und die Überladung der optimalen Erweiterungsmethode "MemoryExtensions.AsSpan(string?, int)" erfordert einen Empfänger vom Typ "string?".        
    D:\PSAppDeployToolkit\src\PSADT\PSADT\FileSystem\FileHandleManager.cs(239,75): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\ProcessManagement\ProcessUtilities.cs(223,60): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<SERVICE_STATUS_PROCESS>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\ProcessManagement\ProcessUtilities.cs(242,53): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<PROCESS_BASIC_INFORMATION>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\ProcessManagement\ProcessUtilities.cs(322,52): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<UNICODE_STRING>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\ProcessManagement\ProcessUtilities.cs(346,67): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<SYSTEM_PROCESS_ID_INFORMATION>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\Security\TokenManager.cs(26,54): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<TOKEN_ELEVATION>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\Security\TokenManager.cs(68,59): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<TOKEN_LINKED_TOKEN>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\Security\TokenManager.cs(140,44): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<TOKEN_USER>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\Security\PrivilegeManager.cs(69,56): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<TOKEN_PRIVILEGES>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\Security\PrivilegeManager.cs(79,56): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<LUID_AND_ATTRIBUTES>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\Security\PrivilegeManager.cs(90,56): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<LUID_AND_ATTRIBUTES>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
    D:\PSAppDeployToolkit\src\PSADT\PSADT\ProcessManagement\ProcessManager.cs(631,74): error CS1929: "Span<byte>" enthält keine Definition für "AsStructure", und die Überladung der optimalen Erweiterungsmethode "ReadOnlySpanExtensions.AsStructure<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>(ReadOnlySpan<byte>)" erfordert einen Empfänger vom Typ "System.ReadOnlySpan<byte>".
  iNKORE.UI.WPF.Modern.Controls net472 Erfolgreich (25,4s) → D:\PSAppDeployToolkit\lib\iNKORE.UI.WPF.Modern\source\iNKORE.UI.WPF.Modern.Controls\bin\Release\net472\iNKORE.UI.WPF.Modern.Controls.dll
  iNKORE.UI.WPF.Modern.Controls net8.0-windows10.0.18362.0 Erfolgreich (27,6s) → D:\PSAppDeployToolkit\lib\iNKORE.UI.WPF.Modern\source\iNKORE.UI.WPF.Modern.Controls\bin\Release\net8.0-windows10.0.18362.0\iNKORE.UI.WPF.Modern.Controls.dll

Erstellen von fehlerhaft mit 36 Fehler(n) in 59,4s
ERROR: Failed to build solution "PSADT.slnx". Exit code: 1
At D:\PSAppDeployToolkit\src\PSAppDeployToolkit.build.ps1:326 char:34
+ … EXITCODE) { throw "Failed to build solution `"$($buildItem.SolutionPa …
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
At D:\PSAppDeployToolkit\src\PSAppDeployToolkit.build.ps1:270 char:1
+ Add-BuildTask DotNetBuild {
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~
Build FAILED. 5 tasks, 1 errors, 0 warnings 00:01:01.8595837
Exception: D:\PSAppDeployToolkit\src\PSAppDeployToolkit.build.ps1:326:34
Line |
 326 |  … EXITCODE) { throw "Failed to build solution `"$($buildItem.SolutionPa …
     |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Failed to build solution "PSADT.slnx". Exit code: 1
```