### PR TITLE
Update v3 compatibility wrappers in AppDeployToolkitMain.ps1 to handle functions/parameters deprecated in 4.2.0

### DIFF
--- a/src/PSAppDeployToolkit/opt/Frontend/v3/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/src/PSAppDeployToolkit/opt/Frontend/v3/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -1895,7 +1895,7 @@ function Update-GroupPolicy
 
 #---------------------------------------------------------------------------
 #
-# MARK: Wrapper around Get-ADTUniversalDate
+# MARK: Legacy implementation of Get-UniversalDate
 #
 #---------------------------------------------------------------------------
 
@@ -1916,15 +1916,19 @@ function Get-UniversalDate
     # Set strict mode to the highest within this function's scope.
     Set-StrictMode -Version 3
 
-    Write-ADTLogEntry -Message "The function [$($MyInvocation.MyCommand.Name)] has been replaced by [Get-ADTUniversalDate]. Please migrate your scripts to use the new function." -Severity Warning -DebugMessage:$noDepWarnings
+    Write-ADTLogEntry -Message "The function [$($MyInvocation.MyCommand.Name)] is deprecated and compatibility behavior is provided inline. Please migrate your scripts away from this function." -Severity Warning -DebugMessage:$noDepWarnings
     if ($PSBoundParameters.ContainsKey('ContinueOnError'))
     {
         $null = $PSBoundParameters.Remove('ContinueOnError')
     }
+    if (!$PSBoundParameters.ContainsKey('DateTime'))
+    {
+        $DateTime = [System.DateTime]::Now.ToString([System.Globalization.DateTimeFormatInfo]::CurrentInfo.UniversalSortableDateTimePattern).TrimEnd('Z')
+    }
 
     try
     {
-        Get-ADTUniversalDate @PSBoundParameters
+        [System.DateTime]::Parse($DateTime, $Host.CurrentCulture).ToUniversalTime().ToString([System.Globalization.DateTimeFormatInfo]::CurrentInfo.UniversalSortableDateTimePattern)
     }
     catch
     {

--- a/src/PSAppDeployToolkit/opt/Frontend/v3/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/src/PSAppDeployToolkit/opt/Frontend/v3/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -768,9 +768,13 @@ function Update-SessionEnvironmentVariables
     Set-StrictMode -Version 3
 
     Write-ADTLogEntry -Message "The function [$($MyInvocation.MyCommand.Name)] has been replaced by [Update-ADTEnvironmentPsProvider]. Please migrate your scripts to use the new function." -Severity Warning -DebugMessage:$noDepWarnings
+    if ($PSBoundParameters.ContainsKey('LoadLoggedOnUserEnvironmentVariables'))
+    {
+        $null = $PSBoundParameters.Remove('LoadLoggedOnUserEnvironmentVariables')
+    }
     try
     {
-        Update-ADTEnvironmentPsProvider -LoadLoggedOnUserEnvironmentVariables:$LoadLoggedOnUserEnvironmentVariables
+        Update-ADTEnvironmentPsProvider
     }
     catch
     {

--- a/src/PSAppDeployToolkit/opt/Frontend/v3/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/src/PSAppDeployToolkit/opt/Frontend/v3/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -2556,6 +2556,11 @@ function Execute-MSI
         $PSBoundParameters.Transforms = $Transform.Split([System.IO.Path]::PathSeparator)
         $null = $PSBoundParameters.Remove('Transform')
     }
+    if ($PSBoundParameters.ContainsKey('Patch'))
+    {
+        $PSBoundParameters.Patches = $Patch.Split([System.IO.Path]::PathSeparator)
+        $null = $PSBoundParameters.Remove('Patch')
+    }
     if ($PSBoundParameters.ContainsKey('IgnoreExitCodes'))
     {
         $PSBoundParameters.IgnoreExitCodes = $IgnoreExitCodes.Split(',')

--- a/src/PSAppDeployToolkit/opt/Frontend/v3/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/src/PSAppDeployToolkit/opt/Frontend/v3/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -2553,12 +2553,12 @@ function Execute-MSI
     }
     if ($PSBoundParameters.ContainsKey('Transform'))
     {
-        $PSBoundParameters.Transforms = $Transform.Split([System.IO.Path]::PathSeparator)
+        $PSBoundParameters.Transforms = $Transform.Split(';')
         $null = $PSBoundParameters.Remove('Transform')
     }
     if ($PSBoundParameters.ContainsKey('Patch'))
     {
-        $PSBoundParameters.Patches = $Patch.Split([System.IO.Path]::PathSeparator)
+        $PSBoundParameters.Patches = $Patch.Split(';')
         $null = $PSBoundParameters.Remove('Patch')
     }
     if ($PSBoundParameters.ContainsKey('IgnoreExitCodes'))

--- a/src/PSAppDeployToolkit/opt/Frontend/v3/AppDeployToolkit/AppDeployToolkitMain.ps1
+++ b/src/PSAppDeployToolkit/opt/Frontend/v3/AppDeployToolkit/AppDeployToolkitMain.ps1
@@ -2376,7 +2376,8 @@ function Execute-Process
         [System.Management.Automation.SwitchParameter]$CreateNoWindow,
 
         [Parameter(Mandatory = $false)]
-        [System.Management.Automation.SwitchParameter]$WorkingDirectory,
+        [PSAppDeployToolkit.Attributes.ValidateNotNullOrWhiteSpace()]
+        [System.String]$WorkingDirectory,
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.SwitchParameter]$NoWait,


### PR DESCRIPTION
# Pull Request

## Description

Update v3 compatibility wrappers in AppDeployToolkitMain.ps1 to handle functions/parameters deprecated in 4.2.0:
- Update Get-UniversalDate wrapper to inline 4.1.x implementation of now depreacted function Get-ADTUniversalDate
- Update Update-SessionEnvironmentVariables compatibility wrapper to drop deprecated LoadLoggedOnUserEnvironmentVariables parameter

Also fixed 2 long-standing never-reported issues:
- Fix incorrect type of $WorkingDirectory in Execute-Process wrapper
- Change Patch parameter to Patches in Execute-MSI wrapper

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have tested that the module can build following my changes
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Dot-sourced AppDeployToolkitMain.ps1 and tested all affected functions.