### PR TITLE
Fix incorrect variable usage in build module

### DIFF
--- a/src/PSAppDeployToolkit.Build/Private/Confirm-ADTBuildModulesPresent.ps1
+++ b/src/PSAppDeployToolkit.Build/Private/Confirm-ADTBuildModulesPresent.ps1
@@ -38,7 +38,7 @@ function Confirm-ADTBuildModulesPresent
             if (!($nugetProvider = Get-PackageProvider -Name NuGet -ListAvailable -ErrorAction Ignore) -or ($nugetProvider.Version -lt [System.Version]::new(2, 8, 5, 201)))
             {
                 Write-ADTBuildLogEntry -Message "Installing/updating NuGet package provider, please wait..."
-                $null = Install-PackageProvider -Name NuGet -Scope $Scope -Force
+                $null = Install-PackageProvider -Name NuGet -Scope CurrentUser -Force
             }
 
             # Commence installing modules one by one. We need to do this individually as we can't specify names and differing minimum versions.


### PR DESCRIPTION
# Pull Request

## Description

The variable `$Scope` is never defined or used elsewhere.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested my changes to prove my fix is effective
- [ ] I have tested that the module can build following my changes
- [ ] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

It hasn't
