### PR TITLE
Add package manifest parser

### DIFF
--- a/src/PSADT/PSADT/Types/PackageManifestInfo.cs
+++ b/src/PSADT/PSADT/Types/PackageManifestInfo.cs
@@ -1,0 +1,144 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace PSADT.Types
+{
+    /// <summary>
+    /// Contains information parsed from a package manifest.
+    /// </summary>
+    public sealed record PackageManifestInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PackageManifestInfo"/> struct.
+        /// </summary>
+        /// <param name="name">The name of the package.</param>
+        /// <param name="version">The version of the package.</param>
+        /// <param name="architecture">The architecture of the package.</param>
+        /// <param name="resourceId">The resource ID of the package.</param>
+        /// <param name="publisherId">The publisher ID of the package.</param>
+        /// <param name="publisherDn">The distinguished name of the publisher.</param>
+        /// <param name="displayName">The display name of the package.</param>
+        /// <param name="publisherDisplayName">The display name of the publisher.</param>
+        /// <param name="description">The description of the package.</param>
+        /// <param name="isFramework">Indicates whether the package is a framework.</param>
+        /// <param name="isResource">Indicates whether the package is a resource.</param>
+        /// <param name="isBundle">Indicates whether the package is a bundle.</param>
+        /// <param name="bundledApplications">The applications bundled within the package.</param>
+        /// <param name="bundledResources">The resources bundled within the package.</param>
+        public PackageManifestInfo(
+            string name,
+            string version,
+            string architecture,
+            string resourceId,
+            string publisherId,
+            string publisherDn,
+            string displayName,
+            string publisherDisplayName,
+            string description,
+            bool isFramework,
+            bool isResource,
+            bool isBundle,
+            IList<string> bundledApplications,
+            IList<string> bundledResources)
+        {
+            Name = name;
+            Version = version;
+            Architecture = architecture;
+            ResourceId = resourceId;
+            PublisherId = publisherId;
+
+            FullName = $"{name}_{version}_{architecture}_{resourceId}_{publisherId}";
+            FamilyName = $"{name}_{publisherId}";
+
+            PublisherDn = publisherDn;
+            DisplayName = displayName;
+            PublisherDisplayName = publisherDisplayName;
+            Description = description;
+            IsFramework = isFramework;
+            IsResource = isResource;
+            IsBundle = isBundle;
+            BundledApplications = new ReadOnlyCollection<string>(bundledApplications);
+            BundledResources = new ReadOnlyCollection<string>(bundledResources);
+        }
+
+        /// <summary>
+        /// The name of the package.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The version of the package.
+        /// </summary>
+        public string Version { get; }
+
+        /// <summary>
+        /// The architecture of the package.
+        /// </summary>
+        public string Architecture { get; }
+
+        /// <summary>
+        /// The resource ID of the package.
+        /// </summary>
+        public string ResourceId { get; }
+
+        /// <summary>
+        /// The publisher ID of the package.
+        /// </summary>
+        public string PublisherId { get; }
+
+        /// <summary>
+        /// The full name of the package.
+        /// </summary>
+        public string FullName { get; }
+
+        /// <summary>
+        /// The family name of the package.
+        /// </summary>
+        public string FamilyName { get; }
+
+        /// <summary>
+        /// The distinguished name of the publisher.
+        /// </summary>
+        public string PublisherDn { get; }
+
+        /// <summary>
+        /// The display name of the package.
+        /// </summary>
+        public string DisplayName { get; }
+
+        /// <summary>
+        /// The display name of the publisher.
+        /// </summary>
+        public string PublisherDisplayName { get; }
+
+        /// <summary>
+        /// The description of the package.
+        /// </summary>
+        public string Description { get; }
+
+        /// <summary>
+        /// Indicates whether the package is a framework.
+        /// </summary>
+        public bool IsFramework { get; }
+
+        /// <summary>
+        /// Indicates whether the package is a resource.
+        /// </summary>
+        public bool IsResource { get; }
+
+        /// <summary>
+        /// Indicates whether the package is a bundle.
+        /// </summary>
+        public bool IsBundle { get; }
+
+        /// <summary>
+        /// If the package is a bundle, the applications bundled within the package.
+        /// </summary>
+        public ReadOnlyCollection<string> BundledApplications { get; }
+
+        /// <summary>
+        /// If the package is a bundle, the resources bundled within the package.
+        /// </summary>
+        public ReadOnlyCollection<string> BundledResources { get; }
+    }
+}

--- a/src/PSADT/PSADT/Utilities/PackageUtilities.cs
+++ b/src/PSADT/PSADT/Utilities/PackageUtilities.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace PSADT.Utilities
+{
+    /// <summary>
+    /// Methods to interact with Appx packages based on identifier
+    /// </summary>
+    public static class PackageUtilities
+    {
+        private const int ERROR_SUCCESS = 0;
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1838:Avoid 'StringBuilder' parameters for P/Invokes", Justification = "This P/Invoke is temporary for now.")]
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, ExactSpelling = true), DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        private static extern ulong PackageFamilyNameFromId(
+            PACKAGE_ID packageId,
+            ref uint packageFamilyNameLength,
+            StringBuilder? packageFamilyName);
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode, Pack = 4)]
+        private struct PACKAGE_ID
+        {
+            public uint reserved;
+            public uint processorArchitecture;
+            public PACKAGE_VERSION version;
+            public string name;
+            public string publisher;
+            public string resourceId;
+            public string publisherId;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        private struct PACKAGE_VERSION
+        {
+            [FieldOffset(0)]
+            public ulong Version;
+            [FieldOffset(0)]
+            public ushort Revision;
+            [FieldOffset(2)]
+            public ushort Build;
+            [FieldOffset(4)]
+            public ushort Minor;
+            [FieldOffset(6)]
+            public ushort Major;
+        }
+
+        /// <summary>
+        /// Retrieves the package family name from a given package name and publisher.
+        /// </summary>
+        public static string GetPackageFamilyName(string name, string publisher)
+        {
+            PACKAGE_ID packageId = new()
+            {
+                name = name,
+                publisher = publisher
+            };
+
+            uint packageFamilyNameLength = 0;
+            _ = PackageFamilyNameFromId(packageId, ref packageFamilyNameLength, null);
+
+            StringBuilder packageFamilyNameBuilder = new((int)packageFamilyNameLength);
+            return PackageFamilyNameFromId(packageId, ref packageFamilyNameLength, packageFamilyNameBuilder) == ERROR_SUCCESS
+                ? packageFamilyNameBuilder.ToString()
+                : throw new InvalidOperationException("Failed to retrieve package family name from package ID.");
+        }
+    }
+}

--- a/src/PSADT/PSADT/Utilities/XmlUtilities.cs
+++ b/src/PSADT/PSADT/Utilities/XmlUtilities.cs
@@ -12,14 +12,14 @@ namespace PSADT.Utilities
     /// <remarks>All methods in this class use secure XML reader settings to help prevent XML external entity
     /// (XXE) attacks and prohibit DTD processing. The utilities are intended for scenarios where XML input may be
     /// untrusted or where external resource resolution should be disabled.</remarks>
-    internal static class XmlUtilities
+    public static class XmlUtilities
     {
         /// <summary>
         /// Loads an XML document from the specified file path in a safe manner.
         /// </summary>
         /// <param name="path">The file system path to the XML file to load. Cannot be null or empty.</param>
         /// <returns>An XmlDocument representing the contents of the specified file.</returns>
-        internal static XmlDocument SafeLoadFromPath(string path)
+        public static XmlDocument SafeLoadFromPath(string path)
         {
             if (path is null)
             {
@@ -34,11 +34,26 @@ namespace PSADT.Utilities
         }
 
         /// <summary>
+        /// Loads an XML document from the specified stream in a safe manner.
+        /// </summary>
+        /// <param name="stream">The stream containing the XML data to load. Cannot be null.</param>
+        /// <returns>An XmlDocument representing the contents of the stream.</returns>
+        public static XmlDocument SafeLoadFromStream(Stream stream)
+        {
+            if (stream is null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+            using StreamReader reader = new(stream);
+            return SafeLoadCommon(reader);
+        }
+
+        /// <summary>
         /// Parses the specified XML string and returns an XmlDocument instance representing its contents.
         /// </summary>
         /// <param name="input">A string containing the XML data to parse. Cannot be null.</param>
         /// <returns>An XmlDocument representing the parsed XML content.</returns>
-        internal static XmlDocument SafeLoadFromText(string input)
+        public static XmlDocument SafeLoadFromText(string input)
         {
             if (string.IsNullOrWhiteSpace(input))
             {
@@ -54,7 +69,7 @@ namespace PSADT.Utilities
         /// </summary>
         /// <param name="input">A read-only span of characters containing the XML data to parse.</param>
         /// <returns>An XmlDocument representing the parsed XML content.</returns>
-        internal static XmlDocument SafeLoadFromText(ReadOnlySpan<char> input)
+        public static XmlDocument SafeLoadFromText(ReadOnlySpan<char> input)
         {
             return SafeLoadFromText(input.ToString().TrimRemoveNull());
         }

--- a/src/PSAppDeployToolkit/ImportsFirst.ps1
+++ b/src/PSAppDeployToolkit/ImportsFirst.ps1
@@ -106,6 +106,7 @@ try
                 'Microsoft.PowerShell.Commands.Management'
                 'System.ServiceProcess'
                 'System.Windows.Forms'
+                'System.IO.Compression.FileSystem'
             )
         }
 

--- a/src/PSAppDeployToolkit/PSAppDeployToolkit.psd1
+++ b/src/PSAppDeployToolkit/PSAppDeployToolkit.psd1
@@ -101,6 +101,7 @@
         'Get-ADTMsiTableProperty'
         'Get-ADTObjectProperty'
         'Get-ADTOperatingSystemInfo'
+        'Get-ADTPackageManifest'
         'Get-ADTPEFileArchitecture'
         'Get-ADTPendingReboot'
         'Get-ADTPowerShellProcessPath'

--- a/src/PSAppDeployToolkit/Public/Get-ADTPackageManifest.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTPackageManifest.ps1
@@ -1,0 +1,203 @@
+﻿#-----------------------------------------------------------------------------
+#
+# MARK: Get-ADTPackageManifest
+#
+#-----------------------------------------------------------------------------
+
+function Get-ADTPackageManifest
+{
+    <#
+    .SYNOPSIS
+        Get all of the properties from a package manifest file or package installer.
+
+    .DESCRIPTION
+        Parse the given appx/msix (bundle) installer or manifest file and extract all of the relevant properties into a strongly typed object.
+
+    .PARAMETER LiteralPath
+        The fully qualified path to an appx/msix (bundle) installer, or a xml containing manifest data.
+
+    .INPUTS
+        None
+
+        You cannot pipe objects to this function.
+
+    .OUTPUTS
+        PSADT.Types.PackageManifestInfo
+
+        Returns the object containing the data the input represents.
+
+    .EXAMPLE
+        Get-ADTPackageManifest -LiteralPath 'C:\Package\Package.appx'
+
+        Retrieve all of the properties from the installer.
+
+	.EXAMPLE
+		Get-ADTPackageManifest -LiteralPath 'C:\Program Files\WindowsApps\Contoso.App_1.0.0.0_x64__8wekyb3d8bbwe\AppxManifest.xml'
+
+		Retrieve all of the properties from the manifest file.
+
+    .NOTES
+        An active ADT session is NOT required to use this function.
+
+        Tags: psadt<br />
+        Website: https://psappdeploytoolkit.com<br />
+        Copyright: (C) 2025 PSAppDeployToolkit Team (Sean Lillis, Dan Cunningham, Muhammad Mashwani, Mitch Richters, Dan Gough).<br />
+        License: https://opensource.org/license/lgpl-3-0
+
+    .LINK
+        https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTPackageManifest
+    #>
+    [CmdletBinding()]
+    [OutputType([PSADT.Types.PackageManifestInfo])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateScript({
+                if (!(Test-Path -LiteralPath $_ -PathType Leaf))
+                {
+                    $PSCmdlet.ThrowTerminatingError((New-ADTValidateScriptErrorRecord -ParameterName Path -ProvidedValue $_ -ExceptionMessage 'The specified path does not exist.'))
+                }
+                elseif ([System.IO.Path]::GetExtension($_) -notin @('.appx', '.appxbundle', '.msix', '.msixbundle', '.xml'))
+                {
+                    $PSCmdlet.ThrowTerminatingError((New-ADTValidateScriptErrorRecord -ParameterName Path -ProvidedValue $_ -ExceptionMessage 'The file must be a package installer or manifest file.'))
+                }
+                return ![System.String]::IsNullOrWhiteSpace($_)
+            })]
+        [Alias('Path', 'PSPath')]
+        [System.String]$LiteralPath
+    )
+
+    begin
+    {
+        Initialize-ADTFunction -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+    }
+
+    process
+    {
+        $item = Get-Item -LiteralPath $LiteralPath
+
+        # If the given path is the installer, read the xml from the archive stream
+        $xml = if ($item.Extension -in @('.appx', '.appxbundle', '.msix', 'msixbundle'))
+        {
+            $archiveSelector = if ($item.Extension -like '*bundle') { 'AppxMetadata/AppxBundleManifest.xml' } else { 'AppxManifest.xml' }
+            $zipArchive = [System.IO.Compression.ZipFile]::OpenRead($item.FullName)
+            try
+            {
+                if (!($manifestEntry = $zipArchive.GetEntry($archiveSelector)))
+                {
+                    $naerParams = @{
+                        Exception = [System.InvalidOperationException]::('The given package file does not contain the expected manifest file.')
+                        Category = [System.Management.Automation.ErrorCategory]::ObjectNotFound
+                        ErrorId = 'PackageIsMissingManifest'
+                    }
+                    $PSCmdlet.ThrowTerminatingError((New-ADTErrorRecord @naerParams))
+                }
+
+                [PSADT.Utilities.XmlUtilities]::SafeLoadFromStream($manifestEntry.Open())
+            }
+            finally
+            {
+                if ($zipArchive)
+                {
+                    $zipArchive.Dispose()
+                }
+            }
+        }
+        # If the file is the document file, use a stream reader
+        else
+        {
+            [PSADT.Utilities.XmlUtilities]::SafeLoadFromPath($item.FullName)
+        }
+
+        # Get the identity node that must be present in both packages and bundles.
+        if (!($idNode = $xml.SelectSingleNode('/*[local-name()="Package" or local-name()="Bundle"]/*[local-name()="Identity"]')))
+        {
+            $naerParams = @{
+                Exception = [System.InvalidOperationException]::new('The given manifest is missing the required Identity node')
+                Category = [System.Management.Automation.ErrorCategory]::InvalidData
+                ErrorId = 'DocumentNotPackageManifest'
+                TargetObject = $xml
+            }
+            $PSCmdlet.ThrowTerminatingError((New-ADTErrorRecord @naerParams))
+        }
+
+        # Extract all information form the id node.
+        $isBundle = $idNode.ParentNode.LocalName -eq 'Bundle'
+        $name = $idNode.Attributes['Name'].Value
+        $version = $idNode.Attributes['Version'].Value
+        $architecture = if ($idNode.Attributes['ProcessorArchitecture']) { $idNode.Attributes['ProcessorArchitecture'].Value.ToLower() } else { 'neutral' }
+        $publisherDn = $idNode.Attributes['Publisher'].Value
+        $resourceId = if ($isBundle) { '~' } elseif ($idNode.Attributes['ResourceId']) { $idNode.Attributes['ResourceId'].Value } else { '' }
+        $publisherId = [PSADT.Utilities.PackageUtilities]::GetPackageFamilyName($name, $publisherDn).Split('_')[1]
+
+        # Set the default values, that will be overwritten by the manifest data, if possible.
+        $displayName = $null
+        $publisherDisplayName = $null
+        $isFramework = $false
+        $isResource = $false
+        $description = $null
+        $bundledApplications = [System.Collections.Generic.List[System.String]]::new()
+        $bundledResources = [System.Collections.Generic.List[System.String]]::new()
+
+        if ($isBundle)
+        {
+            # Bundles include information about the included packages. Expose them separated by type.
+            $idNode.ParentNode['Packages'].ChildNodes | & {
+                process
+                {
+                    $attr = $_.Attributes
+                    $arch = if ($attr['Architecture']) { $attr['Architecture'].Value.ToLower() } else { 'neutral' }
+                    $fullName = "${name}_$($attr['Version'].Value)_${arch}_$($attr['resourceId'].Value)_${publisherId}"
+
+                    if ($attr['Type'] -and $attr['Type'].Value -eq 'application')
+                    {
+                        $bundledApplications.Add($fullName)
+                    }
+                    else
+                    {
+                        $bundledResources.Add($fullName)
+                    }
+                }
+            }
+        }
+        else
+        {
+            # Packages contains a required node Properties, containing additional information such as the DisplayName.
+            $propNode = $idNode.ParentNode['Properties']
+
+            $displayName = $propNode['DisplayName'].InnerText
+            $publisherDisplayName = $propNode['PublisherDisplayName'].InnerText
+            $isFramework = $propNode['Framework'] -and $propNode['Framework'].InnerText -eq 'true'
+            $isResource = $propNode['ResourcePackage'] -and $propNode['ResourcePackage'].InnerText -eq 'true'
+
+            if ($propNode['Description'])
+            {
+                $description = $propNode['Description'].InnerText
+            }
+        }
+
+        $PSCmdlet.WriteObject(
+            [PSADT.Types.PackageManifestInfo]::new(
+                $name,
+                $version,
+                $architecture,
+                $resourceId,
+                $publisherId,
+                $publisherDn,
+                $displayName,
+                $publisherDisplayName,
+                $description,
+                $isFramework,
+                $isResource,
+                $isBundle,
+                $bundledApplications,
+                $bundledResources
+            )
+        )
+    }
+
+    end
+    {
+        Complete-ADTFunction -Cmdlet $PSCmdlet
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description
This PR adds a package manifest parser for Appx/MSIX manifests. 
It can be used to obtain information about appx/msix installers or read manifests of already installed packages.

This improves on default Appx module capabilites by being able to read the required data from any kind of source (not just installed packages),
helpful if you want to get information from the installer itself (e.g. zero-conf or when creating the package).
Additionally it retains information about bundled resources which allows resolving packages to the original bundle.

This feature has no dependencies and is not yet integrated into any other function.

I see this function being used to obtain installed application information from the registry:
* ProvisionedPackages from
  `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Appx\AppxAllUserStore\Applications`
* Any user package from
  `HKEY_CLASSES_ROOT\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\PackageRepository\Packages`
* Specific user package from
  `HKEY_USERS\<SID>\SOFTWARE\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\Repository\Packages`

or for implementing a second zero-conf solution like msi but for appx.

PartOf: #1450

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [X] I am pulling to the **develop** branch
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have tested my changes to prove my fix is effective
- [X] I have tested that the module can build following my changes
- [X] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

1) Read the manifest directly from any of the sources mentioned in **Description** (filename AppxManifest.xml)
2) Read the manifest from .appx package
3) Read the manifest from .appxbundle package
