### PR TITLE
Flag `Start-ADTProcess` `-IgnoreExitCodes` as deprecated for removal in 4.3.0.

### DIFF
--- a/src/PSAppDeployToolkit/Public/Start-ADTProcess.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTProcess.ps1
@@ -488,6 +488,7 @@ function Start-ADTProcess
         [Parameter(Mandatory = $false, ParameterSetName = 'UseShellExecute_CreateWindow_Wait')]
         [Parameter(Mandatory = $false, ParameterSetName = 'UseShellExecute_WindowStyle_Timeout')]
         [Parameter(Mandatory = $false, ParameterSetName = 'UseShellExecute_WindowStyle_Wait')]
+        [System.Obsolete("Please use '-ErrorAction SilentlyContinue' instead as this will be removed in PSAppDeployToolkit 4.3.0.")]
         [ValidateNotNullOrEmpty()]
         [SupportsWildcards()]
         [System.String[]]$IgnoreExitCodes,
@@ -541,6 +542,12 @@ function Start-ADTProcess
         }
         Initialize-ADTFunction -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
         $canSetExitCode = $true
+
+        # Log the deprecation of -IgnoreExitCodes to the log.
+        if ($PSBoundParameters.ContainsKey('IgnoreExitCodes'))
+        {
+            Write-ADTLogEntry -Message "The parameter [-IgnoreExitCodes] is obsolete and will be removed in PSAppDeployToolkit 4.3.0. Please use [-SuccessExitCodes]/[-RebootExitCodes] for known exit codes, or [-ErrorAction SilentlyContinue] for ignoring any exit code instead." -Severity 2
+        }
 
         # Set up defaults if not specified.
         if (!$PSBoundParameters.ContainsKey('SuccessExitCodes'))


### PR DESCRIPTION
# Pull Request

## Description

The preface to this is that a power user recently instructed an inexperienced user to use it in their DCU setup to perform security related updates (firmware, driver, etc), and therefore if DCU failed with some unexpected exit code, this guy would have received success in ConfigMgr, which isn't acceptable and could even compromise his employment. It's just a terrible parameter that's a vestige from the 3.x days that's better served by `-ErrorAction SilentlyContinue` instead.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have tested that the module can build following my changes
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.