### PR TITLE
Ensure the exit code from `dotnet publish` is measured.

### DIFF
--- a/src/PSAppDeployToolkit.Build/Private/Invoke-ADTDotNetCompilation.ps1
+++ b/src/PSAppDeployToolkit.Build/Private/Invoke-ADTDotNetCompilation.ps1
@@ -145,6 +145,10 @@ function Invoke-ADTDotNetCompilation
                     {
                         Write-ADTBuildLogEntry -Message "Running publish action for [$([System.IO.Path]::GetFileName($publishItem.Key))], please wait..."
                         $null = & $dotnet publish $publishItem.Key -r win-x64  # The RID doesn't matter here, it's all IL but we need to specify it.
+                        if ($Global:LASTEXITCODE)
+                        {
+                            throw "Publishing item [$($publishItem.Key -replace '^.+\\')] failed with exit code [$Global:LASTEXITCODE]."
+                        }
                     }
                 }
 

--- a/src/PSAppDeployToolkit/Public/Show-ADTInstallationProgress.ps1
+++ b/src/PSAppDeployToolkit/Public/Show-ADTInstallationProgress.ps1
@@ -31,7 +31,7 @@ function Show-ADTInstallationProgress
         The location of the dialog on the screen.
 
     .PARAMETER NotTopMost
-        Specifies whether the progress window shouldn't be topmost.
+        Specifies that the progress window will not be displayed as the topmost window.
 
     .PARAMETER AllowMove
         Specifies that the user can move the dialog on the screen.

--- a/src/PSAppDeployToolkit/Public/Start-ADTProcess.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTProcess.ps1
@@ -16,7 +16,7 @@ function Start-ADTProcess
     .PARAMETER FilePath
         Path to the file to be executed. If the file is located directly in the "Files" directory of the App Deploy Toolkit, only the file name needs to be specified.
 
-        Otherwise, the full path of the file must be specified. If the files is in a subdirectory of "Files", use the `$($adtSession.DirFiles)` variable, as shown in the example.
+        Otherwise, the full path of the file must be specified. If the file is in a subdirectory of "Files", use the `$($adtSession.DirFiles)` variable, as shown in the example.
 
     .PARAMETER ArgumentList
         Arguments to be passed to the executable.
@@ -53,7 +53,7 @@ function Start-ADTProcess
     .PARAMETER UseShellExecute
         Specifies whether to use the operating system shell to start the process. `$true` if the shell should be used when starting the process; `$false` if the process should be created directly from the executable file.
 
-        The word "Shell" in this context refers to a graphical shell (similar to the Windows shell) rather than command shells (for example, bash or sh) and lets users launch graphical applications or open documents. It lets you open a file or a url and the Shell will figure out the program to open it with.
+        The word "Shell" in this context refers to a graphical shell (similar to the Windows shell) rather than command shells (for example, bash or sh) and lets users launch graphical applications or open documents. It lets you open a file or a URL and the Shell will figure out the program to open it with.
 
         The WorkingDirectory property behaves differently depending on the value of the `-UseShellExecute` parameter. When `-UseShellExecute` is `$true`, the `-WorkingDirectory` parameter specifies the location of the executable. When `-UseShellExecute` is `$false`, the `-WorkingDirectory` parameter is not used to find the executable. Instead, it is used only by the process that is started and has meaning only within the context of the new process.
 

--- a/src/PSAppDeployToolkit/Public/Start-ADTProcessAsUser.ps1
+++ b/src/PSAppDeployToolkit/Public/Start-ADTProcessAsUser.ps1
@@ -16,7 +16,7 @@ function Start-ADTProcessAsUser
     .PARAMETER FilePath
         Path to the file to be executed. If the file is located directly in the "Files" directory of the App Deploy Toolkit, only the file name needs to be specified.
 
-        Otherwise, the full path of the file must be specified. If the files is in a subdirectory of "Files", use the `$($adtSession.DirFiles)` variable, as shown in the example.
+        Otherwise, the full path of the file must be specified. If the file is in a subdirectory of "Files", use the `$($adtSession.DirFiles)` variable, as shown in the example.
 
     .PARAMETER ArgumentList
         Arguments to be passed to the executable.
@@ -50,7 +50,7 @@ function Start-ADTProcessAsUser
     .PARAMETER UseShellExecute
         Specifies whether to use the operating system shell to start the process. `$true` if the shell should be used when starting the process; `$false` if the process should be created directly from the executable file.
 
-        The word "Shell" in this context refers to a graphical shell (similar to the Windows shell) rather than command shells (for example, bash or sh) and lets users launch graphical applications or open documents. It lets you open a file or a url and the Shell will figure out the program to open it with.
+        The word "Shell" in this context refers to a graphical shell (similar to the Windows shell) rather than command shells (for example, bash or sh) and lets users launch graphical applications or open documents. It lets you open a file or a URL and the Shell will figure out the program to open it with.
 
         The `-WorkingDirectory` parameter behaves differently depending on the value of the `-UseShellExecute` parameter. When `-UseShellExecute` is `$true`, the `-WorkingDirectory` parameter specifies the location of the executable. When `-UseShellExecute` is `$false`, the `-WorkingDirectory` parameter is not used to find the executable. Instead, it is used only by the process that is started and has meaning only within the context of the new process.
 


### PR DESCRIPTION
# Pull Request

## Description

We test the exit code for `dotnet build` and `dotnet test`, but not this one.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] General code cleanup (non-breaking change which improves readability)

## Checklist

- [ ] I am pulling to the **main** branch
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested my changes to prove my fix is effective
- [ ] I have tested that the module can build following my changes
- [ ] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.