### PR TITLE
Docs: clarify ProcessDefinition Name/Description semantics

### DIFF
--- a/modules/PSAppDeployToolkit/Public/Get-ADTRunningProcesses.ps1
+++ b/modules/PSAppDeployToolkit/Public/Get-ADTRunningProcesses.ps1
@@ -14,7 +14,8 @@ function Get-ADTRunningProcesses
         The `Get-ADTRunningProcesses` function returns the processes that are running from the provided list of process objects.
 
     .PARAMETER ProcessDefinition
-        One or more process objects to search for.
+        One or more process objects to search for. Provide either the bare process name (do not include the `.exe`), or the full path to a specific executable if you need to distinguish between two processes that share the same name (for example, two different vendors' `javaw.exe`). Wildcards (`*`) are supported in either form.
+        Specify custom descriptions like this: `@{ Name = 'winword'; Description = 'Microsoft Office Word' }, @{ Name = 'excel'; Description = 'Microsoft Office Excel' }`. The `Description` property is purely cosmetic - it does not filter or restrict which running processes are matched.
 
     .INPUTS
         None.


### PR DESCRIPTION
## Description

As requested by @mjr4077au in #2182, this mirrors the wording used in #2319 (the `-CloseProcesses` help text on `Show-ADTInstallationWelcome`) onto the `ProcessDefinition` parameter of `Get-ADTRunningProcesses`.

The previous text said nothing about how `Name` and `Description` behave. `Name` can be a bare process name or a full path to target a specific executable (wildcards supported), and `Description` is purely cosmetic - it is never used to filter which running processes get matched.

This is a documentation-only change, no code paths are affected.

Related: #2182, #2319

## Type of change

Documentation update (non-breaking change which improves clarity).

## Checklist
- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (this PR is exactly that)
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.