### PR TITLE
Add -PerUser support to Register-ADTDll, Unregister-ADTDll and Invoke-ADTRegSvr32

### DIFF
--- a/src/PSAppDeployToolkit/Public/Invoke-ADTRegSvr32.ps1
+++ b/src/PSAppDeployToolkit/Public/Invoke-ADTRegSvr32.ps1
@@ -19,7 +19,7 @@ function Invoke-ADTRegSvr32
     .PARAMETER Action
         Specify whether to register or unregister the DLL.
 
-    .PARAMETER PerUser
+    .PARAMETER AsUser
         Specifies that the DLL should be registered for the current user only by calling its DllInstall entry point with the 'user' argument (regsvr32.exe /n /i:user). If this function is running under the SYSTEM account, regsvr32.exe is executed in the context of the currently logged on user. Note that the DLL must support per-user registration via a DllInstall export for this to work.
 
     .INPUTS
@@ -43,7 +43,7 @@ function Invoke-ADTRegSvr32
         Unregisters the specified DLL file.
 
     .EXAMPLE
-        Invoke-ADTRegSvr32 -FilePath "C:\Test\DcTLSFileToDMSComp.dll" -Action 'Register' -PerUser
+        Invoke-ADTRegSvr32 -FilePath "C:\Test\DcTLSFileToDMSComp.dll" -Action 'Register' -AsUser
 
         Registers the specified DLL file for the currently logged on user only.
 
@@ -83,7 +83,7 @@ function Invoke-ADTRegSvr32
         [System.String]$Action,
 
         [Parameter(Mandatory = $false)]
-        [System.Management.Automation.SwitchParameter]$PerUser
+        [System.Management.Automation.SwitchParameter]$AsUser
     )
 
     begin
@@ -94,12 +94,12 @@ function Invoke-ADTRegSvr32
         {
             Register
             {
-                "/s$(if ($PerUser) { ' /n /i:user' }) `"$FilePath`""
+                "/s$(if ($AsUser) { ' /n /i:user' }) `"$FilePath`""
                 break
             }
             Unregister
             {
-                "/s /u$(if ($PerUser) { ' /n /i:user' }) `"$FilePath`""
+                "/s /u$(if ($AsUser) { ' /n /i:user' }) `"$FilePath`""
                 break
             }
         }
@@ -166,19 +166,8 @@ function Invoke-ADTRegSvr32
 
                 # Register the DLL file and measure the success. Per-user registration writes to the
                 # user's HKCU hive, so when running as SYSTEM, execute as the logged on user instead.
-                if ($PerUser -and [PSADT.AccountManagement.AccountUtilities]::CallerSid.IsWellKnown([System.Security.Principal.WellKnownSidType]::LocalSystemSid))
+                if ($AsUser)
                 {
-                    if (!(Get-ADTClientServerUser))
-                    {
-                        $naerParams = @{
-                            Exception = [System.InvalidOperationException]::new("The DLL file [$FilePath] cannot be $($Action.ToLowerInvariant() + 'ed') per-user as there is no logged on user to process the request against.")
-                            Category = [System.Management.Automation.ErrorCategory]::InvalidOperation
-                            ErrorId = 'NoActiveUserError'
-                            TargetObject = $FilePath
-                            RecommendedAction = "Please ensure a user is logged onto the system and try again."
-                        }
-                        throw (New-ADTErrorRecord @naerParams)
-                    }
                     Start-ADTProcessAsUser -FilePath $RegSvr32Path -ArgumentList $ActionParameters -CreateNoWindow -SuccessExitCodes 0
                 }
                 else

--- a/src/PSAppDeployToolkit/Public/Invoke-ADTRegSvr32.ps1
+++ b/src/PSAppDeployToolkit/Public/Invoke-ADTRegSvr32.ps1
@@ -19,6 +19,9 @@ function Invoke-ADTRegSvr32
     .PARAMETER Action
         Specify whether to register or unregister the DLL.
 
+    .PARAMETER PerUser
+        Specifies that the DLL should be registered for the current user only by calling its DllInstall entry point with the 'user' argument (regsvr32.exe /n /i:user). If this function is running under the SYSTEM account, regsvr32.exe is executed in the context of the currently logged on user. Note that the DLL must support per-user registration via a DllInstall export for this to work.
+
     .INPUTS
         None
 
@@ -38,6 +41,11 @@ function Invoke-ADTRegSvr32
         Invoke-ADTRegSvr32 -FilePath "C:\Test\DcTLSFileToDMSComp.dll" -Action 'Unregister'
 
         Unregisters the specified DLL file.
+
+    .EXAMPLE
+        Invoke-ADTRegSvr32 -FilePath "C:\Test\DcTLSFileToDMSComp.dll" -Action 'Register' -PerUser
+
+        Registers the specified DLL file for the currently logged on user only.
 
     .NOTES
         An active ADT session is NOT required to use this function.
@@ -72,7 +80,10 @@ function Invoke-ADTRegSvr32
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('Register', 'Unregister')]
-        [System.String]$Action
+        [System.String]$Action,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.SwitchParameter]$PerUser
     )
 
     begin
@@ -83,12 +94,12 @@ function Invoke-ADTRegSvr32
         {
             Register
             {
-                "/s `"$FilePath`""
+                "/s$(if ($PerUser) { ' /n /i:user' }) `"$FilePath`""
                 break
             }
             Unregister
             {
-                "/s /u `"$FilePath`""
+                "/s /u$(if ($PerUser) { ' /n /i:user' }) `"$FilePath`""
                 break
             }
         }
@@ -153,8 +164,27 @@ function Invoke-ADTRegSvr32
                     throw (New-ADTErrorRecord @naerParams)
                 }
 
-                # Register the DLL file and measure the success.
-                Start-ADTProcess -FilePath $RegSvr32Path -ArgumentList $ActionParameters -CreateNoWindow -SuccessExitCodes 0
+                # Register the DLL file and measure the success. Per-user registration writes to the
+                # user's HKCU hive, so when running as SYSTEM, execute as the logged on user instead.
+                if ($PerUser -and [PSADT.AccountManagement.AccountUtilities]::CallerSid.IsWellKnown([System.Security.Principal.WellKnownSidType]::LocalSystemSid))
+                {
+                    if (!(Get-ADTClientServerUser))
+                    {
+                        $naerParams = @{
+                            Exception = [System.InvalidOperationException]::new("The DLL file [$FilePath] cannot be $($Action.ToLowerInvariant() + 'ed') per-user as there is no logged on user to process the request against.")
+                            Category = [System.Management.Automation.ErrorCategory]::InvalidOperation
+                            ErrorId = 'NoActiveUserError'
+                            TargetObject = $FilePath
+                            RecommendedAction = "Please ensure a user is logged onto the system and try again."
+                        }
+                        throw (New-ADTErrorRecord @naerParams)
+                    }
+                    Start-ADTProcessAsUser -FilePath $RegSvr32Path -ArgumentList $ActionParameters -CreateNoWindow -SuccessExitCodes 0
+                }
+                else
+                {
+                    Start-ADTProcess -FilePath $RegSvr32Path -ArgumentList $ActionParameters -CreateNoWindow -SuccessExitCodes 0
+                }
             }
             catch
             {

--- a/src/PSAppDeployToolkit/Public/Register-ADTDll.ps1
+++ b/src/PSAppDeployToolkit/Public/Register-ADTDll.ps1
@@ -16,7 +16,7 @@ function Register-ADTDll
     .PARAMETER FilePath
         Path to the DLL file.
 
-    .PARAMETER PerUser
+    .PARAMETER AsUser
         Specifies that the DLL should be registered for the current user only by calling its DllInstall entry point with the 'user' argument (regsvr32.exe /n /i:user). If this function is running under the SYSTEM account, regsvr32.exe is executed in the context of the currently logged on user. Note that the DLL must support per-user registration via a DllInstall export for this to work.
 
     .INPUTS
@@ -35,7 +35,7 @@ function Register-ADTDll
         Registers the specified DLL file.
 
     .EXAMPLE
-        Register-ADTDll -FilePath "C:\Test\DcTLSFileToDMSComp.dll" -PerUser
+        Register-ADTDll -FilePath "C:\Test\DcTLSFileToDMSComp.dll" -AsUser
 
         Registers the specified DLL file for the currently logged on user only.
 
@@ -70,7 +70,7 @@ function Register-ADTDll
         [System.String]$FilePath,
 
         [Parameter(Mandatory = $false)]
-        [System.Management.Automation.SwitchParameter]$PerUser
+        [System.Management.Automation.SwitchParameter]$AsUser
     )
 
     begin

--- a/src/PSAppDeployToolkit/Public/Register-ADTDll.ps1
+++ b/src/PSAppDeployToolkit/Public/Register-ADTDll.ps1
@@ -16,6 +16,9 @@ function Register-ADTDll
     .PARAMETER FilePath
         Path to the DLL file.
 
+    .PARAMETER PerUser
+        Specifies that the DLL should be registered for the current user only by calling its DllInstall entry point with the 'user' argument (regsvr32.exe /n /i:user). If this function is running under the SYSTEM account, regsvr32.exe is executed in the context of the currently logged on user. Note that the DLL must support per-user registration via a DllInstall export for this to work.
+
     .INPUTS
         None
 
@@ -30,6 +33,11 @@ function Register-ADTDll
         Register-ADTDll -FilePath "C:\Test\DcTLSFileToDMSComp.dll"
 
         Registers the specified DLL file.
+
+    .EXAMPLE
+        Register-ADTDll -FilePath "C:\Test\DcTLSFileToDMSComp.dll" -PerUser
+
+        Registers the specified DLL file for the currently logged on user only.
 
     .NOTES
         An active ADT session is NOT required to use this function.
@@ -59,7 +67,10 @@ function Register-ADTDll
                 }
                 return ![System.String]::IsNullOrWhiteSpace($_)
             })]
-        [System.String]$FilePath
+        [System.String]$FilePath,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.SwitchParameter]$PerUser
     )
 
     begin

--- a/src/PSAppDeployToolkit/Public/Unregister-ADTDll.ps1
+++ b/src/PSAppDeployToolkit/Public/Unregister-ADTDll.ps1
@@ -16,6 +16,9 @@ function Unregister-ADTDll
     .PARAMETER FilePath
         Path to the DLL file.
 
+    .PARAMETER PerUser
+        Specifies that the DLL should be unregistered for the current user only by calling its DllInstall entry point with the 'user' argument (regsvr32.exe /u /n /i:user). If this function is running under the SYSTEM account, regsvr32.exe is executed in the context of the currently logged on user. Note that the DLL must support per-user registration via a DllInstall export for this to work.
+
     .INPUTS
         None
 
@@ -30,6 +33,11 @@ function Unregister-ADTDll
         Unregister-ADTDll -FilePath "C:\Test\DcTLSFileToDMSComp.dll"
 
         Unregisters the specified DLL file.
+
+    .EXAMPLE
+        Unregister-ADTDll -FilePath "C:\Test\DcTLSFileToDMSComp.dll" -PerUser
+
+        Unregisters the specified DLL file for the currently logged on user only.
 
     .NOTES
         An active ADT session is NOT required to use this function.
@@ -59,7 +67,10 @@ function Unregister-ADTDll
                 }
                 return ![System.String]::IsNullOrWhiteSpace($_)
             })]
-        [System.String]$FilePath
+        [System.String]$FilePath,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.SwitchParameter]$PerUser
     )
 
     begin

--- a/src/PSAppDeployToolkit/Public/Unregister-ADTDll.ps1
+++ b/src/PSAppDeployToolkit/Public/Unregister-ADTDll.ps1
@@ -16,7 +16,7 @@ function Unregister-ADTDll
     .PARAMETER FilePath
         Path to the DLL file.
 
-    .PARAMETER PerUser
+    .PARAMETER AsUser
         Specifies that the DLL should be unregistered for the current user only by calling its DllInstall entry point with the 'user' argument (regsvr32.exe /u /n /i:user). If this function is running under the SYSTEM account, regsvr32.exe is executed in the context of the currently logged on user. Note that the DLL must support per-user registration via a DllInstall export for this to work.
 
     .INPUTS
@@ -35,7 +35,7 @@ function Unregister-ADTDll
         Unregisters the specified DLL file.
 
     .EXAMPLE
-        Unregister-ADTDll -FilePath "C:\Test\DcTLSFileToDMSComp.dll" -PerUser
+        Unregister-ADTDll -FilePath "C:\Test\DcTLSFileToDMSComp.dll" -AsUser
 
         Unregisters the specified DLL file for the currently logged on user only.
 
@@ -70,7 +70,7 @@ function Unregister-ADTDll
         [System.String]$FilePath,
 
         [Parameter(Mandatory = $false)]
-        [System.Management.Automation.SwitchParameter]$PerUser
+        [System.Management.Automation.SwitchParameter]$AsUser
     )
 
     begin


### PR DESCRIPTION
# Pull Request

## Description

Adds a -PerUser switch for DLL registration to run in the user's context, including the logged-on user if running as SYSTEM.

I was [fixing the Teams Outlook addin](https://learn.microsoft.com/en-us/troubleshoot/microsoftteams/meetings/resolve-teams-meeting-add-in-issues#reregister-the-teams-addin-loader), but found I couldn't use `Register-ADTDll` because I was running in SYSTEM context.

Happy to make this a feature request instead if that's preferred. I also wasn't sure about the structure, `Register-ADTDllAsUser` felt like overkill but I couldn't find any other cmdlets with a user-context switch. I went with `-PerUser` to avoid ambiguity with the `-User [Identifier]` parameter used elsewhere. `-AsUser` might be better though?

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have tested that the module can build following my changes
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

I assume the docstring changes will update the docs automatically.

## How Has This Been Tested?

Used the cmdlets to unregister and register `%LocalAppData%\Microsoft\TeamsMeetingAdd-in\1.26.16801\x64\Microsoft.Teams.AddinLoader.dll`