### PR TITLE
examples(VLC): install/uninstall ASP.NET Core Runtime 10.0.11 (silent)

### DIFF
--- a/examples/VLC/Invoke-AppDeployToolkit.ps1
+++ b/examples/VLC/Invoke-AppDeployToolkit.ps1
@@ -51,19 +51,19 @@ param
 
 ## MARK: Variables
 $adtSession = @{
-    AppVendor = 'VideoLAN'
-    AppName = 'VLC media player'
-    AppVersion = '3.0.23'
+    AppVendor = 'Microsoft'
+    AppName = 'ASP.NET Core Runtime'
+    AppVersion = '10.0.11'
     AppArch = 'x64'
     AppLang = 'EN'
     AppRevision = '01'
     AppSuccessExitCodes = @(0)
     AppRebootExitCodes = @(1641, 3010)
-    AppProcessesToClose = @(@{ Name = 'vlc'; Description = 'VLC media player' })
+    AppProcessesToClose = @()
     RequireAdmin = $true
 
     AppScriptVersion = '1.0.0'
-    AppScriptDate = '2026-04-01'
+    AppScriptDate = '2026-09-02'
     AppScriptAuthor = 'PSAppDeployToolkit'
 
     DeployAppScriptFriendlyName = $MyInvocation.MyCommand.Name
@@ -88,7 +88,7 @@ New-Variable -Name Pre-Install -Value {
 
 ## MARK: Install
 New-Variable -Name Install -Value {
-    Start-ADTProcess -FilePath "vlc-$($adtSession.AppVersion)-win64.exe" -ArgumentList '/L=1033 /S'
+    Start-ADTProcess -FilePath "aspnetcore-runtime-10.0.11-win-x64.exe" -ArgumentList '/install','/quiet','/norestart'
 }
 
 ## MARK: Post-Install
@@ -109,7 +109,7 @@ New-Variable -Name Pre-Uninstall -Value {
 
 ## MARK: Uninstall
 New-Variable -Name Uninstall -Value {
-    Uninstall-ADTApplication -Name 'VLC media player' -NameMatch 'Exact' -ArgumentList '/S'
+    Start-ADTProcess -FilePath "aspnetcore-runtime-10.0.11-win-x64.exe" -ArgumentList '/uninstall','/quiet','/norestart'
 }
 
 ## MARK: Post-Uninstall


### PR DESCRIPTION
# Pull Request

## Description

Update examples/VLC/Invoke-AppDeployToolkit.ps1 to configure MARK: Variables for ASP.NET Core Runtime 10.0.11 and to run aspnetcore-runtime-10.0.11-win-x64.exe with /install /quiet /norestart and /uninstall /quiet /norestart. This makes the VLC example show how to install the ASP.NET Core runtime silently.

Fixes: N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **main** branch
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested my changes to prove my fix is effective
- [ ] I have tested that the module can build following my changes
- [ ] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Edited and committed the example file in the feature branch. Please test in a VM by placing aspnetcore-runtime-10.0.11-win-x64.exe in the package SupportFiles folder and running:

```
& .\Invoke-AppDeployToolkit.ps1 -DeploymentType Install -DeployMode Silent
```

N/A for other environments.