### PR TITLE
Fix: Correct Show-ADTinstallationProgress docs 

### DIFF
--- a/src/PSAppDeployToolkit/Public/Show-ADTInstallationProgress.ps1
+++ b/src/PSAppDeployToolkit/Public/Show-ADTInstallationProgress.ps1
@@ -11,7 +11,7 @@ function Show-ADTInstallationProgress
         Displays a progress dialog in a separate thread with an updateable custom message.
 
     .DESCRIPTION
-        The `Show-ADTInstallationProgress` function creates a UI window in a separate thread to display a marquee style progress ellipse with a custom message that can be updated. The status message supports line breaks.
+        The `Show-ADTInstallationProgress` function creates a UI window in a separate thread to display a progress bar with a custom message that can be updated. The status message supports line breaks.
 
         The first time this function is called in a script, it will display a balloon tip notification to indicate that the installation has started (provided balloon tips are enabled in the `config.psd1` file).
 
@@ -22,7 +22,7 @@ function Show-ADTInstallationProgress
         The status message detail to be displayed with a fluent progress window. The default status message is taken from the imported `strings.psd1` file.
 
     .PARAMETER StatusBarPercentage
-        The percentage to display on the status bar. If null or not supplied, the status bar will continuously scroll.
+        The percentage to display on the progress bar with a fluent progress window. If null or not supplied, an indeterminate progress bar is displayed.
 
     .PARAMETER MessageAlignment
         The text alignment to use for the status message.


### PR DESCRIPTION
# Pull Request

## Description

The function documentation indicate that Show-ADTInstallationProgress shows a progress ring. This is only true for v3 and needs to be updated for v4, otherwise the -StatusBarPercentage parameter makes no sense.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [X] I am pulling to the **main** branch
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have tested my changes to prove my fix is effective
- [X] I have tested that the module can build following my changes
- [ X I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Verified the change gets reflected on a local instance of the website.
