### PR TITLE
Add identity transformer

### DIFF
--- a/src/PSADT/PSAppDeployToolkit/Attributes/IdentityTransformationAttribute.cs
+++ b/src/PSADT/PSAppDeployToolkit/Attributes/IdentityTransformationAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using PSAppDeployToolkit.Utilities;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation;
 using System.Reflection;
@@ -27,31 +28,31 @@ namespace PSAppDeployToolkit.Attributes
         /// <exception cref="ArgumentException">Thrown if the input object is not supported for transformation.</exception>
         /// <exception cref="ArgumentNullException">Thrown if the input data is null.</exception>
         [SuppressMessage("Style", "IDE0046:Use conditional expression for return", Justification = "Conditional expression would be unreadable.")]
-        public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
+        public override object Transform(EngineIntrinsics engineIntrinsics, object? inputData)
         {
-            if (inputData is null)
+            if (!PowerShellUtilities.TryGetBaseObject(inputData, out inputData))
             {
-                throw new ArgumentNullException(nameof(inputData), "Cannot transform null to an IdentityReference.");
-            }
-            if (inputData is WellKnownSidType wellKnownSidType)
-            {
-                return new SecurityIdentifier(wellKnownSidType, domainSid: null);
+                throw new ArgumentNullException(paramName: nameof(inputData), "Cannot transform null to IdentityReference.");
             }
             if (inputData is IdentityReference identity)
             {
                 return identity;
             }
+            if (inputData is WellKnownSidType wellKnownSidType)
+            {
+                return new SecurityIdentifier(wellKnownSidType, domainSid: null);
+            }
             if (inputData is WindowsIdentity windowsIdentity)
             {
                 return windowsIdentity.User ?? throw new InvalidOperationException("The given WindowsIdentity did not provide the required user identity.");
             }
-            if (TryConvertPowerShellCommandObject(inputData, out SecurityIdentifier? pwshCommandSid))
-            {
-                return pwshCommandSid;
-            }
             if (inputData is string str && TryParseIdentityReference(str, out IdentityReference? strIdentity))
             {
                 return strIdentity;
+            }
+            if (TryConvertPowerShellCommandObject(inputData, out SecurityIdentifier? pwshCommandSid))
+            {
+                return pwshCommandSid;
             }
             throw new ArgumentException("Input data must be of type IdentityReference, WindowsIdentity, LocalPrincipal, WellKnownSidType or a string representing any of those types.", nameof(inputData));
         }
@@ -96,10 +97,6 @@ namespace PSAppDeployToolkit.Attributes
         private static bool TryParseSid(string identityString, [NotNullWhen(true)] out SecurityIdentifier? identity)
         {
             identity = null;
-            if (string.IsNullOrWhiteSpace(identityString))
-            {
-                return false;
-            }
             try
             {
                 identity = new SecurityIdentifier(identityString);
@@ -120,10 +117,6 @@ namespace PSAppDeployToolkit.Attributes
         private static bool TryParseNTAccount(string identityString, [NotNullWhen(true)] out NTAccount? identity)
         {
             identity = null;
-            if (string.IsNullOrWhiteSpace(identityString))
-            {
-                return false;
-            }
             try
             {
                 identity = new NTAccount(identityString);
@@ -145,15 +138,6 @@ namespace PSAppDeployToolkit.Attributes
         private static bool TryConvertPowerShellCommandObject(object identityObject, [NotNullWhen(true)] out SecurityIdentifier? identity)
         {
             identity = null;
-            // Unwrap the actual object, if it is wrapped
-            if (identityObject is PSObject psObj)
-            {
-                identityObject = psObj.BaseObject;
-            }
-            if (identityObject is null)
-            {
-                return false;
-            }
             Type objectType = identityObject.GetType();
             if (!string.Equals(objectType.Namespace, "Microsoft.PowerShell.Commands", StringComparison.Ordinal))
             {
@@ -166,12 +150,12 @@ namespace PSAppDeployToolkit.Attributes
                 identity = directSid;
                 return true;
             }
-            if (objectType.BaseType is Type parentType
-                && string.Equals(parentType.Name, "LocalPrincipal", StringComparison.Ordinal)
-                && objectType.GetProperty("SID", typeof(SecurityIdentifier)) is PropertyInfo parentProperty
-                && parentProperty.GetValue(identityObject) is SecurityIdentifier parentSid)
+            if (objectType.BaseType is Type baseType
+                && string.Equals(baseType.Name, "LocalPrincipal", StringComparison.Ordinal)
+                && objectType.GetProperty("SID", typeof(SecurityIdentifier)) is PropertyInfo baseProperty
+                && baseProperty.GetValue(identityObject) is SecurityIdentifier baseSid)
             {
-                identity = parentSid;
+                identity = baseSid;
                 return true;
             }
             return false;

--- a/src/PSADT/PSAppDeployToolkit/Attributes/IdentityTransformationAttribute.cs
+++ b/src/PSADT/PSAppDeployToolkit/Attributes/IdentityTransformationAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation;
 using System.Reflection;
 using System.Security.Principal;
@@ -16,81 +17,113 @@ namespace PSAppDeployToolkit.Attributes
         ///  * <see cref="IdentityReference"/>
         ///  * <see cref="WindowsIdentity"/>
         ///  * <see cref="WellKnownSidType"/>
-        ///  * LocalUser
+        ///  * LocalPrincipal
         ///  * <see cref="string"/> representing the above
         /// </summary>
         /// <param name="engineIntrinsics">The PowerShell engine intrinsics.</param>
         /// <param name="inputData">The input value to transform.</param>
-        /// <returns></returns>
-        /// <exception cref="InvalidOperationException">Thrown if the input object did not contain the required properties.</exception>
+        /// <returns>The identity reference the input object represents.</returns>
+        /// <exception cref="InvalidOperationException">Thrown if the input object was valid but did not contain the required data.</exception>
         /// <exception cref="ArgumentException">Thrown if the input object is not supported for transformation.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if the input data is null.</exception>
+        [SuppressMessage("Style", "IDE0046:Use conditional expression for return", Justification = "Conditional expression would be unreadable.")]
         public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
         {
-
+            if (inputData is null)
+            {
+                throw new ArgumentNullException(nameof(inputData), "Cannot transform null to an IdentityReference.");
+            }
             if (inputData is WellKnownSidType wellKnownSidType)
             {
-                return new SecurityIdentifier(wellKnownSidType, null);
+                return new SecurityIdentifier(wellKnownSidType, domainSid: null);
             }
-            else if (inputData is IdentityReference identity)
+            if (inputData is IdentityReference identity)
             {
                 return identity;
             }
-            else if (inputData is WindowsIdentity windowsIdentity)
+            if (inputData is WindowsIdentity windowsIdentity)
             {
-                return windowsIdentity.User
-                    ?? throw new InvalidOperationException("The given WindowsIdentity did not provide the required user identity.");
+                return windowsIdentity.User ?? throw new InvalidOperationException("The given WindowsIdentity did not provide the required user identity.");
             }
-            else if (inputData.GetType().FullName == "Microsoft.PowerShell.Commands.LocalUser"
-                && inputData.GetType().GetProperty("SID", typeof(SecurityIdentifier)) is PropertyInfo localUserSidProperty)
+            if (TryConvertPowerShellCommandObject(inputData, out SecurityIdentifier? pwshCommandSid))
             {
-                return localUserSidProperty.GetValue(inputData)
-                    ?? throw new InvalidOperationException("The given LocalUser did not provide the required SID property.");
+                return pwshCommandSid;
             }
-            else if (inputData is string str && TryParseIdentityReference(str, out IdentityReference strIdentity))
+            if (inputData is string str && TryParseIdentityReference(str, out IdentityReference? strIdentity))
             {
                 return strIdentity;
             }
-            else
-            {
-                throw new ArgumentException("Input data must be of type string, IdentityReference, WindowsIdentity or a string representing any of those types, or a WellKnownSidType value.", nameof(inputData));
-            }
+            throw new ArgumentException("Input data must be of type IdentityReference, WindowsIdentity, LocalPrincipal, WellKnownSidType or a string representing any of those types.", nameof(inputData));
         }
 
         /// <summary>
-        /// Tries to parse a string as <see cref="IdentityReference"/>, returning the corresponding object.
+        /// Try to parse string into an <see cref="IdentityReference"/>.
         /// </summary>
-        /// <param name="identityString">The string to parse.</param>
-        /// <param name="identity">The <see cref="IdentityReference"/> if parsing succeeds; otherwise NullSid</param>
-        /// <returns>True if the input string was successfully parsed  name; otherwise, false.</returns>
-        private static bool TryParseIdentityReference(string identityString, out IdentityReference identity)
+        /// <param name="identityString">The string representing the IdentityReference.</param>
+        /// <param name="identity">The parsed IdentityReference.</param>
+        /// <returns>True if parsing was successful, otherwise false.</returns>
+        private static bool TryParseIdentityReference(string identityString, [NotNullWhen(true)] out IdentityReference? identity)
         {
-            identity = new SecurityIdentifier(WellKnownSidType.NullSid, null);
+            identity = null;
             if (string.IsNullOrWhiteSpace(identityString))
             {
                 return false;
             }
-
-            // Try Enum
-            if (Enum.TryParse(identityString, true, out WellKnownSidType wellKnownSidType))
+            if (Enum.TryParse(identityString, ignoreCase: true, out WellKnownSidType wellKnownSidType))
             {
-                identity = new SecurityIdentifier(wellKnownSidType, null);
+                identity = new SecurityIdentifier(wellKnownSidType, domainSid: null);
                 return true;
             }
-
-            // Try SID
-            if (identityString.StartsWith("S-", StringComparison.OrdinalIgnoreCase))
+            if (TryParseSid(identityString, out SecurityIdentifier? sid))
             {
-                try
-                {
-                    identity = new SecurityIdentifier(identityString);
-                    return true;
-                }
-                catch (ArgumentException)
-                {
-                }
+                identity = sid;
+                return true;
             }
+            if (TryParseNTAccount(identityString, out NTAccount? ntAccount))
+            {
+                identity = ntAccount;
+                return true;
+            }
+            return false;
+        }
 
-            // Try NTAccount
+        /// <summary>
+        /// Try to parse string into a <see cref="SecurityIdentifier"/>.
+        /// </summary>
+        /// <param name="identityString">The string representing the SecrutiyIdentifier.</param>
+        /// <param name="identity">The parsed SecrutiyIdentifier.</param>
+        /// <returns>True if parsing was successful, otherwise false.</returns>
+        private static bool TryParseSid(string identityString, [NotNullWhen(true)] out SecurityIdentifier? identity)
+        {
+            identity = null;
+            if (string.IsNullOrWhiteSpace(identityString))
+            {
+                return false;
+            }
+            try
+            {
+                identity = new SecurityIdentifier(identityString);
+                return true;
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to parse string into a <see cref="NTAccount"/>.
+        /// </summary>
+        /// <param name="identityString">The string representing the NTAccount.</param>
+        /// <param name="identity">The parsed NTAccount.</param>
+        /// <returns>True if parsing was successful, otherwise false.</returns>
+        private static bool TryParseNTAccount(string identityString, [NotNullWhen(true)] out NTAccount? identity)
+        {
+            identity = null;
+            if (string.IsNullOrWhiteSpace(identityString))
+            {
+                return false;
+            }
             try
             {
                 identity = new NTAccount(identityString);
@@ -98,8 +131,49 @@ namespace PSAppDeployToolkit.Attributes
             }
             catch (IdentityNotMappedException)
             {
+                return false;
             }
+        }
 
+
+        /// <summary>
+        /// Try to extract the SID from a LocalPrincipal type using reflection. The LocalPrincipal type is used within the Microsoft.PowerShell.LocalAccounts module.
+        /// </summary>
+        /// <param name="identityObject">The object to analyse.</param>
+        /// <param name="identity">The parsed SecrutiyIdentifier.</param>
+        /// <returns>True if extraction was successful, otherwise false.</returns>
+        private static bool TryConvertPowerShellCommandObject(object identityObject, [NotNullWhen(true)] out SecurityIdentifier? identity)
+        {
+            identity = null;
+            // Unwrap the actual object, if it is wrapped
+            if (identityObject is PSObject psObj)
+            {
+                identityObject = psObj.BaseObject;
+            }
+            if (identityObject is null)
+            {
+                return false;
+            }
+            Type objectType = identityObject.GetType();
+            if (!string.Equals(objectType.Namespace, "Microsoft.PowerShell.Commands", StringComparison.Ordinal))
+            {
+                return false;
+            }
+            if (string.Equals(objectType.Name, "LocalPrincipal", StringComparison.Ordinal)
+                && objectType.GetProperty("SID", typeof(SecurityIdentifier)) is PropertyInfo directProperty
+                && directProperty.GetValue(identityObject) is SecurityIdentifier directSid)
+            {
+                identity = directSid;
+                return true;
+            }
+            if (objectType.BaseType is Type parentType
+                && string.Equals(parentType.Name, "LocalPrincipal", StringComparison.Ordinal)
+                && objectType.GetProperty("SID", typeof(SecurityIdentifier)) is PropertyInfo parentProperty
+                && parentProperty.GetValue(identityObject) is SecurityIdentifier parentSid)
+            {
+                identity = parentSid;
+                return true;
+            }
             return false;
         }
     }

--- a/src/PSADT/PSAppDeployToolkit/Attributes/IdentityTransformationAttribute.cs
+++ b/src/PSADT/PSAppDeployToolkit/Attributes/IdentityTransformationAttribute.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Management.Automation;
+using System.Reflection;
+using System.Security.Principal;
+
+namespace PSAppDeployToolkit.Attributes
+{
+    /// <summary>
+    /// Transforms objects into a <see cref="IdentityReference"/>.
+    /// </summary>
+    public sealed class IdentityTransformationAttribute : ArgumentTransformationAttribute
+    {
+        /// <summary>
+        /// Transforms input object into base <see cref="IdentityReference"/> objects for consumption in downstream PowerShell functions.
+        /// Supported types:
+        ///  * <see cref="IdentityReference"/>
+        ///  * <see cref="WindowsIdentity"/>
+        ///  * <see cref="WellKnownSidType"/>
+        ///  * LocalUser
+        ///  * <see cref="string"/> representing the above
+        /// </summary>
+        /// <param name="engineIntrinsics">The PowerShell engine intrinsics.</param>
+        /// <param name="inputData">The input value to transform.</param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException">Thrown if the input object did not contain the required properties.</exception>
+        /// <exception cref="ArgumentException">Thrown if the input object is not supported for transformation.</exception>
+        public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
+        {
+
+            if (inputData is WellKnownSidType wellKnownSidType)
+            {
+                return new SecurityIdentifier(wellKnownSidType, null);
+            }
+            else if (inputData is IdentityReference identity)
+            {
+                return identity;
+            }
+            else if (inputData is WindowsIdentity windowsIdentity)
+            {
+                return windowsIdentity.User
+                    ?? throw new InvalidOperationException("The given WindowsIdentity did not provide the required user identity.");
+            }
+            else if (inputData.GetType().FullName == "Microsoft.PowerShell.Commands.LocalUser"
+                && inputData.GetType().GetProperty("SID", typeof(SecurityIdentifier)) is PropertyInfo localUserSidProperty)
+            {
+                return localUserSidProperty.GetValue(inputData)
+                    ?? throw new InvalidOperationException("The given LocalUser did not provide the required SID property.");
+            }
+            else if (inputData is string str && TryParseIdentityReference(str, out IdentityReference strIdentity))
+            {
+                return strIdentity;
+            }
+            else
+            {
+                throw new ArgumentException("Input data must be of type string, IdentityReference, WindowsIdentity or a string representing any of those types, or a WellKnownSidType value.", nameof(inputData));
+            }
+        }
+
+        /// <summary>
+        /// Tries to parse a string as <see cref="IdentityReference"/>, returning the corresponding object.
+        /// </summary>
+        /// <param name="identityString">The string to parse.</param>
+        /// <param name="identity">The <see cref="IdentityReference"/> if parsing succeeds; otherwise NullSid</param>
+        /// <returns>True if the input string was successfully parsed  name; otherwise, false.</returns>
+        private static bool TryParseIdentityReference(string identityString, out IdentityReference identity)
+        {
+            identity = new SecurityIdentifier(WellKnownSidType.NullSid, null);
+            if (string.IsNullOrWhiteSpace(identityString))
+            {
+                return false;
+            }
+
+            // Try Enum
+            if (Enum.TryParse(identityString, true, out WellKnownSidType wellKnownSidType))
+            {
+                identity = new SecurityIdentifier(wellKnownSidType, null);
+                return true;
+            }
+
+            // Try SID
+            if (identityString.StartsWith("S-", StringComparison.OrdinalIgnoreCase))
+            {
+                try
+                {
+                    identity = new SecurityIdentifier(identityString);
+                    return true;
+                }
+                catch (ArgumentException)
+                {
+                }
+            }
+
+            // Try NTAccount
+            try
+            {
+                identity = new NTAccount(identityString);
+                return true;
+            }
+            catch (IdentityNotMappedException)
+            {
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

Added a identity transformation attribute for consumtion in functions that require identity information.
It can handle transforming inputs from common sources  into a IdentityReference for consumption within a function.

**Sample**
```powershell
function test {
  param(
    [PSAppDeployToolkit.Attributes.IdentityTransformation()]
    [System.Security.Principal.IdentityReference]
    $User
  )
  return $User.Translate([System.Security.Principal.NTAccount]).Value
}
```

This will allow inputs like:
```powershell
test -User (Get-LocalUser -Name 'Administrator')
test -User ([System.Security.Principal.WindowsIdentity]::GetCurrent())
test -User ([System.Security.Principal.SecurityIdentifier]::new('S-1-5-18'))
test -User ([System.Security.Principal.WellKnownSidType]::LocalSystemSid)
test -User 'S-1-5-18'
test -User 'SYSTEM'
test -User 'LocalSystemSid'
```

Within code, can be translated into any `IdentityReference` with the `Translate()` method.

This should streamline handling identities.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [X] I am pulling to the **main** branch
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested my changes to prove my fix is effective
- [X] I have tested that the module can build following my changes
- [X] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

This class has been tested in downstream projects from my company. It was adapted to fit the coding style of the PSADT