### PR TITLE
Add `-Include` parameter to `Get-ADTBoundParametersAndDefaultValues`

### DIFF
--- a/src/PSAppDeployToolkit/Public/Get-ADTBoundParametersAndDefaultValues.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTBoundParametersAndDefaultValues.ps1
@@ -65,7 +65,6 @@ function Get-ADTBoundParametersAndDefaultValues
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ParameterSetName', Justification = "This parameter is used within delegates that PSScriptAnalyzer has no visibility of. See https://github.com/PowerShell/PSScriptAnalyzer/issues/1472 for more details.")]
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'HelpMessage', Justification = "This parameter is used within delegates that PSScriptAnalyzer has no visibility of. See https://github.com/PowerShell/PSScriptAnalyzer/issues/1472 for more details.")]
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'Exclude', Justification = "This parameter is used within delegates that PSScriptAnalyzer has no visibility of. See https://github.com/PowerShell/PSScriptAnalyzer/issues/1472 for more details.")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'Include', Justification = 'This parameter is used within delegates that PSScriptAnalyzer has no visibility of. See https://github.com/PowerShell/PSScriptAnalyzer/issues/1472 for more details.')]
     [CmdletBinding()]
     [OutputType([System.Collections.Generic.Dictionary[System.String, System.Object]])]
     param
@@ -207,13 +206,6 @@ function Get-ADTBoundParametersAndDefaultValues
                 $parameters | & {
                     process
                     {
-                        # Filter in included values.
-                        if ($Include -and ($Include -notcontains $_.Name.VariablePath.UserPath))
-                        {
-                            $null = $obj.Remove($_.Name.VariablePath.UserPath)
-                            return
-                        }
-
                         # Filter out excluded values.
                         if ($Exclude -contains $_.Name.VariablePath.UserPath)
                         {
@@ -252,7 +244,20 @@ function Get-ADTBoundParametersAndDefaultValues
                     }
                 }
 
-                # Return dictionary to the caller, even if it's empty.
+                if (!$Include)
+                {
+                    # Return dictionary to the caller, even if it's empty.
+                    return $obj
+                }
+
+                foreach ($key in $($obj.Keys))
+                {
+                    if ($Include -notcontains $key)
+                    {
+                        $null = $obj.Remove($key)
+                    }
+                }
+
                 return $obj
             }
             catch

--- a/src/PSAppDeployToolkit/Public/Get-ADTBoundParametersAndDefaultValues.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTBoundParametersAndDefaultValues.ps1
@@ -25,6 +25,13 @@ function Get-ADTBoundParametersAndDefaultValues
     .PARAMETER Exclude
         One or more parameter names to exclude from the results.
 
+        Note: When a parameter name appears in both `-Include` and `-Exclude`, the `-Exclude` filter takes precedence and the parameter is excluded.
+
+    .PARAMETER Include
+        One or more parameter names to explicitly include in the results. All other parameter names will be excluded.
+
+        Note: When a parameter name appears in both `-Include` and `-Exclude`, the `-Exclude` filter takes precedence and the parameter is excluded.
+
     .PARAMETER CommonParameters
         Specifies whether PowerShell advanced function common parameters should be included.
 
@@ -58,6 +65,7 @@ function Get-ADTBoundParametersAndDefaultValues
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ParameterSetName', Justification = "This parameter is used within delegates that PSScriptAnalyzer has no visibility of. See https://github.com/PowerShell/PSScriptAnalyzer/issues/1472 for more details.")]
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'HelpMessage', Justification = "This parameter is used within delegates that PSScriptAnalyzer has no visibility of. See https://github.com/PowerShell/PSScriptAnalyzer/issues/1472 for more details.")]
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'Exclude', Justification = "This parameter is used within delegates that PSScriptAnalyzer has no visibility of. See https://github.com/PowerShell/PSScriptAnalyzer/issues/1472 for more details.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'Include', Justification = 'This parameter is used within delegates that PSScriptAnalyzer has no visibility of. See https://github.com/PowerShell/PSScriptAnalyzer/issues/1472 for more details.')]
     [CmdletBinding()]
     [OutputType([System.Collections.Generic.Dictionary[System.String, System.Object]])]
     param
@@ -77,6 +85,10 @@ function Get-ADTBoundParametersAndDefaultValues
         [Parameter(Mandatory = $false)]
         [PSAppDeployToolkit.Attributes.ValidateNotNullOrWhiteSpace()]
         [System.String[]]$Exclude,
+
+        [Parameter(Mandatory = $false)]
+        [PSAppDeployToolkit.Attributes.ValidateNotNullOrWhiteSpace()]
+        [System.String[]]$Include,
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.SwitchParameter]$CommonParameters
@@ -193,6 +205,13 @@ function Get-ADTBoundParametersAndDefaultValues
                 $parameters | & {
                     process
                     {
+                        # Filter in included values.
+                        if ($Include -and ($Include -notcontains $_.Name.VariablePath.UserPath))
+                        {
+                            $null = $obj.Remove($_.Name.VariablePath.UserPath)
+                            return
+                        }
+
                         # Filter out excluded values.
                         if ($Exclude -contains $_.Name.VariablePath.UserPath)
                         {

--- a/src/PSAppDeployToolkit/Public/Get-ADTBoundParametersAndDefaultValues.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTBoundParametersAndDefaultValues.ps1
@@ -84,10 +84,12 @@ function Get-ADTBoundParametersAndDefaultValues
 
         [Parameter(Mandatory = $false)]
         [PSAppDeployToolkit.Attributes.ValidateNotNullOrWhiteSpace()]
+        [PSAppDeployToolkit.Attributes.ValidateUnique()]
         [System.String[]]$Exclude,
 
         [Parameter(Mandatory = $false)]
         [PSAppDeployToolkit.Attributes.ValidateNotNullOrWhiteSpace()]
+        [PSAppDeployToolkit.Attributes.ValidateUnique()]
         [System.String[]]$Include,
 
         [Parameter(Mandatory = $false)]

--- a/src/PSAppDeployToolkit/Public/Get-ADTBoundParametersAndDefaultValues.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTBoundParametersAndDefaultValues.ps1
@@ -244,20 +244,19 @@ function Get-ADTBoundParametersAndDefaultValues
                     }
                 }
 
-                if (!$Include)
+                if ($Include)
                 {
-                    # Return dictionary to the caller, even if it's empty.
-                    return $obj
-                }
-
-                foreach ($key in $($obj.Keys))
-                {
-                    if ($Include -notcontains $key)
+                    # Filter out parameters not specified in -Include
+                    foreach ($key in $($obj.Keys))
                     {
-                        $null = $obj.Remove($key)
+                        if ($Include -notcontains $key)
+                        {
+                            $null = $obj.Remove($key)
+                        }
                     }
                 }
 
+                # Return dictionary to the caller, even if it's empty.
                 return $obj
             }
             catch


### PR DESCRIPTION
# Pull Request

## Description

- Add `-Include` parameter to `Get-ADTBoundParametersAndDefaultValues`
- Add ValidateUnique attributes to `-Include` and `-Exclude`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have tested that the module can build following my changes
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

```PowerShell
function test-test {
[cmdletbinding()]
param (
[string]$param1,
[string]$param2,
[string]$param3
)
#Get-ADTBoundParametersAndDefaultValues -Invocation $MyInvocation
#Get-ADTBoundParametersAndDefaultValues -Invocation $MyInvocation -Exclude param3
Get-ADTBoundParametersAndDefaultValues -Invocation $MyInvocation -Include param3
}
```
