### PR TITLE
Migrate Pester tests from v5 to v6

### DIFF
--- a/.github/workflows/module-build.yml
+++ b/.github/workflows/module-build.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # https://github.com/actions/cache/releases/tag/v5.0.3
       with:
         path: ~\Documents\WindowsPowerShell\Modules
-        key: ${{ runner.os }}-psmodule-PSScriptAnalyzer-1.25.0-Pester-5.7.1-platyPS-0.14.2-Alt3.Docusaurus.Powershell-1.0.37
+        key: ${{ runner.os }}-psmodule-PSScriptAnalyzer-1.25.0-Pester-6.0.1-platyPS-0.14.2-Alt3.Docusaurus.Powershell-1.0.37
 
     - name: Install PowerShell modules
       if: steps.psmodule-cache.outputs.cache-hit != 'true'
@@ -46,7 +46,7 @@ jobs:
       run: |
         Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
         Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.25.0 -Force -Scope CurrentUser
-        Install-Module -Name Pester -RequiredVersion 5.7.1 -Force -SkipPublisherCheck -Scope CurrentUser
+        Install-Module -Name Pester -RequiredVersion 6.0.1 -Force -SkipPublisherCheck -Scope CurrentUser
         Install-Module -Name platyPS -RequiredVersion 0.14.2 -Force -Scope CurrentUser
         Install-Module -Name Alt3.Docusaurus.Powershell -RequiredVersion 1.0.37 -Force -Scope CurrentUser
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -239,7 +239,7 @@
         {
             "label": "DevCC-Single",
             "type": "shell",
-            "command": "Import-Module -Name '${workspaceFolder}/src/${workspaceFolderBasename}/${workspaceFolderBasename}.psm1';$pesterConfig = New-PesterConfiguration;$pesterConfig.run.Path = '${workspaceFolder}/src/Tests/Unit/*/${input:functionName}.Tests.ps1';$pesterConfig.CodeCoverage.Enabled = $true;$pesterConfig.CodeCoverage.Path = '${workspaceFolder}/src/${workspaceFolderBasename}/*/${input:functionName}.ps1';$pesterConfig.CodeCoverage.OutputPath = '${workspaceFolder}/cov.xml';$pesterConfig.CodeCoverage.OutputFormat = 'CoverageGutters';Invoke-Pester -Configuration $pesterConfig",
+            "command": "Import-Module -Name '${workspaceFolder}/src/${workspaceFolderBasename}/${workspaceFolderBasename}.psm1';$pesterConfig = New-PesterConfiguration;$pesterConfig.run.Path = '${workspaceFolder}/src/Tests/Unit/*/${input:functionName}.Tests.ps1';$pesterConfig.CodeCoverage.Enabled = $true;$pesterConfig.CodeCoverage.Path = '${workspaceFolder}/src/${workspaceFolderBasename}/*/${input:functionName}.ps1';$pesterConfig.CodeCoverage.OutputPath = '${workspaceFolder}/cov.xml';$pesterConfig.CodeCoverage.OutputFormat = 'JaCoCo';Invoke-Pester -Configuration $pesterConfig",
             "problemMatcher": "$pester",
             "presentation": {
                 "echo": false,

--- a/src/PSAppDeployToolkit.Build/PSAppDeployToolkit.Build.psm1
+++ b/src/PSAppDeployToolkit.Build/PSAppDeployToolkit.Build.psm1
@@ -138,7 +138,7 @@ try
                 }).AsReadOnly()
             RequiredModules = ([System.Collections.ObjectModel.ReadOnlyCollection[Microsoft.PowerShell.Commands.ModuleSpecification]][Microsoft.PowerShell.Commands.ModuleSpecification[]]$(
                     @{ ModuleName = 'PSScriptAnalyzer'; Guid = 'd6245802-193d-4068-a631-8863a4342a18'; ModuleVersion = '1.25.0' }
-                    @{ ModuleName = 'Pester'; Guid = 'a699dea5-2c73-4616-a270-1f7abb777e71'; ModuleVersion = '5.7.1' }
+                    @{ ModuleName = 'Pester'; Guid = 'a699dea5-2c73-4616-a270-1f7abb777e71'; ModuleVersion = '6.0.1' }
                 ))
             ModuleName = 'PSAppDeployToolkit'
             ModuleSpecification = [Microsoft.PowerShell.Commands.ModuleSpecification]@{ ModuleName = [System.Management.Automation.WildcardPattern]::Escape([System.IO.Path]::Combine($PSScriptRoot -replace '\.Build$', 'PSAppDeployToolkit.psd1')); Guid = '8c3c366b-8606-4576-9f2d-4051144f7ca2'; ModuleVersion = '4.2.0' }

--- a/src/PSAppDeployToolkit.Build/Private/Invoke-ADTPesterOutputHandler.ps1
+++ b/src/PSAppDeployToolkit.Build/Private/Invoke-ADTPesterOutputHandler.ps1
@@ -12,7 +12,7 @@ filter Invoke-ADTPesterOutputHandler
     {
         # Skip over the messages we don't want.
         $rawLine = $_.MessageData.Message -replace '\x1B\[[0-9;]*m'
-        if (!$rawLine.Length -or ($rawLine -cmatch '^(Pester v\d+|Running tests\.|\s\d+|Missed commands:|\r\nFile\s+Class\s+Function\s+Line\s+Command)'))
+        if (!$rawLine.Length -or ($rawLine -cmatch '^(Pester v\d+|Running tests( from \d+ files?)?\.|\s\d+|Missed commands:|\r\nFile\s+Class\s+Function\s+Line\s+Command)'))
         {
             return
         }

--- a/src/PSAppDeployToolkit.Build/Private/Invoke-ADTPesterOutputHandler.ps1
+++ b/src/PSAppDeployToolkit.Build/Private/Invoke-ADTPesterOutputHandler.ps1
@@ -12,7 +12,7 @@ filter Invoke-ADTPesterOutputHandler
     {
         # Skip over the messages we don't want.
         $rawLine = $_.MessageData.Message -replace '\x1B\[[0-9;]*m'
-        if (!$rawLine.Length -or ($rawLine -cmatch '^(Pester v\d+|Running tests( from \d+ files?)?\.|\s\d+|Missed commands:|\r\nFile\s+Class\s+Function\s+Line\s+Command)'))
+        if (!$rawLine.Length -or ($rawLine -cmatch '^(Pester v\d+|\s*Running tests( from \d+ files?)?\.|\s\d+|Missed commands:|\r\nFile\s+Class\s+Function\s+Line\s+Command)'))
         {
             return
         }


### PR DESCRIPTION
Fix #2253

Pester 6 shipped, so this moves the suite onto it. It is mostly the version pin, the tests run on v6 unchanged and the classic `Should -Be` assertions keep working, so I did not touch them. The new `Should-*` assertions are a separate change.

- Pin Pester `6.0.1` in the CI workflow (install step and the module cache key) and in `PSAppDeployToolkit.Build`'s required modules.
- `DevCC-Single` VSCode task set `CodeCoverage.OutputFormat = 'CoverageGutters'`, removed in v6, so switch it to `JaCoCo`.
- The output handler filtered the old `Running tests.` banner. v6 renamed it to `Running tests from N files.` and prints it with a leading newline, so widen the filter to skip that too.

Verified on `windows-latest` (Windows PowerShell 5.1) with Pester 6.0.1: 1539 unit tests pass, 0 failures.

Same approach as the PowerShell migration in #27661, keep the assertions and only fix what v6 removed. PSADT has no empty `-ForEach` cases though (the only data-driven one is the exported-function list, never empty once the module is imported), so I left `Run.FailOnNullOrEmptyForEach` at the v6 default rather than disabling it, which keeps the empty-data guard on.

🤖
