### PR TITLE
Flag `Copy-ADTFile` `-FileCopyMode` as deprecated for removal in 4.3.0.

### DIFF
--- a/src/PSAppDeployToolkit/Public/Copy-ADTFile.ps1
+++ b/src/PSAppDeployToolkit/Public/Copy-ADTFile.ps1
@@ -135,7 +135,7 @@ function Copy-ADTFile
         if ($FileCopyMode -eq 'Robocopy')
         {
             # Announce deprecation of Robocopy file copy mode.
-            Write-ADTLogEntry -Message "The file copy mode [Robocopy] is deprecated and will be removed in PSAppDeployToolkit 4.2.0. Please use the [Native] file copy mode and instead." -Severity 2
+            Write-ADTLogEntry -Message "The file copy mode [Robocopy] is deprecated and will be removed in PSAppDeployToolkit 4.3.0. Please use the [Native] file copy mode and instead." -Severity 2
 
             # Check if Robocopy is on the system.
             if (Test-Path -LiteralPath "$([System.Environment]::SystemDirectory)\Robocopy.exe" -PathType Leaf)


### PR DESCRIPTION
# Pull Request

## Description

The Robocopy file copy method has been a continual source of problems since its introduction and has effectively been abandoned by its original contributor. @DanGough has continued to maintain this code however it's ultimately becoming a detriment to the project with no real benefit.

The native file copying capabilities of PowerShell are preferable as they integrate properly, have proper error control workflows and don't require strange twists/contortions to interoperate with existing functionality that `Copy-ADTFile` has had long before the Robocopy code came to be.

Fixes https://github.com/PSAppDeployToolkit/PSAppDeployToolkit/issues/2022.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have tested that the module can build following my changes
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.