### PR TITLE
Various doc/bug fixes

### DIFF
--- a/src/PSAppDeployToolkit/Public/Get-ADTExecutableInfo.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTExecutableInfo.ps1
@@ -68,7 +68,14 @@ function Get-ADTExecutableInfo
         [System.String[]]$LiteralPath,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'InputObject', ValueFromPipeline = $true)]
-        [ValidateNotNullOrEmpty()]
+        [ValidateScript({
+                $_.Refresh()
+                if (!$_.Exists)
+                {
+                    $PSCmdlet.ThrowTerminatingError((New-ADTValidateScriptErrorRecord -ParameterName InputObject -ProvidedValue $_ -ExceptionMessage 'The specified file does not exist.'))
+                }
+                return !!$_
+            })]
         [System.IO.FileInfo]$InputObject
     )
 

--- a/src/PSAppDeployToolkit/Public/Get-ADTIniSection.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTIniSection.ps1
@@ -53,13 +53,7 @@ function Get-ADTIniSection
     param
     (
         [Parameter(Mandatory = $true)]
-        [ValidateScript({
-                if (!(Test-Path -LiteralPath $_ -PathType Leaf))
-                {
-                    $PSCmdlet.ThrowTerminatingError((New-ADTValidateScriptErrorRecord -ParameterName FilePath -ProvidedValue $_ -ExceptionMessage 'The specified file does not exist.'))
-                }
-                return ![System.String]::IsNullOrWhiteSpace($_)
-            })]
+        [PSAppDeployToolkit.Attributes.ValidateNotNullOrWhiteSpace()]
         [System.String]$FilePath,
 
         [Parameter(Mandatory = $true)]

--- a/src/PSAppDeployToolkit/Public/Get-ADTIniValue.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTIniValue.ps1
@@ -56,13 +56,7 @@ function Get-ADTIniValue
     param
     (
         [Parameter(Mandatory = $true)]
-        [ValidateScript({
-                if (!(Test-Path -LiteralPath $_ -PathType Leaf))
-                {
-                    $PSCmdlet.ThrowTerminatingError((New-ADTValidateScriptErrorRecord -ParameterName FilePath -ProvidedValue $_ -ExceptionMessage 'The specified file does not exist.'))
-                }
-                return ![System.String]::IsNullOrWhiteSpace($_)
-            })]
+        [PSAppDeployToolkit.Attributes.ValidateNotNullOrWhiteSpace()]
         [System.String]$FilePath,
 
         [Parameter(Mandatory = $true)]

--- a/src/PSAppDeployToolkit/Public/Get-ADTMsiTableProperty.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTMsiTableProperty.ps1
@@ -31,7 +31,7 @@ function Get-ADTMsiTableProperty
     .PARAMETER GetSummaryInformation
         Retrieves the Summary Information for the Windows Installer database.
 
-        Summary Information property descriptions: https://msdn.microsoft.com/en-us/library/aa372049(v=vs.85).aspx
+        Summary Information property descriptions: https://learn.microsoft.com/en-us/windows/win32/msi/summary-property-descriptions
 
     .INPUTS
         None

--- a/src/PSAppDeployToolkit/Public/Get-ADTPEFileArchitecture.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTPEFileArchitecture.ps1
@@ -77,7 +77,14 @@ function Get-ADTPEFileArchitecture
         [System.String[]]$LiteralPath,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'InputObject', ValueFromPipeline = $true)]
-        [ValidateNotNullOrEmpty()]
+        [ValidateScript({
+                $_.Refresh()
+                if (!$_.Exists)
+                {
+                    $PSCmdlet.ThrowTerminatingError((New-ADTValidateScriptErrorRecord -ParameterName InputObject -ProvidedValue $_ -ExceptionMessage 'The specified file does not exist.'))
+                }
+                return !!$_
+            })]
         [System.IO.FileInfo]$InputObject,
 
         [Parameter(Mandatory = $false)]

--- a/src/PSAppDeployToolkit/Public/Get-ADTPEFileArchitecture.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTPEFileArchitecture.ps1
@@ -25,7 +25,7 @@ function Get-ADTPEFileArchitecture
         A FileInfo object to retrieve executable info from. Available for pipelining.
 
     .PARAMETER PassThru
-        Get the file object, attach a property indicating the file binary type, and write to pipeline.
+        Returns a FileInfo object with an additional "BinaryType" property containing the PE file architecture, rather than a IMAGE_FILE_MACHINE enum value.
 
     .INPUTS
         System.IO.FileInfo
@@ -35,7 +35,12 @@ function Get-ADTPEFileArchitecture
     .OUTPUTS
         PSADT.Interop.IMAGE_FILE_MACHINE
 
-        Returns an IMAGE_FILE_MACHINE enum value indicating the file binary type.
+        By default, this function returns an IMAGE_FILE_MACHINE enum value indicating the file binary type.
+
+    .OUTPUTS
+        System.IO.FileInfo
+
+        When the `-PassThru` parameter is provided, a FileInfo object is returned with an additional "BinaryType" property containing the PE file architecture as an IMAGE_FILE_MACHINE enum value.
 
     .EXAMPLE
         Get-ADTPEFileArchitecture -FilePath "$env:windir\notepad.exe"
@@ -56,6 +61,7 @@ function Get-ADTPEFileArchitecture
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'LiteralPath', Justification = "This parameter is accessed programmatically via the ParameterSet it's within, which PSScriptAnalyzer doesn't understand.")]
     [CmdletBinding()]
     [OutputType([PSADT.Interop.IMAGE_FILE_MACHINE])]
+    [OutputType([System.IO.FileInfo])]
     param
     (
         [Parameter(Mandatory = $true, ParameterSetName = 'Path')]
@@ -125,7 +131,7 @@ function Get-ADTPEFileArchitecture
                     Write-ADTLogEntry -Message "File [$($file.FullName)] has a detected file architecture of [$peArchEnum]."
                     if ($PassThru)
                     {
-                        $file | Add-Member -MemberType NoteProperty -Name BinaryType -Value $peArchEnum -Force -PassThru
+                        Add-Member -InputObject $file -MemberType NoteProperty -Name BinaryType -Value $peArchEnum -Force -PassThru
                     }
                     else
                     {

--- a/src/PSAppDeployToolkit/Public/Get-ADTShortcut.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTShortcut.ps1
@@ -64,10 +64,6 @@ function Get-ADTShortcut
                 {
                     $PSCmdlet.ThrowTerminatingError((New-ADTValidateScriptErrorRecord -ParameterName LiteralPath -ProvidedValue $_ -ExceptionMessage 'The specified path does not have the correct extension.'))
                 }
-                if (!(Test-Path -LiteralPath $_ -PathType Leaf))
-                {
-                    $PSCmdlet.ThrowTerminatingError((New-ADTValidateScriptErrorRecord -ParameterName LiteralPath -ProvidedValue $_ -ExceptionMessage 'The specified path does not exist.'))
-                }
                 return ![System.String]::IsNullOrWhiteSpace($_)
             })]
         [Alias('Path', 'PSPath')]

--- a/src/PSAppDeployToolkit/Public/Get-ADTWindowTitle.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTWindowTitle.ps1
@@ -70,8 +70,6 @@ function Get-ADTWindowTitle
     .NOTES
         An active ADT session is NOT required to use this function.
 
-        Function does not work in SYSTEM context unless launched with "psexec.exe -s -i" to run it as an interactive process under the SYSTEM account.
-
         Tags: psadt<br />
         Website: https://psappdeploytoolkit.com<br />
         Copyright: (C) 2026 PSAppDeployToolkit Team (Sean Lillis, Dan Cunningham, Muhammad Mashwani, Mitch Richters, Dan Gough).<br />

--- a/src/PSAppDeployToolkit/Public/Remove-ADTFolder.ps1
+++ b/src/PSAppDeployToolkit/Public/Remove-ADTFolder.ps1
@@ -118,6 +118,7 @@ function Remove-ADTFolder
         }
         else
         {
+            $InputObject.Refresh()
             if (!$InputObject.Exists)
             {
                 Write-ADTLogEntry -Message "Folder [$InputObject] does not exist."

--- a/src/PSAppDeployToolkit/Public/Remove-ADTIniSection.ps1
+++ b/src/PSAppDeployToolkit/Public/Remove-ADTIniSection.ps1
@@ -54,13 +54,7 @@ function Remove-ADTIniSection
     param
     (
         [Parameter(Mandatory = $true)]
-        [ValidateScript({
-                if (!(Test-Path -LiteralPath $_ -PathType Leaf))
-                {
-                    $PSCmdlet.ThrowTerminatingError((New-ADTValidateScriptErrorRecord -ParameterName FilePath -ProvidedValue $_ -ExceptionMessage 'The specified file does not exist.'))
-                }
-                return ![System.String]::IsNullOrWhiteSpace($_)
-            })]
+        [PSAppDeployToolkit.Attributes.ValidateNotNullOrWhiteSpace()]
         [System.String]$FilePath,
 
         [Parameter(Mandatory = $true)]

--- a/src/PSAppDeployToolkit/Public/Remove-ADTIniValue.ps1
+++ b/src/PSAppDeployToolkit/Public/Remove-ADTIniValue.ps1
@@ -62,13 +62,7 @@ function Remove-ADTIniValue
     param
     (
         [Parameter(Mandatory = $true)]
-        [ValidateScript({
-                if (!(Test-Path -LiteralPath $_ -PathType Leaf))
-                {
-                    $PSCmdlet.ThrowTerminatingError((New-ADTValidateScriptErrorRecord -ParameterName FilePath -ProvidedValue $_ -ExceptionMessage 'The specified file does not exist.'))
-                }
-                return ![System.String]::IsNullOrWhiteSpace($_)
-            })]
+        [PSAppDeployToolkit.Attributes.ValidateNotNullOrWhiteSpace()]
         [System.String]$FilePath,
 
         [Parameter(Mandatory = $true)]

--- a/src/Tests/Unit/Get-ADTIniSection.Tests.ps1
+++ b/src/Tests/Unit/Get-ADTIniSection.Tests.ps1
@@ -44,7 +44,7 @@ MyKey2=MyValue2
             { Get-ADTIniSection -FilePath " `f`n`r`t`v" -Section 'Anything' } | Should @shouldParams
         }
         It 'Should verify that FilePath exists' {
-            { Get-ADTIniSection -FilePath "$TestDrive\DoesNotExist.ini" -Section 'Anything' } | Should -Throw -ExceptionType ([System.ArgumentException]) -ExpectedMessage "The specified file does not exist.*" -ErrorId 'InvalidFilePathParameterValue,Get-ADTIniSection'
+            { Get-ADTIniSection -FilePath "$TestDrive\DoesNotExist.ini" -Section 'Anything' } | Should -Throw -ExceptionType ([System.IO.FileNotFoundException]) -ErrorId 'LiteralPathNotFound,Get-ADTIniSection'
         }
         It 'Should verify that Section is not null, empty or whitespace' {
             $shouldParams = @{

--- a/src/Tests/Unit/Get-ADTIniValue.Tests.ps1
+++ b/src/Tests/Unit/Get-ADTIniValue.Tests.ps1
@@ -48,7 +48,7 @@ MyWhitespaceKey=
             { Get-ADTIniValue -FilePath " `f`n`r`t`v" -Section 'Anything' -Key 'Anything' } | Should @shouldParams
         }
         It 'Should verify that FilePath exists' {
-            { Get-ADTIniValue -FilePath "$TestDrive\DoesNotExist.ini" -Section 'Anything' -Key 'Anything' } | Should -Throw -ExceptionType ([System.ArgumentException]) -ExpectedMessage "The specified file does not exist.*" -ErrorId 'InvalidFilePathParameterValue,Get-ADTIniValue'
+            { Get-ADTIniValue -FilePath "$TestDrive\DoesNotExist.ini" -Section 'Anything' -Key 'Anything' } | Should -Throw -ExceptionType ([System.IO.FileNotFoundException]) -ErrorId 'LiteralPathNotFound,Get-ADTIniValue'
         }
         It 'Should verify that Section is not null, empty or whitespace' {
             $shouldParams = @{

--- a/src/Tests/Unit/Get-ADTRegistryKey.Tests.ps1
+++ b/src/Tests/Unit/Get-ADTRegistryKey.Tests.ps1
@@ -106,9 +106,9 @@ Describe 'Get-ADTRegistryKey' {
                 ExceptionType = [System.Management.Automation.ParameterBindingException]
                 ErrorId = 'ParameterArgumentValidationError,Get-ADTRegistryKey'
             }
-            { Get-ADTRegistryKey -LiteralPath $TestRegistry -Name $null } | Should @shouldParams
-            { Get-ADTRegistryKey -LiteralPath $TestRegistry -Name '' } | Should @shouldParams
-            { Get-ADTRegistryKey -LiteralPath $TestRegistry -Name " `f`n`r`t`v" } | Should @shouldParams
+            { Get-ADTRegistryKey -LiteralPath $null } | Should @shouldParams
+            { Get-ADTRegistryKey -LiteralPath '' } | Should @shouldParams
+            { Get-ADTRegistryKey -LiteralPath " `f`n`r`t`v" } | Should @shouldParams
         }
         It 'Should verify that Name is not null, empty or whitespace' {
             $shouldParams = @{

--- a/src/Tests/Unit/Remove-ADTIniSection.Tests.ps1
+++ b/src/Tests/Unit/Remove-ADTIniSection.Tests.ps1
@@ -38,7 +38,7 @@ MyOtherKey=MyOtherValue
             { Remove-ADTIniSection -FilePath " `f`n`r`t`v" -Section 'Anything' } | Should @shouldParams
         }
         It 'Should verify that FilePath exists' {
-            { Remove-ADTIniSection -FilePath "$TestDrive\DoesNotExist.ini" -Section 'Anything' } | Should -Throw -ExceptionType ([System.ArgumentException]) -ExpectedMessage "The specified file does not exist.*" -ErrorId 'InvalidFilePathParameterValue,Remove-ADTIniSection'
+            { Remove-ADTIniSection -FilePath "$TestDrive\DoesNotExist.ini" -Section 'Anything' } | Should -Throw -ExceptionType ([System.IO.FileNotFoundException]) -ErrorId 'LiteralPathNotFound,Remove-ADTIniSection'
         }
         It 'Should verify that Section is not null, empty or whitespace' {
             $shouldParams = @{

--- a/src/Tests/Unit/Remove-ADTIniValue.Tests.ps1
+++ b/src/Tests/Unit/Remove-ADTIniValue.Tests.ps1
@@ -36,7 +36,7 @@ MyOtherKey=MyOtherValue
             { Remove-ADTIniValue -FilePath " `f`n`r`t`v" -Section 'Anything' -Key 'Anything' } | Should @shouldParams
         }
         It 'Should verify that FilePath exists' {
-            { Remove-ADTIniValue -FilePath "$TestDrive\DoesNotExist.ini" -Section 'Anything' -Key 'Anything' } | Should -Throw -ExceptionType ([System.ArgumentException]) -ExpectedMessage 'The specified file does not exist.*' -ErrorId 'InvalidFilePathParameterValue,Remove-ADTIniValue'
+            { Remove-ADTIniValue -FilePath "$TestDrive\DoesNotExist.ini" -Section 'Anything' -Key 'Anything' } | Should -Throw -ExceptionType ([System.IO.FileNotFoundException]) -ErrorId 'LiteralPathNotFound,Remove-ADTIniValue'
         }
         It 'Should verify that Section is not null, empty or whitespace' {
             $shouldParams = @{


### PR DESCRIPTION
# Pull Request

## Description

- Fix bug in `Get-ADTRegistryKey` Pester test where null input validation wasn't being checked on the LiteralPath parameter
- Add missing output type to `Get-ADTPEFileArchitecture`
- Fully take advantage of `Resolve-ADTFileSystemPath`  in `Get-ADTIni*` and `Get-ADTShortcut`
- Refresh FileSystemInfo objects before checking if they exist
- More fixes to comment-based help
- Negligible performance improvement by calling `Add-Member` with the `-InputObject` parameter directly

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have tested that the module can build following my changes
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Validate that `Get-ADTIni*` and `Get-ADTShortcut` still throw when null/whitespace inputs are provided or, a file path that doesn't exist is provided.