### PR TITLE
Add Pester tests for `Convert-ADTRegistryPath`

### DIFF
--- a/src/Tests/Unit/Convert-ADTRegistryPath.Tests.ps1
+++ b/src/Tests/Unit/Convert-ADTRegistryPath.Tests.ps1
@@ -1,0 +1,57 @@
+﻿BeforeAll {
+    Remove-Module PSAppDeployToolkit -Force -ErrorAction SilentlyContinue
+    Import-Module "$PSScriptRoot\..\..\PSAppDeployToolkit\PSAppDeployToolkit.psd1" -Force
+}
+Describe 'Convert-ADTRegistryPath' {
+    BeforeAll {
+        # Mock Write-ADTLogEntry due to its expense when running via Pester.
+        Mock -ModuleName PSAppDeployToolkit Write-ADTLogEntry { }
+    }
+
+    Context 'Functionality' {
+        It 'Should return Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SOFTWARE' {
+            Convert-ADTRegistryPath -Key 'HKLM\SOFTWARE' | Should -Be 'Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SOFTWARE'
+            Convert-ADTRegistryPath -Key 'HKLM:\SOFTWARE' | Should -Be 'Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SOFTWARE'
+            Convert-ADTRegistryPath -Key 'HKEY_LOCAL_MACHINE\SOFTWARE' | Should -Be 'Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SOFTWARE'
+        }
+        It 'Should return Microsoft.PowerShell.Core\Registry::HKEY_USERS\S-1-5-18\SOFTWARE' {
+            Convert-ADTRegistryPath -Key 'HKCU\SOFTWARE' -SID 'S-1-5-18' | Should -Be 'Microsoft.PowerShell.Core\Registry::HKEY_USERS\S-1-5-18\SOFTWARE'
+            Convert-ADTRegistryPath -Key 'HKCU:\SOFTWARE' -SID 'S-1-5-18' | Should -Be 'Microsoft.PowerShell.Core\Registry::HKEY_USERS\S-1-5-18\SOFTWARE'
+            Convert-ADTRegistryPath -Key 'HKEY_CURRENT_USER\SOFTWARE' -SID 'S-1-5-18' | Should -Be 'Microsoft.PowerShell.Core\Registry::HKEY_USERS\S-1-5-18\SOFTWARE'
+        }
+        It 'Should return Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node' {
+            Convert-ADTRegistryPath -Key 'HKLM\SOFTWARE' -Wow6432Node | Should -Be 'Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node'
+            Convert-ADTRegistryPath -Key 'HKLM:\SOFTWARE' -Wow6432Node | Should -Be 'Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node'
+            Convert-ADTRegistryPath -Key 'HKEY_LOCAL_MACHINE\SOFTWARE' -Wow6432Node | Should -Be 'Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node'
+        }
+    }
+
+    Context 'Input Validation' {
+        It 'Should verify that Key is not null, empty or whitespace' {
+            { Convert-ADTRegistryPath -Key $null } | Should -Throw
+            { Convert-ADTRegistryPath -Key '' } | Should -Throw
+            { Convert-ADTRegistryPath -Key ' ' } | Should -Throw
+        }
+        It 'Should verify that SID is not null or empty' {
+            { Convert-ADTRegistryPath -Key 'Anything' -SID $null } | Should -Throw
+            { Convert-ADTRegistryPath -Key 'Anything' -SID '' } | Should -Throw
+            { Convert-ADTRegistryPath -Key 'Anything' -SID ' ' } | Should -Throw
+        }
+        It 'Should verify that the registry hive is HKEY_CURRENT_USER when the -SID parameter is provided' {
+            { Convert-ADTRegistryPath -Key 'HKLM\SOFTWARE' -SID 'S-1-5-18' } | Should -Throw
+            { Convert-ADTRegistryPath -Key 'HKLM:\SOFTWARE' -SID 'S-1-5-18' } | Should -Throw
+            { Convert-ADTRegistryPath -Key 'HKEY_LOCAL_MACHINE\SOFTWARE' -SID 'S-1-5-18' } | Should -Throw
+            { Convert-ADTRegistryPath -Key 'HKEY_LOCAL_MACHINE:\SOFTWARE' -SID 'S-1-5-18' } | Should -Throw
+            { Convert-ADTRegistryPath -Key 'HKEY_CURRENT_USER:\SOFTWARE' -SID 'S-1-5-18' } | Should -Throw
+        }
+        It 'Should verify that the registry hive provided is a valid registry hive' {
+            { Convert-ADTRegistryPath -Key 'HKCC:\TestLocation' } | Should -Not -Throw
+            { Convert-ADTRegistryPath -Key 'HKCU:\TestLocation' } | Should -Not -Throw
+            { Convert-ADTRegistryPath -Key 'HKCR:\TestLocation' } | Should -Not -Throw
+            { Convert-ADTRegistryPath -Key 'HKLM:\TestLocation' } | Should -Not -Throw
+            { Convert-ADTRegistryPath -Key 'HKPD:\TestLocation' } | Should -Not -Throw
+            { Convert-ADTRegistryPath -Key 'HKU:\TestLocation' } | Should -Not -Throw
+            { Convert-ADTRegistryPath -Key 'TestRegistry:\TestLocation' } | Should -Throw
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

Part of: https://github.com/PSAppDeployToolkit/PSAppDeployToolkit/issues/1414

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have tested that the module can build following my changes
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

```PowerShell
. .\build.ps1
```