### PR TITLE
Various minor Dutch string fixes and changes

### DIFF
--- a/src/PSAppDeployToolkit/Strings/nl/strings.psd1
+++ b/src/PSAppDeployToolkit/Strings/nl/strings.psd1
@@ -70,8 +70,8 @@
         }
     }
     RestartPrompt = @{
-        ButtonRestartLater = 'Minimaliseren.'
-        ButtonRestartNow = 'Nu opnieuw opstarten.'
+        ButtonRestartLater = 'Minimaliseren'
+        ButtonRestartNow = 'Nu opnieuw opstarten'
         Message = @{
             Install = 'Om de installatie te voltooien, moet u uw computer opnieuw opstarten.'
             Repair = 'Om de reparatie te voltooien, moet u uw computer opnieuw opstarten.'
@@ -138,14 +138,14 @@
             DeferralsRemaining = 'Resterende uitstel'
             DeferralDeadline = 'Uitsteltermijn'
             ButtonLeftText = @{
-                Install = 'Sluit Apps & installeer.'
-                Repair = 'Sluit Apps & repareer.'
-                Uninstall = 'Sluit Apps & de-installeer.'
+                Install = 'Sluit Apps en Installeer'
+                Repair = 'Sluit Apps en Repareer'
+                Uninstall = 'Sluit Apps en De-installeer'
             }
             ButtonLeftNoProcessesText = @{
-                Install = 'Installeren.'
-                Repair = 'Repareren.'
-                Uninstall = 'De-installeren.'
+                Install = 'Installeren'
+                Repair = 'Repareren'
+                Uninstall = 'De-installeren'
             }
             ButtonRightText = 'Uitstellen'
             Subtitle = @{


### PR DESCRIPTION
# Pull Request

## Description

This PR changes the strings for the close apps dialog to reflect the correct deployment type. (install and repair deployments showed the uninstall string).

Some additional minor changes were made to the button texts to make these more consistent with other languages and common UI elements:
- Removed periods from button action texts (the English file and other languages do not use periods, this is not something specifically used in the Dutch locale either).
- Replaced ampersands with the full word "en" (Ampersands are not commonly used in Dutch language and UI elements, this change has also been made for various other languages, and i followed this example).
- Aligned capitalization of some strings with the original English file and other translations.

Fixes: #1990 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [ ] I have tested that the module can build following my changes
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

I have replaced the Strings file in an existing deployment, and i verified all changes were applied.
