### PR TITLE
Add -Exclude parameter to Copy-ADTContentToCache. (#1740)

### DIFF
--- a/src/PSAppDeployToolkit/Public/Copy-ADTContentToCache.ps1
+++ b/src/PSAppDeployToolkit/Public/Copy-ADTContentToCache.ps1
@@ -20,6 +20,13 @@ function Copy-ADTContentToCache
     .PARAMETER LiteralPath
         The path to the software cache folder.
 
+    .PARAMETER Skip
+        Specifies one or more content categories to exclude from the cache copy. Acceptable values are 'Files', 'SupportFiles', and 'Other'.
+
+        - Files: Excludes the Files folder and does not remap the DirFiles session property.
+        - SupportFiles: Excludes the SupportFiles folder and does not remap the DirSupportFiles session property.
+        - Other: Excludes all content other than the Files and SupportFiles folders.
+
     .INPUTS
         None
 
@@ -34,6 +41,16 @@ function Copy-ADTContentToCache
         Copy-ADTContentToCache -LiteralPath "$envWinDir\Temp\PSAppDeployToolkit"
 
         This example copies the toolkit content to the specified cache folder.
+
+    .EXAMPLE
+        Copy-ADTContentToCache -Skip Files
+
+        This example copies the toolkit content to the default cache folder, excluding the Files folder and leaving DirFiles pointing at the original location.
+
+    .EXAMPLE
+        Copy-ADTContentToCache -Skip Other
+
+        This example copies only the Files and SupportFiles folders to the default cache folder, skipping all other content.
 
     .NOTES
         An active ADT session is required to use this function.
@@ -61,11 +78,20 @@ function Copy-ADTContentToCache
         [Parameter(Mandatory = $false)]
         [PSAppDeployToolkit.Attributes.ValidateNotNullOrWhiteSpace()]
         [Alias('Path', 'PSPath')]
-        [System.String]$LiteralPath = "$((Get-ADTConfig).Toolkit.CachePath)\$((Get-ADTSession).InstallName)"
+        [System.String]$LiteralPath = "$((Get-ADTConfig).Toolkit.CachePath)\$((Get-ADTSession).InstallName)",
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Files', 'SupportFiles', 'Other')]
+        [System.String[]]$Skip
     )
 
     begin
     {
+        if ('Files' -in $Skip -and 'SupportFiles' -in $Skip -and 'Other' -in $Skip)
+        {
+            $PSCmdlet.ThrowTerminatingError((New-ADTValidateScriptErrorRecord -ParameterName Skip -ProvidedValue $Skip -ExceptionMessage 'Cannot specify all possible values for -Skip parameter as there would be nothing to copy.'))
+        }
+
         try
         {
             $adtSession = Get-ADTSession
@@ -75,6 +101,7 @@ function Copy-ADTContentToCache
         {
             $PSCmdlet.ThrowTerminatingError($_)
         }
+
         Initialize-ADTFunction -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
     }
 
@@ -125,12 +152,41 @@ function Copy-ADTContentToCache
                 {
                     Write-ADTLogEntry -Message "Source and destination are the same path [$LiteralPath]. Skipping copy operation."
                 }
-                else
+                elseif (!$PSBoundParameters.ContainsKey('Skip'))
                 {
+                    # Fast path: copy everything in a single operation.
                     Copy-ADTFile -Path (Join-Path -Path $scriptDir -ChildPath *) -Destination $LiteralPath -Recurse
                 }
-                $adtSession.DirFiles = Join-Path -Path $LiteralPath -ChildPath Files
-                $adtSession.DirSupportFiles = Join-Path -Path $LiteralPath -ChildPath SupportFiles
+                else
+                {
+                    # Selective copy: enumerate top-level items and copy based on -Skip.
+                    if ('Other' -notin $Skip)
+                    {
+                        Get-ChildItem -LiteralPath $scriptDir -Force | & { process { if ($_.Name -notin @('Files', 'SupportFiles')) { Copy-ADTFile -LiteralPath $_.FullName -Destination $LiteralPath -Recurse } } }
+                    }
+                    $filesSourcePath = Join-Path -Path $scriptDir -ChildPath Files
+                    if ('Files' -notin $Skip -and (Test-Path -LiteralPath $filesSourcePath -PathType Container))
+                    {
+                        Copy-ADTFile -LiteralPath $filesSourcePath -Destination $LiteralPath -Recurse
+                    }
+                    $supportFilesSourcePath = Join-Path -Path $scriptDir -ChildPath SupportFiles
+                    if ('SupportFiles' -notin $Skip -and (Test-Path -LiteralPath $supportFilesSourcePath -PathType Container))
+                    {
+                        Copy-ADTFile -LiteralPath $supportFilesSourcePath -Destination $LiteralPath -Recurse
+                    }
+                }
+
+                # Remap session properties for categories that were copied.
+                $filesDestPath = Join-Path -Path $LiteralPath -ChildPath Files
+                if ('Files' -notin $Skip -and (Test-Path -LiteralPath $filesDestPath -PathType Container))
+                {
+                    $adtSession.DirFiles = $filesDestPath
+                }
+                $supportFilesDestPath = Join-Path -Path $LiteralPath -ChildPath SupportFiles
+                if ('SupportFiles' -notin $Skip -and (Test-Path -LiteralPath $supportFilesDestPath -PathType Container))
+                {
+                    $adtSession.DirSupportFiles = $supportFilesDestPath
+                }
             }
             catch
             {

--- a/src/PSAppDeployToolkit/Public/Copy-ADTContentToCache.ps1
+++ b/src/PSAppDeployToolkit/Public/Copy-ADTContentToCache.ps1
@@ -43,9 +43,9 @@ function Copy-ADTContentToCache
         This example copies the toolkit content to the specified cache folder.
 
     .EXAMPLE
-        Copy-ADTContentToCache -Skip Files
+        Copy-ADTContentToCache -Skip Files,SupportFiles
 
-        This example copies the toolkit content to the default cache folder, excluding the Files folder and leaving DirFiles pointing at the original location.
+        This example copies the toolkit content to the default cache folder, excluding the Files and SupportFiles folders and leaving DirFiles and DirSupportFiles pointing at the original location.
 
     .EXAMPLE
         Copy-ADTContentToCache -Skip Other

--- a/src/PSAppDeployToolkit/Public/Copy-ADTContentToCache.ps1
+++ b/src/PSAppDeployToolkit/Public/Copy-ADTContentToCache.ps1
@@ -21,11 +21,11 @@ function Copy-ADTContentToCache
         The path to the software cache folder.
 
     .PARAMETER Exclude
-        Specifies one or more content categories to exclude from the cache copy. Acceptable values are 'Files', 'SupportFiles', and 'Other'.
+        Specifies one or more content categories to exclude from the cache copy. Acceptable values are 'Files', 'SupportFiles', and 'Toolkit'.
 
         - Files: Excludes the Files folder and does not remap the DirFiles session property.
         - SupportFiles: Excludes the SupportFiles folder and does not remap the DirSupportFiles session property.
-        - Other: Excludes all content other than the Files and SupportFiles folders.
+        - Toolkit: Excludes all content other than the Files and SupportFiles folders.
 
     .INPUTS
         None
@@ -48,7 +48,7 @@ function Copy-ADTContentToCache
         This example copies the toolkit content to the default cache folder, excluding the Files and SupportFiles folders and leaving DirFiles and DirSupportFiles pointing at the original location.
 
     .EXAMPLE
-        Copy-ADTContentToCache -Exclude Other
+        Copy-ADTContentToCache -Exclude Toolkit
 
         This example copies only the Files and SupportFiles folders to the default cache folder, excluding all other content.
 
@@ -81,13 +81,13 @@ function Copy-ADTContentToCache
         [System.String]$LiteralPath = "$((Get-ADTConfig).Toolkit.CachePath)\$((Get-ADTSession).InstallName)",
 
         [Parameter(Mandatory = $false)]
-        [ValidateSet('Files', 'SupportFiles', 'Other')]
+        [ValidateSet('Files', 'SupportFiles', 'Toolkit')]
         [System.String[]]$Exclude
     )
 
     begin
     {
-        if ('Files' -in $Exclude -and 'SupportFiles' -in $Exclude -and 'Other' -in $Exclude)
+        if ('Files' -in $Exclude -and 'SupportFiles' -in $Exclude -and 'Toolkit' -in $Exclude)
         {
             $PSCmdlet.ThrowTerminatingError((New-ADTValidateScriptErrorRecord -ParameterName Exclude -ProvidedValue $Exclude -ExceptionMessage 'Cannot specify all possible values for -Exclude parameter as there would be nothing to copy.'))
         }
@@ -162,7 +162,7 @@ function Copy-ADTContentToCache
                 else
                 {
                     # Selective copy: enumerate top-level items and copy based on -Exclude.
-                    if ('Other' -notin $Exclude)
+                    if ('Toolkit' -notin $Exclude)
                     {
                         Get-ChildItem -LiteralPath $scriptDir -Force | & { process { if ($_.Name -notin $folderNames) { Copy-ADTFile -LiteralPath $_.FullName -Destination $LiteralPath -Recurse } } }
                     }

--- a/src/PSAppDeployToolkit/Public/Copy-ADTContentToCache.ps1
+++ b/src/PSAppDeployToolkit/Public/Copy-ADTContentToCache.ps1
@@ -20,7 +20,7 @@ function Copy-ADTContentToCache
     .PARAMETER LiteralPath
         The path to the software cache folder.
 
-    .PARAMETER Skip
+    .PARAMETER Exclude
         Specifies one or more content categories to exclude from the cache copy. Acceptable values are 'Files', 'SupportFiles', and 'Other'.
 
         - Files: Excludes the Files folder and does not remap the DirFiles session property.
@@ -43,14 +43,14 @@ function Copy-ADTContentToCache
         This example copies the toolkit content to the specified cache folder.
 
     .EXAMPLE
-        Copy-ADTContentToCache -Skip Files,SupportFiles
+        Copy-ADTContentToCache -Exclude Files,SupportFiles
 
         This example copies the toolkit content to the default cache folder, excluding the Files and SupportFiles folders and leaving DirFiles and DirSupportFiles pointing at the original location.
 
     .EXAMPLE
-        Copy-ADTContentToCache -Skip Other
+        Copy-ADTContentToCache -Exclude Other
 
-        This example copies only the Files and SupportFiles folders to the default cache folder, skipping all other content.
+        This example copies only the Files and SupportFiles folders to the default cache folder, excluding all other content.
 
     .NOTES
         An active ADT session is required to use this function.
@@ -82,14 +82,14 @@ function Copy-ADTContentToCache
 
         [Parameter(Mandatory = $false)]
         [ValidateSet('Files', 'SupportFiles', 'Other')]
-        [System.String[]]$Skip
+        [System.String[]]$Exclude
     )
 
     begin
     {
-        if ('Files' -in $Skip -and 'SupportFiles' -in $Skip -and 'Other' -in $Skip)
+        if ('Files' -in $Exclude -and 'SupportFiles' -in $Exclude -and 'Other' -in $Exclude)
         {
-            $PSCmdlet.ThrowTerminatingError((New-ADTValidateScriptErrorRecord -ParameterName Skip -ProvidedValue $Skip -ExceptionMessage 'Cannot specify all possible values for -Skip parameter as there would be nothing to copy.'))
+            $PSCmdlet.ThrowTerminatingError((New-ADTValidateScriptErrorRecord -ParameterName Exclude -ProvidedValue $Exclude -ExceptionMessage 'Cannot specify all possible values for -Exclude parameter as there would be nothing to copy.'))
         }
 
         try
@@ -154,25 +154,25 @@ function Copy-ADTContentToCache
                 {
                     Write-ADTLogEntry -Message "Source and destination are the same path [$LiteralPath]. Skipping copy operation."
                 }
-                elseif (!$PSBoundParameters.ContainsKey('Skip'))
+                elseif (!$PSBoundParameters.ContainsKey('Exclude'))
                 {
                     # Fast path: copy everything in a single operation.
                     Copy-ADTFile -Path (Join-Path -Path $scriptDir -ChildPath *) -Destination $LiteralPath -Recurse
                 }
                 else
                 {
-                    # Selective copy: enumerate top-level items and copy based on -Skip.
-                    if ('Other' -notin $Skip)
+                    # Selective copy: enumerate top-level items and copy based on -Exclude.
+                    if ('Other' -notin $Exclude)
                     {
                         Get-ChildItem -LiteralPath $scriptDir -Force | & { process { if ($_.Name -notin $folderNames) { Copy-ADTFile -LiteralPath $_.FullName -Destination $LiteralPath -Recurse } } }
                     }
                     $filesSourcePath = Join-Path -Path $scriptDir -ChildPath 'Files'
-                    if (('Files' -notin $Skip) -and (Test-Path -LiteralPath $filesSourcePath -PathType Container))
+                    if (('Files' -notin $Exclude) -and (Test-Path -LiteralPath $filesSourcePath -PathType Container))
                     {
                         Copy-ADTFile -LiteralPath $filesSourcePath -Destination $LiteralPath -Recurse
                     }
                     $supportFilesSourcePath = Join-Path -Path $scriptDir -ChildPath SupportFiles
-                    if (('SupportFiles' -notin $Skip) -and (Test-Path -LiteralPath $supportFilesSourcePath -PathType Container))
+                    if (('SupportFiles' -notin $Exclude) -and (Test-Path -LiteralPath $supportFilesSourcePath -PathType Container))
                     {
                         Copy-ADTFile -LiteralPath $supportFilesSourcePath -Destination $LiteralPath -Recurse
                     }
@@ -180,12 +180,12 @@ function Copy-ADTContentToCache
 
                 # Remap session properties for categories that were copied.
                 $filesDestPath = Join-Path -Path $LiteralPath -ChildPath 'Files'
-                if (('Files' -notin $Skip) -and (Test-Path -LiteralPath $filesDestPath -PathType Container))
+                if (('Files' -notin $Exclude) -and (Test-Path -LiteralPath $filesDestPath -PathType Container))
                 {
                     $adtSession.DirFiles = $filesDestPath
                 }
                 $supportFilesDestPath = Join-Path -Path $LiteralPath -ChildPath SupportFiles
-                if (('SupportFiles' -notin $Skip) -and (Test-Path -LiteralPath $supportFilesDestPath -PathType Container))
+                if (('SupportFiles' -notin $Exclude) -and (Test-Path -LiteralPath $supportFilesDestPath -PathType Container))
                 {
                     $adtSession.DirSupportFiles = $supportFilesDestPath
                 }

--- a/src/PSAppDeployToolkit/Public/Copy-ADTContentToCache.ps1
+++ b/src/PSAppDeployToolkit/Public/Copy-ADTContentToCache.ps1
@@ -166,26 +166,26 @@ function Copy-ADTContentToCache
                     {
                         Get-ChildItem -LiteralPath $scriptDir -Force | & { process { if ($_.Name -notin $folderNames) { Copy-ADTFile -LiteralPath $_.FullName -Destination $LiteralPath -Recurse } } }
                     }
-                    $filesSourcePath = Join-Path -Path $scriptDir -ChildPath Files
-                    if ('Files' -notin $Skip -and (Test-Path -LiteralPath $filesSourcePath -PathType Container))
+                    $filesSourcePath = Join-Path -Path $scriptDir -ChildPath 'Files'
+                    if (('Files' -notin $Skip) -and (Test-Path -LiteralPath $filesSourcePath -PathType Container))
                     {
                         Copy-ADTFile -LiteralPath $filesSourcePath -Destination $LiteralPath -Recurse
                     }
                     $supportFilesSourcePath = Join-Path -Path $scriptDir -ChildPath SupportFiles
-                    if ('SupportFiles' -notin $Skip -and (Test-Path -LiteralPath $supportFilesSourcePath -PathType Container))
+                    if (('SupportFiles' -notin $Skip) -and (Test-Path -LiteralPath $supportFilesSourcePath -PathType Container))
                     {
                         Copy-ADTFile -LiteralPath $supportFilesSourcePath -Destination $LiteralPath -Recurse
                     }
                 }
 
                 # Remap session properties for categories that were copied.
-                $filesDestPath = Join-Path -Path $LiteralPath -ChildPath Files
-                if ('Files' -notin $Skip -and (Test-Path -LiteralPath $filesDestPath -PathType Container))
+                $filesDestPath = Join-Path -Path $LiteralPath -ChildPath 'Files'
+                if (('Files' -notin $Skip) -and (Test-Path -LiteralPath $filesDestPath -PathType Container))
                 {
                     $adtSession.DirFiles = $filesDestPath
                 }
                 $supportFilesDestPath = Join-Path -Path $LiteralPath -ChildPath SupportFiles
-                if ('SupportFiles' -notin $Skip -and (Test-Path -LiteralPath $supportFilesDestPath -PathType Container))
+                if (('SupportFiles' -notin $Skip) -and (Test-Path -LiteralPath $supportFilesDestPath -PathType Container))
                 {
                     $adtSession.DirSupportFiles = $supportFilesDestPath
                 }

--- a/src/PSAppDeployToolkit/Public/Copy-ADTContentToCache.ps1
+++ b/src/PSAppDeployToolkit/Public/Copy-ADTContentToCache.ps1
@@ -103,6 +103,8 @@ function Copy-ADTContentToCache
         }
 
         Initialize-ADTFunction -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+        $folderNames = @('Files', 'SupportFiles')
     }
 
     process
@@ -162,7 +164,7 @@ function Copy-ADTContentToCache
                     # Selective copy: enumerate top-level items and copy based on -Skip.
                     if ('Other' -notin $Skip)
                     {
-                        Get-ChildItem -LiteralPath $scriptDir -Force | & { process { if ($_.Name -notin @('Files', 'SupportFiles')) { Copy-ADTFile -LiteralPath $_.FullName -Destination $LiteralPath -Recurse } } }
+                        Get-ChildItem -LiteralPath $scriptDir -Force | & { process { if ($_.Name -notin $folderNames) { Copy-ADTFile -LiteralPath $_.FullName -Destination $LiteralPath -Recurse } } }
                     }
                     $filesSourcePath = Join-Path -Path $scriptDir -ChildPath Files
                     if ('Files' -notin $Skip -and (Test-Path -LiteralPath $filesSourcePath -PathType Container))


### PR DESCRIPTION
# Pull Request

## Description

Adds -Skip parameter to Copy-ADTContentToCache, resolves #1740.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have tested that the module can build following my changes
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Tested all possible combos of the -Skip parameter including not using it and specifying all possible values combined (which will throw an error). Ensured that Files/SupportFiles is only copied and session property updated if those folders exist.
