### PR TITLE
Implement -NoClobber switch to prevent overwriting of files in Copy-ADTFile and Copy-ADTFileToUserProfiles

### DIFF
--- a/src/PSAppDeployToolkit/Public/Copy-ADTFile.ps1
+++ b/src/PSAppDeployToolkit/Public/Copy-ADTFile.ps1
@@ -28,6 +28,9 @@ function Copy-ADTFile
     .PARAMETER Flatten
         Flattens the files into the root destination directory.
 
+    .PARAMETER NoClobber
+        Prevents overwriting existing files at the destination. When specified, files that already exist at the destination path are skipped.
+
     .PARAMETER ContinueFileCopyOnError
         Continue copying files if an error is encountered. This will continue the deployment script and will warn about files that failed to be copied.
 
@@ -70,6 +73,11 @@ function Copy-ADTFile
 
         Copies all files within the active session's Files folder to 'C:\some\random\file\path', overwriting the destination file if it exists.
 
+    .EXAMPLE
+        Copy-ADTFile -Path "$($adtSession.DirFiles)\*" -Destination C:\some\random\file\path -NoClobber
+
+        Copies files from the active session's Files folder that do not already exist at the destination.
+
     .NOTES
         An active ADT session is NOT required to use this function.
 
@@ -105,6 +113,9 @@ function Copy-ADTFile
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.SwitchParameter]$Flatten,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.SwitchParameter]$NoClobber,
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.SwitchParameter]$ContinueFileCopyOnError,
@@ -176,6 +187,14 @@ function Copy-ADTFile
                         $RobocopyParams = $RobocopyParams -replace '/IM(\s+|$)'
                         $RobocopyAdditionalParams = $RobocopyAdditionalParams -replace '/IM(\s+|$)'
                     }
+
+                    # If NoClobber is specified, strip /IS, /IT, and /IM to prevent copying existing files,
+                    # and add /XC, /XN, /XO to exclude Changed, Newer, and Older files.
+                    if ($NoClobber)
+                    {
+                        $RobocopyParams = ($RobocopyParams -replace '/IS(\s+|$)' -replace '/IT(\s+|$)' -replace '/IM(\s+|$)') + ' /XC /XN /XO'
+                        $RobocopyAdditionalParams = $RobocopyAdditionalParams -replace '/IS(\s+|$)' -replace '/IT(\s+|$)' -replace '/IM(\s+|$)'
+                    }
                 }
             }
             else
@@ -243,6 +262,7 @@ function Copy-ADTFile
                             Destination = $Destination  # Use the original destination path, not $robocopyDestination which could have had a subfolder appended to it.
                             Recurse = $false  # Disable recursion as this will create subfolders in the destination.
                             Flatten = $false  # Disable flattening to prevent infinite loops.
+                            NoClobber = $NoClobber
                             ContinueFileCopyOnError = $ContinueFileCopyOnError
                             FileCopyMode = $FileCopyMode
                             RobocopyParams = $RobocopyParams
@@ -415,10 +435,27 @@ function Copy-ADTFile
                         # Perform copy operation.
                         $null = if ($Flatten)
                         {
-                            Write-ADTLogEntry -Message "Copying file(s) recursively in path [$srcPath] to destination [$Destination] root folder, flattened."
+                            Write-ADTLogEntry -Message "Copying file(s) recursively in path [$srcPath] to destination [$Destination] root folder, flattened$(if ($NoClobber) { ', with -NoClobber' })."
                             if ($srcPaths = Get-ChildItem @pathSplat -File -Recurse -Force -ErrorAction Ignore)
                             {
-                                if ($PSCmdlet.ShouldProcess($Destination, "Copy from [$srcPath]"))
+                                if ($NoClobber)
+                                {
+                                    $srcPaths = @($srcPaths | & {
+                                            process
+                                            {
+                                                $destFilePath = Join-Path -Path $Destination -ChildPath $_.Name
+                                                if (Test-Path -LiteralPath $destFilePath -PathType Leaf)
+                                                {
+                                                    Write-ADTLogEntry -Message "File already exists at destination [$destFilePath]. Skipping due to -NoClobber." -Severity Warning
+                                                }
+                                                else
+                                                {
+                                                    return $_
+                                                }
+                                            }
+                                        })
+                                }
+                                if ($srcPaths.Count -and $PSCmdlet.ShouldProcess($Destination, "Copy from [$srcPath]"))
                                 {
                                     Copy-Item -LiteralPath $srcPaths.PSPath @ciParams
                                 }
@@ -426,16 +463,64 @@ function Copy-ADTFile
                         }
                         elseif ($Recurse)
                         {
-                            Write-ADTLogEntry -Message "Copying file(s) recursively in path [$srcPath] to destination [$Destination]."
-                            if ($PSCmdlet.ShouldProcess($Destination, "Copy from [$srcPath]"))
+                            Write-ADTLogEntry -Message "Copying file(s) recursively in path [$srcPath] to destination [$Destination]$(if ($NoClobber) { ' with -NoClobber' })."
+                            if ($NoClobber)
+                            {
+                                $srcRoot = (Resolve-Path -LiteralPath (Split-Path -Path $srcPath -Parent)).Path
+                                $destRoot = if (($destItem = Get-Item -LiteralPath $Destination -Force).PSIsContainer) { $destItem.FullName } else { Split-Path -Path $destItem.FullName -Parent }
+
+                                Get-ChildItem @pathSplat -Recurse -Force -ErrorAction Ignore | & {
+                                    process
+                                    {
+                                        $relativePath = $_.FullName.Substring($srcRoot.Length).TrimStart('\')
+                                        $destFilePath = Join-Path -Path $destRoot -ChildPath $relativePath
+                                        if (!$_.PSIsContainer -and (Test-Path -LiteralPath $destFilePath -PathType Leaf))
+                                        {
+                                            Write-ADTLogEntry -Message "File already exists at destination [$destFilePath]. Skipping due to -NoClobber." -Severity Warning
+                                        }
+                                        elseif ($PSCmdlet.ShouldProcess($destFilePath, "Copy from [$($_.FullName)]"))
+                                        {
+                                            $destDir = Split-Path -Path $destFilePath -Parent
+                                            if (!(Test-Path -LiteralPath $destDir -PathType Container))
+                                            {
+                                                $null = New-Item -Path $destDir -ItemType Directory -Force
+                                            }
+                                            $ciParams.Destination = $destFilePath
+                                            Copy-Item -LiteralPath $_.PSPath @ciParams
+                                        }
+                                    }
+                                }
+                            }
+                            elseif ($PSCmdlet.ShouldProcess($Destination, "Copy from [$srcPath]"))
                             {
                                 Copy-Item @pathSplat -Recurse @ciParams
                             }
                         }
                         else
                         {
-                            Write-ADTLogEntry -Message "Copying file in path [$srcPath] to destination [$Destination]."
-                            if ($PSCmdlet.ShouldProcess($Destination, "Copy from [$srcPath]"))
+                            Write-ADTLogEntry -Message "Copying file(s) in path [$srcPath] to destination [$Destination]$(if ($NoClobber) { ' with -NoClobber' })."
+                            if ($NoClobber)
+                            {
+                                $srcRoot = (Resolve-Path -LiteralPath (Split-Path -Path $srcPath -Parent)).Path
+                                $destRoot = if (($destItem = Get-Item -LiteralPath $Destination -Force).PSIsContainer) { $destItem.FullName } else { Split-Path -Path $destItem.FullName -Parent }
+
+                                Get-Item @pathSplat -Force -ErrorAction Ignore | & {
+                                    process
+                                    {
+                                        $relativePath = $_.FullName.Substring($srcRoot.Length).TrimStart('\')
+                                        $destFilePath = Join-Path -Path $destRoot -ChildPath $relativePath
+                                        if (!$_.PSIsContainer -and (Test-Path -LiteralPath $destFilePath -PathType Leaf))
+                                        {
+                                            Write-ADTLogEntry -Message "File already exists at destination [$destFilePath]. Skipping due to -NoClobber." -Severity Warning
+                                        }
+                                        elseif ($PSCmdlet.ShouldProcess($destFilePath, "Copy from [$($_.FullName)]"))
+                                        {
+                                            Copy-Item -LiteralPath $_.PSPath @ciParams
+                                        }
+                                    }
+                                }
+                            }
+                            elseif ($PSCmdlet.ShouldProcess($Destination, "Copy from [$srcPath]"))
                             {
                                 Copy-Item @pathSplat @ciParams
                             }

--- a/src/PSAppDeployToolkit/Public/Copy-ADTFileToUserProfiles.ps1
+++ b/src/PSAppDeployToolkit/Public/Copy-ADTFileToUserProfiles.ps1
@@ -31,6 +31,9 @@ function Copy-ADTFileToUserProfiles
     .PARAMETER Flatten
         Flattens the files into the root destination directory.
 
+    .PARAMETER NoClobber
+        Prevents overwriting existing files at the destination. When specified, files that already exist at the destination path are skipped.
+
     .PARAMETER ContinueFileCopyOnError
         Continue copying files if an error is encountered. This will continue the deployment script and will warn about files that failed to be copied.
 
@@ -128,6 +131,9 @@ function Copy-ADTFileToUserProfiles
         [System.Management.Automation.SwitchParameter]$Flatten,
 
         [Parameter(Mandatory = $false)]
+        [System.Management.Automation.SwitchParameter]$NoClobber,
+
+        [Parameter(Mandatory = $false)]
         [ValidateSet('Native', 'Robocopy')]
         [System.String]$FileCopyMode,
 
@@ -171,6 +177,7 @@ function Copy-ADTFileToUserProfiles
         $CopyFileSplat = @{
             Recurse = $Recurse
             Flatten = $Flatten
+            NoClobber = $NoClobber
             ContinueFileCopyOnError = $ContinueFileCopyOnError
         }
         if ($PSBoundParameters.ContainsKey('FileCopyMode'))

--- a/src/Tests/Unit/Copy-ADTFile.Tests.ps1
+++ b/src/Tests/Unit/Copy-ADTFile.Tests.ps1
@@ -359,6 +359,60 @@ Describe 'Copy-ADTFile'-ForEach @(
         { Copy-ADTFile -Path "$SourcePath\doesNotExist.txt" -Destination $DestinationPath -FileCopyMode $FileCopyMode -ErrorAction Stop } | Should -Throw
     }
 
+    Context 'NoClobber tests' {
+        It 'Does not overwrite an existing file with -NoClobber ($FileCopyMode = $<FileCopyMode>)' {
+            New-Item -Path "$DestinationPath\test.txt" -ItemType File -Force | Set-Content -Value 'original content'
+
+            Copy-ADTFile -Path "$SourcePath\test.txt" -Destination $DestinationPath -FileCopyMode $FileCopyMode -NoClobber
+
+            "$DestinationPath\test.txt" | Should -FileContentMatch 'original content'
+        }
+
+        It 'Copies a file when destination does not exist with -NoClobber ($FileCopyMode = $<FileCopyMode>)' {
+            Copy-ADTFile -Path "$SourcePath\test.txt" -Destination $DestinationPath -FileCopyMode $FileCopyMode -NoClobber
+
+            "$DestinationPath\test.txt" | Should -Exist
+        }
+
+        It 'Copies only new files with wildcard and -NoClobber ($FileCopyMode = $<FileCopyMode>)' {
+            New-Item -Path "$DestinationPath\test.txt" -ItemType File -Force | Set-Content -Value 'original content'
+
+            Copy-ADTFile -Path "$SourcePath\test*.txt" -Destination $DestinationPath -FileCopyMode $FileCopyMode -NoClobber
+
+            "$DestinationPath\test.txt" | Should -FileContentMatch 'original content'
+            "$DestinationPath\test3.txt" | Should -Exist
+        }
+
+        It 'Copies only new files recursively with -NoClobber ($FileCopyMode = $<FileCopyMode>)' {
+            New-Item -Path "$DestinationPath\Source\Subfolder1\test1.txt" -ItemType File -Force | Set-Content -Value 'original content'
+
+            Copy-ADTFile -Path $SourcePath -Destination $DestinationPath -FileCopyMode $FileCopyMode -NoClobber -Recurse
+
+            "$DestinationPath\Source\Subfolder1\test1.txt" | Should -FileContentMatch 'original content'
+            "$DestinationPath\Source\Subfolder2\test2.txt" | Should -Exist
+        }
+
+        It 'Copies only new files with -Flatten and -NoClobber ($FileCopyMode = $<FileCopyMode>)' {
+            New-Item -Path "$DestinationPath\test.txt" -ItemType File -Force | Set-Content -Value 'original content'
+
+            Copy-ADTFile -Path $SourcePath -Destination $DestinationPath -FileCopyMode $FileCopyMode -NoClobber -Flatten
+
+            "$DestinationPath\test.txt" | Should -FileContentMatch 'original content'
+            "$DestinationPath\test1.txt" | Should -Exist
+            "$DestinationPath\test2.txt" | Should -Exist
+            "$DestinationPath\test3.txt" | Should -Exist
+        }
+
+        It 'Copies only new files from an array with -NoClobber ($FileCopyMode = $<FileCopyMode>)' {
+            New-Item -Path "$DestinationPath\test.txt" -ItemType File -Force | Set-Content -Value 'original content'
+
+            Copy-ADTFile -Path @("$SourcePath\test.txt", "$SourcePath\Subfolder1\test1.txt") -Destination $DestinationPath -FileCopyMode $FileCopyMode -NoClobber
+
+            "$DestinationPath\test.txt" | Should -FileContentMatch 'original content'
+            "$DestinationPath\test1.txt" | Should -Exist
+        }
+    }
+
     if ((Get-ItemPropertyValue -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name 'LongPathsEnabled' -ErrorAction SilentlyContinue) -eq 1)
     {
         It 'Copies files to and from paths longer than 260 characters ($FileCopyMode = $<FileCopyMode>)' {


### PR DESCRIPTION
This adds a -NoClobber parameter to Copy-ADTFile and Copy-ADTFileToUserProfiles. When active, individual file items are checked and skipped if they already exist.

Resolves #1636

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have tested that the module can build following my changes
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Extra Pester tests created plus a bunch of manual test cases.