### PR TITLE
Fix the Fluent dialog icon and accent not applying after the first dialog, and the same-thread AttachThreadInput exception

### DIFF
--- a/src/PSADT/PSADT.UserInterface.Interfaces.TestHarness/Program.cs
+++ b/src/PSADT/PSADT.UserInterface.Interfaces.TestHarness/Program.cs
@@ -141,6 +141,7 @@ namespace PSADT.UserInterface.Interfaces.TestHarness
                     { "FluentAccentColor", ValueTypeConverter.ToInt(0xFF00CC6A) }, // Accent Color: Green #00CC6A
                     { "DialogTopMost", true },
                     { "DialogAllowMinimize", true },
+                    { "DialogAllowMove", true },
                     { "AppTitle", appTitle },
                     { "Subtitle", subtitle },
                     { "AppIconImage", appIconImage },
@@ -156,6 +157,7 @@ namespace PSADT.UserInterface.Interfaces.TestHarness
                     { "DialogExpiryDuration", dialogExpiryDuration },
                     { "FluentAccentColor", ValueTypeConverter.ToInt(0xFF0099BC) }, // Accent Color: Cyan #0099BC
                     { "DialogTopMost", true },
+                    { "DialogAllowMove", true },
                     { "AppTitle", appTitle },
                     { "Subtitle", subtitle },
                     { "AppIconImage", appIconImage },
@@ -176,6 +178,7 @@ namespace PSADT.UserInterface.Interfaces.TestHarness
                     { "DialogExpiryDuration", dialogExpiryDuration },
                     { "FluentAccentColor", ValueTypeConverter.ToInt(0xFF4A5459) }, // Accent Color: Navy Blue #4A5459
                     { "DialogTopMost", true },
+                    { "DialogAllowMove", true },
                     { "AppTitle", appTitle },
                     { "Subtitle", subtitle },
                     { "AppIconImage", appIconImage },
@@ -195,6 +198,7 @@ namespace PSADT.UserInterface.Interfaces.TestHarness
                     { "DialogExpiryDuration", dialogExpiryDuration },
                     { "FluentAccentColor", ValueTypeConverter.ToInt(0xFFF7630C) }, // Accent Color: Orange #F7630C
                     { "DialogTopMost", true },
+                    { "DialogAllowMove", true },
                     { "AppTitle", appTitle },
                     { "Subtitle", subtitle },
                     { "AppIconImage", appIconImage },
@@ -213,6 +217,7 @@ namespace PSADT.UserInterface.Interfaces.TestHarness
                     { "DialogExpiryDuration", dialogExpiryDuration },
                     { "FluentAccentColor", ValueTypeConverter.ToInt(0xFFF600CE) }, // Accent Color: Purple #F600CE
                     { "DialogTopMost", true },
+                    { "DialogAllowMove", true },
                     { "AppTitle", appTitle },
                     { "Subtitle", subtitle },
                     { "AppIconImage", appIconImage },
@@ -234,6 +239,7 @@ namespace PSADT.UserInterface.Interfaces.TestHarness
                     { "DialogExpiryDuration", dialogExpiryDuration },
                     { "FluentAccentColor", ValueTypeConverter.ToInt(0xFFFFB900) }, // Accent Color: Yellow #FFB900
                     { "DialogTopMost", true },
+                    { "DialogAllowMove", true },
                     { "AppTitle", appTitle },
                     { "Subtitle", subtitle },
                     { "AppIconImage", appIconImage },

--- a/src/PSADT/PSADT.UserInterface.Interfaces/Fluent/FluentDialog.xaml.cs
+++ b/src/PSADT/PSADT.UserInterface.Interfaces/Fluent/FluentDialog.xaml.cs
@@ -165,6 +165,14 @@ namespace PSADT.UserInterface.Interfaces.Fluent
             ApplicationThemeManager.Changed += ThemeManager_ActualThemeChanged;
             ApplicationThemeManager.Apply(ApplicationTheme.Auto);
 
+            // Fluence.Wpf gates Changed behind a redundant-publish check, so the Apply above only
+            // raises it for the first dialog in the process (a genuine transition). Later dialogs
+            // apply an identical theme, get no event, and would otherwise show no icon or accent.
+            // Initialize both directly from the resolved theme; the subscription stays for
+            // OS-driven changes while the dialog is open.
+            SetDialogAccent(ApplicationThemeManager.ResolvedTheme);
+            SetDialogIcon(ApplicationThemeManager.ResolvedTheme);
+
             // Set the expiry timer if specified.
             if (options.DialogExpiryDuration > TimeSpan.Zero)
             {

--- a/src/PSADT/PSADT/WindowManagement/WindowTools.cs
+++ b/src/PSADT/PSADT/WindowManagement/WindowTools.cs
@@ -65,10 +65,16 @@ namespace PSADT.WindowManagement
                 _ = PInvoke.ShowWindow(hWnd, Windows.Win32.UI.WindowsAndMessaging.SHOW_WINDOW_CMD.SW_RESTORE);
             }
 
-            // Bring the window to the foreground.
+            // Bring the window to the foreground. AttachThreadInput fails with
+            // ERROR_INVALID_PARAMETER when the two threads are the same (a window we own, e.g. a
+            // dialog raising itself from its own Loaded handler), so only attach across threads.
             uint currentThreadId = PInvoke.GetCurrentThreadId();
             uint windowThreadId = NativeMethods.GetWindowThreadProcessId(hWnd, out _);
-            _ = NativeMethods.AttachThreadInput(currentThreadId, windowThreadId, fAttach: true);
+            bool attachInput = windowThreadId != 0 && windowThreadId != currentThreadId;
+            if (attachInput)
+            {
+                _ = NativeMethods.AttachThreadInput(currentThreadId, windowThreadId, fAttach: true);
+            }
             try
             {
                 _ = NativeMethods.BringWindowToTop(hWnd);
@@ -78,7 +84,10 @@ namespace PSADT.WindowManagement
             }
             finally
             {
-                _ = NativeMethods.AttachThreadInput(currentThreadId, windowThreadId, fAttach: false);
+                if (attachInput)
+                {
+                    _ = NativeMethods.AttachThreadInput(currentThreadId, windowThreadId, fAttach: false);
+                }
             }
         }
 


### PR DESCRIPTION
# Pull Request

## Description

Follow-up to #2311: fixes the missing 60x60 dialog icon Mitch reported on the progress dialog, which affected every Fluent dialog after the first one shown in a process, plus a first-chance `ArgumentException` thrown on every dialog load.

**Missing icon and accent.** `FluentDialog`'s constructor subscribes `ApplicationThemeManager.Changed`, calls `Apply(Auto)`, and relied on the event to run `SetDialogIcon`/`SetDialogAccent` - the only place the icon is ever set. Fluence.Wpf gates `Changed` behind a redundant-publish fingerprint, so only the first dialog in a process (CloseApps) receives the event; every later dialog applies an identical theme, gets no event, and shows no icon - and its per-dialog `FluentAccentColor` was silently never applied either. The constructor now initializes both directly from `ApplicationThemeManager.ResolvedTheme` after the `Apply`, keeping the subscription for OS-driven theme changes while the dialog is open. Latent since the gate arrived with the 0.8.15-pre subtree, not a 0.8.18 regression.

**ArgumentException in `WindowTools.BringWindowToFront`.** `AttachThreadInput` fails with `ERROR_INVALID_PARAMETER` when `idAttach == idAttachTo`, and a dialog raising itself from its own `Loaded` handler always runs on the window's own thread, so the call threw on every dialog and skipped the whole bring-to-front block. The attach/detach pair now runs only when the window thread is valid and different from the current thread.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have tested that the module can build following my changes
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Reproduced and verified with `PSADT.UserInterface.Interfaces.TestHarness` driven via UIAutomation: before the fix, the CloseApps dialog showed its icon but the progress dialog (and later dialogs) did not; after the fix, the progress dialog renders its 60x60 icon and its own green `FluentAccentColor` (previously it inherited the prior dialog's accent), captured in screenshots. The `ArgumentException` no longer occurs because the same-thread `AttachThreadInput` call is no longer made. `PSADT.UserInterface.Interfaces` and the test harness build clean.
