### PR TITLE
Guard `Get-ADTApplication` against missing UpgradeCodes registry key

### DIFF
--- a/src/PSAppDeployToolkit/Public/Get-ADTApplication.ps1
+++ b/src/PSAppDeployToolkit/Public/Get-ADTApplication.ps1
@@ -178,7 +178,7 @@ function Get-ADTApplication
 
         # Define compiled regex for use throughout main loop.
         $updatesAndHotFixesRegex = [System.Text.RegularExpressions.Regex]::new('((?i)kb\d+|(Cumulative|Security) Update|Hotfix)', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase -bor [System.Text.RegularExpressions.RegexOptions]::Compiled)
-        $msiUpgradeCodeLookupTable = Get-ChildItem -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UpgradeCodes\* | Get-ItemProperty | & {
+        $msiUpgradeCodeLookupTable = Get-ChildItem -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UpgradeCodes\* -ErrorAction Ignore | Get-ItemProperty | & {
             begin
             {
                 # Open lookup table dictionary for returning at the end.


### PR DESCRIPTION
# Pull Request

## Description

In Windows Sandbox, and potentially other scenarios, `HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UpgradeCodes` doesn't exist until an MSI is installed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested my changes to prove my fix is effective
- [x] I have tested that the module can build following my changes
- [ ] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Haven't tested this one yet, but `-ErrorAction Ignore` seems to be a convention for missing regkeys elsewhere in the codebase.
