### PR TITLE
Read only fixes

### DIFF
--- a/src/PSAppDeployToolkit/Public/New-ADTTemplate.ps1
+++ b/src/PSAppDeployToolkit/Public/New-ADTTemplate.ps1
@@ -590,10 +590,16 @@ function New-ADTTemplate
                 }
                 Export-ADTScriptBlockToFile -ScriptBlock $Script:ADT.ModuleDefaults.Strings.([System.String]::Empty) -LiteralPath "$templatePath\Strings\strings.psd1"
 
-                # Remove any digital signatures from the ps*1 files.
+                # Ensure all editable ps*1 files are not read-only and remove any digital signatures.
                 Get-ChildItem -LiteralPath $templatePath -File -Filter *.ps*1 -Recurse | & {
                     process
                     {
+                        $attributes = [System.IO.File]::GetAttributes($_.FullName)
+                        if (($attributes -band [System.IO.FileAttributes]::ReadOnly) -ne 0)
+                        {
+                            [System.IO.File]::SetAttributes($_.FullName, ($attributes -band (-bnot [System.IO.FileAttributes]::ReadOnly)))
+                        }
+
                         if (($sigLine = $(($fileLines = [System.IO.File]::ReadAllLines($_.FullName)) -match '^# SIG # Begin signature block$')))
                         {
                             [System.IO.File]::WriteAllLines($_.FullName, $fileLines[0..($fileLines.IndexOf($sigLine) - 2)])
@@ -609,7 +615,11 @@ function New-ADTTemplate
                 $(Get-Item -LiteralPath $templateModulePath; Get-ChildItem -LiteralPath $templateModulePath -Recurse) | & {
                     process
                     {
-                        $_.Attributes = 'ReadOnly'
+                        $attributes = [System.IO.File]::GetAttributes($_.FullName)
+                        if (($attributes -band [System.IO.FileAttributes]::ReadOnly) -eq 0)
+                        {
+                            [System.IO.File]::SetAttributes($_.FullName, ($attributes -bor [System.IO.FileAttributes]::ReadOnly))
+                        }
                     }
                 }
 


### PR DESCRIPTION
# Pull Request

## Description

2 fixes:

- When creating a template, module files are marked as read only. When using this read-only module to create a template, that ends up with the user-editable Invoke-AppDeployToolkit.ps1 (and also the PSAppDeployToolkit.Extensions files) being marked as read-only, which causes New-ADTTemplate to throw an error. Read-only attributes are now removed from all *.ps*1 files in the template before the module is copied in.

- Existing code for marking the module files read-only was clobbering existing attributes and setting read-only. Now it preserves other existing attributes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have tested that the module can build following my changes
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Tested by creating a template then importing that module in a fresh session to create another template - which previously threw an error.
Also verified that other attributes (e.g. hidden/compress/encrypt) are preserved.