### PR TITLE
Docs: clarify AppProcessesToClose Name/Description semantics

### DIFF
--- a/modules/PSAppDeployToolkit/Public/Open-ADTSession.ps1
+++ b/modules/PSAppDeployToolkit/Public/Open-ADTSession.ps1
@@ -53,8 +53,9 @@ function Open-ADTSession
         Specifies the application reboot codes.
 
     .PARAMETER AppProcessesToClose
-        Specifies one or more processes that require closing to ensure a successful deployment.
-
+        Specifies one or more processes that require closing to ensure a successful deployment. Provide either the bare process name (do not include the `.exe`), or the full path to a specific executable if you need to distinguish between two processes that share the same name (for example, two different vendors' `javaw.exe`). Wildcards (`*`) are supported in either form.
+        Specify custom descriptions like this: `@{ Name = 'winword'; Description = 'Microsoft Office Word' }, @{ Name = 'excel'; Description = 'Microsoft Office Excel' }`. The `Description` property is purely cosmetic - it does not filter or restrict which running processes are matched.
+    
     .PARAMETER AppScriptVersion
         Specifies the application script version.
 


### PR DESCRIPTION
## Description

As requested by @mjr4077au in #2182, this mirrors the wording used in #2319 and #2320 onto the `-AppProcessesToClose` parameter of `Open-ADTSession`.

The previous text said nothing about how `Name` and `Description` behave. `Name` can be a bare process name or a full path to target a specific executable (wildcards supported), and `Description` is purely cosmetic - it is never used to filter which running processes get matched.

This is a documentation-only change, no code paths are affected.

Related: #2182, #2319, #2320

## Type of change

Documentation update (non-breaking change which improves clarity).

## Checklist
- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (this PR is exactly that)
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.