### PR TITLE
Docs: clarify CloseProcesses Name/Description semantics

### DIFF
--- a/modules/PSAppDeployToolkit/Public/Show-ADTInstallationWelcome.ps1
+++ b/modules/PSAppDeployToolkit/Public/Show-ADTInstallationWelcome.ps1
@@ -19,7 +19,8 @@ function Show-ADTInstallationWelcome
         * Prevent users from launching the specified applications while the deployment is in progress.
 
     .PARAMETER CloseProcesses
-        Name of the process to stop (do not include the .exe). Specify multiple processes separated by a comma. Specify custom descriptions like this: `@{ Name = 'winword'; Description = 'Microsoft Office Word' }, @{ Name = 'excel'; Description = 'Microsoft Office Excel' }`
+        One or more processes to close. Specify multiple processes separated by a comma. Provide either the bare process name (do not include the `.exe`), or the full path to a specific executable if you need to distinguish between two processes that share the same name (for example, two different vendors' `javaw.exe`). Wildcards (`*`) are supported in either form.
+        Specify custom descriptions to show to the end user like this: `@{ Name = 'winword'; Description = 'Microsoft Office Word' }, @{ Name = 'excel'; Description = 'Microsoft Office Excel' }`. The `Description` property is purely cosmetic - it does not filter or restrict which running processes are matched. Use the full path form of `Name` if you need to target one specific executable.
 
     .PARAMETER HideCloseButton
         Specifies that the 'Close Processes' button be hidden/disabled to force users to manually close down their running processes.


### PR DESCRIPTION
## Description

As requested by @mjr4077au in #2182, this clarifies the help text for the `-CloseProcesses` parameter on `Show-ADTInstallationWelcome`.

The previous text implied that `Name` could only ever be a bare process name, and said nothing about how `Description` behaves. That's what led to the confusion in #2182: `Description` is purely cosmetic (shown to the end user) and is never used to filter which running processes get matched or closed. To target one specific executable (e.g. distinguishing between two vendors' `javaw.exe`), you provide the full path in `Name` instead.

This PR only updates the help text on `Show-ADTInstallationWelcome`. Per the discussion on #2182, @mjr4077au mentioned he'd sync the wording to `Get-ADTRunningProcesses` and `Open-ADTSession` himself.

Related: #2182

## Type of change

Documentation update (non-breaking change which improves clarity).

## Checklist

- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (this PR is exactly that)
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.