### PR TITLE
Replace Out-File with [System.IO.File]::WriteAllText to fix #2152

### DIFF
--- a/src/PSAppDeployToolkit/Public/New-ADTTemplate.ps1
+++ b/src/PSAppDeployToolkit/Public/New-ADTTemplate.ps1
@@ -622,11 +622,9 @@ function New-ADTTemplate
                 # Process the generated script
                 if ($Version.Equals(4))
                 {
-                    $params = @{
-                        LiteralPath = "$templatePath\Invoke-AppDeployToolkit.ps1"
-                        Encoding = ('utf8', 'utf8BOM')[$PSVersionTable.PSEdition.Equals('Core')]
-                    }
-                    $scriptContent = ((Get-Content @params -Raw) -replace '\r?\n', [System.Environment]::NewLine).Replace('..\..\..\..\', [System.Management.Automation.Language.NullString]::Value).Replace('2000-12-31', [System.DateTime]::Now.ToString('yyyy-MM-dd'))
+                    $scriptPath = "$templatePath\Invoke-AppDeployToolkit.ps1"
+                    $scriptEncoding = [System.Text.UTF8Encoding]::new($true, $true)
+                    $scriptContent = ([System.IO.File]::ReadAllText($scriptPath, $scriptEncoding) -replace '\r?\n', [System.Environment]::NewLine).Replace('..\..\..\..\', [System.Management.Automation.Language.NullString]::Value).Replace('2000-12-31', [System.DateTime]::Now.ToString('yyyy-MM-dd'))
 
                     # Collect all script content replacements (absolute offsets) across all features,
                     # then apply them in a single pass from end to start to preserve earlier offsets.
@@ -761,7 +759,7 @@ function New-ADTTemplate
                     {
                         $scriptContent = Set-ADTTextReplacements -InputText $scriptContent -Replacements $scriptReplacements
                     }
-                    Out-File -InputObject $scriptContent @params -Width ([System.Int16]::MaxValue) -Force
+                    [System.IO.File]::WriteAllText($scriptPath, $scriptContent, $scriptEncoding)
                 }
                 else
                 {

--- a/src/Tests/Unit/New-ADTTemplate.Tests.ps1
+++ b/src/Tests/Unit/New-ADTTemplate.Tests.ps1
@@ -67,6 +67,20 @@ Describe 'New-ADTTemplate' {
             }
             $keys
         }
+
+        function Get-ADTTrailingLineBreaks
+        {
+            [CmdletBinding()]
+            [OutputType([System.String])]
+            param ([System.String]$LiteralPath)
+            $content = [System.IO.File]::ReadAllText($LiteralPath, [System.Text.UTF8Encoding]::new($true))
+            $match = [System.Text.RegularExpressions.Regex]::Match($content, '(?:\r\n|\n)+$')
+            if ($match.Success)
+            {
+                return $match.Value.Replace("`r", '\r').Replace("`n", '\n')
+            }
+            return [System.String]::Empty
+        }
     }
 
     Context 'SessionProperties' {
@@ -138,6 +152,12 @@ Describe 'New-ADTTemplate' {
 
         It 'Invoke-AppDeployToolkit.ps1 has UTF-8 BOM' {
             $template.ScriptHasBom | Should -BeTrue
+        }
+
+        It 'Preserves the source template trailing line breaks' {
+            $sourcePath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\PSAppDeployToolkit\opt\Frontend\v4\Invoke-AppDeployToolkit.ps1'
+            $generatedPath = Join-Path -Path $template.Path -ChildPath 'Invoke-AppDeployToolkit.ps1'
+            (Get-ADTTrailingLineBreaks -LiteralPath $generatedPath) | Should -Be (Get-ADTTrailingLineBreaks -LiteralPath $sourcePath)
         }
 
         It 'Config\config.psd1 has UTF-8 BOM' {


### PR DESCRIPTION
# Pull Request

## Description

- Replace Out-File with [System.IO.File]::WriteAllText to prevent spurious linebreaks at EOF. Fixes #2152

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have tested that the module can build following my changes
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Pester test updated to compare trailing linebreaks before and after processing.