### PR TITLE
Fix `Set-Content` calls in `Copy-ADTFile.Tests.ps1`

### DIFF
--- a/src/Tests/Unit/Copy-ADTFile.Tests.ps1
+++ b/src/Tests/Unit/Copy-ADTFile.Tests.ps1
@@ -367,7 +367,7 @@ Describe 'Copy-ADTFile'-ForEach @(
 
             Copy-ADTFile -Path "$SourcePath\test.txt" -Destination $DestinationPath -FileCopyMode $FileCopyMode -NoClobber
 
-            "$DestinationPath\test.txt" | Should -FileContentMatch 'original content'
+            "$DestinationPath\test.txt" | Should -FileContentMatchExactly '^original content$'
         }
 
         It 'Copies a file when destination does not exist with -NoClobber ($FileCopyMode = $<FileCopyMode>)' {
@@ -382,7 +382,7 @@ Describe 'Copy-ADTFile'-ForEach @(
 
             Copy-ADTFile -Path "$SourcePath\test*.txt" -Destination $DestinationPath -FileCopyMode $FileCopyMode -NoClobber
 
-            "$DestinationPath\test.txt" | Should -FileContentMatch 'original content'
+            "$DestinationPath\test.txt" | Should -FileContentMatchExactly '^original content$'
             "$DestinationPath\test3.txt" | Should -Exist
         }
 
@@ -392,7 +392,7 @@ Describe 'Copy-ADTFile'-ForEach @(
 
             Copy-ADTFile -Path $SourcePath -Destination $DestinationPath -FileCopyMode $FileCopyMode -NoClobber -Recurse
 
-            "$DestinationPath\Source\Subfolder1\test1.txt" | Should -FileContentMatch 'original content'
+            "$DestinationPath\Source\Subfolder1\test1.txt" | Should -FileContentMatchExactly '^original content$'
             "$DestinationPath\Source\Subfolder2\test2.txt" | Should -Exist
         }
 
@@ -402,7 +402,7 @@ Describe 'Copy-ADTFile'-ForEach @(
 
             Copy-ADTFile -Path $SourcePath -Destination $DestinationPath -FileCopyMode $FileCopyMode -NoClobber -Flatten
 
-            "$DestinationPath\test.txt" | Should -FileContentMatch 'original content'
+            "$DestinationPath\test.txt" | Should -FileContentMatchExactly '^original content$'
             "$DestinationPath\test1.txt" | Should -Exist
             "$DestinationPath\test2.txt" | Should -Exist
             "$DestinationPath\test3.txt" | Should -Exist
@@ -414,7 +414,7 @@ Describe 'Copy-ADTFile'-ForEach @(
 
             Copy-ADTFile -Path @("$SourcePath\test.txt", "$SourcePath\Subfolder1\test1.txt") -Destination $DestinationPath -FileCopyMode $FileCopyMode -NoClobber
 
-            "$DestinationPath\test.txt" | Should -FileContentMatch 'original content'
+            "$DestinationPath\test.txt" | Should -FileContentMatchExactly '^original content$'
             "$DestinationPath\test1.txt" | Should -Exist
         }
     }


### PR DESCRIPTION
# Pull Request

## Description

- Applies fix from https://github.com/PSAppDeployToolkit/PSAppDeployToolkit/commit/3e8b51336e1d40e53ef2032ef5ece71fa18021e4
- Use more strict file content matching 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have tested that the module can build following my changes
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

```PowerShell
& .\build.cmd
```
