### PR TITLE
Add `-Recurse` parameter to `Remove-ADTHashtableNullOrEmptyValues`

### DIFF
--- a/src/PSAppDeployToolkit/Public/Remove-ADTHashtableNullOrEmptyValues.ps1
+++ b/src/PSAppDeployToolkit/Public/Remove-ADTHashtableNullOrEmptyValues.ps1
@@ -16,10 +16,13 @@ function Remove-ADTHashtableNullOrEmptyValues
     .PARAMETER Hashtable
         The hashtable to remove null values from.
 
-    .INPUTS
-        None
+    .PARAMETER Recurse
+        Specifies to recursively remove nested hashtable values that are null, empty, or whitespace.
 
-        You cannot pipe objects to this function.
+    .INPUTS
+        System.Collections.Hashtable
+
+        The hashtable to remove null or empty entries from.
 
     .OUTPUTS
         System.Collections.Hashtable
@@ -47,18 +50,30 @@ function Remove-ADTHashtableNullOrEmptyValues
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 0)]
         [ValidateNotNullOrEmpty()]
-        [System.Collections.Hashtable]$Hashtable
+        [System.Collections.Hashtable]$Hashtable,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.SwitchParameter]$Recurse
     )
 
-    # Build a new hashtable with only valid values and then return it to the caller.
-    $obj = @{}; foreach ($kvp in $Hashtable.GetEnumerator())
+    process
     {
-        if (![System.String]::IsNullOrWhiteSpace((Out-String -InputObject $kvp.Value)))
+        # Build a new hashtable with only valid values and then return it to the caller.
+        $obj = $Hashtable.Clone(); foreach ($section in $($obj.GetEnumerator()))
         {
-            $obj.Add($kvp.Key, $kvp.Value)
+            # Recursively remove null/empty/whitespace keys from the bottom up, if the Recurse parameter is provided.
+            if ($section.Value -is [System.Collections.Hashtable] -and $Recurse)
+            {
+                $section.Value = & $MyInvocation.MyCommand -Hashtable $section.Value
+            }
+
+            if ([System.String]::IsNullOrWhiteSpace((Out-String -InputObject $section.Value)))
+            {
+                $obj.Remove($section.Key)
+            }
         }
+        return $obj
     }
-    return $obj
 }


### PR DESCRIPTION
# Pull Request

## Description

Using this for in email extension module to remove empty config properties

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have tested that the module can build following my changes
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Calling the function with various forms of null values as well as with/without nested hashtables.
