### PR TITLE
Fix type mismatch in `Get-ADTPendingReboot`

### DIFF
--- a/src/PSAppDeployToolkit/Public/Get-ADTPendingReboot.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTPendingReboot.ps1
@@ -74,7 +74,6 @@ function Get-ADTPendingReboot
     {
         Initialize-ADTFunction -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
         $PendRebootErrorMsg = [System.Collections.Generic.List[System.String]]::new()
-        $PendingFileRenameOperations = [System.Collections.Generic.List[System.String]]::new()
         $HostName = [System.Net.Dns]::GetHostName()
     }
 
@@ -95,7 +94,7 @@ function Get-ADTPendingReboot
                 $IsAppVRebootPending = Test-Path -LiteralPath 'Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Software\Microsoft\AppV\Client\PendingTasks'
 
                 # Get the value of PendingFileRenameOperations.
-                $IsFileRenameRebootPending = !!([String[]]$PendingFileRenameOperations = Get-ItemProperty -LiteralPath 'Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager' | Select-Object -ExpandProperty PendingFileRenameOperations -ErrorAction Ignore)
+                $IsFileRenameRebootPending = !!([System.String[]]$PendingFileRenameOperations = Get-ItemProperty -LiteralPath 'Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager' | Select-Object -ExpandProperty PendingFileRenameOperations -ErrorAction Ignore)
 
                 # Determine SCCM 2012 Client reboot pending status.
                 $IsSCCMClientRebootPending = if ((Get-CimInstance -Namespace root -ClassName __NAMESPACE -Verbose:$false).Name.Contains('ccm'))


### PR DESCRIPTION
# Pull Request

## Description

Fix bug where the `$PendingFileRenameOperations` variable was a string instead of an IReadOnlyList like the RebootInfo constructor was expecting

Fixes: #2030 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [X] I am pulling to the **main** branch
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have tested my changes to prove my fix is effective
- [ ] I have tested that the module can build following my changes
- [X] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Set the PendingFileRenameOperations key and ran the command
