### PR TITLE
Rework parameter sets in Show-ADTInstallationRestartPrompt

### DIFF
--- a/modules/PSAppDeployToolkit/Public/Show-ADTInstallationRestartPrompt.ps1
+++ b/modules/PSAppDeployToolkit/Public/Show-ADTInstallationRestartPrompt.ps1
@@ -96,9 +96,11 @@ function Show-ADTInstallationRestartPrompt
     param
     (
         [Parameter(Mandatory = $true, ParameterSetName = 'NoCountdown')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'NoCountdownSilentRestart')]
         [System.Management.Automation.SwitchParameter]$NoCountdown,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Countdown')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'CountdownSilentRestart')]
         [Alias('CountdownSeconds')]
         [PSAppDeployToolkit.Attributes.TimeSpanTransformation()]
         [PSAppDeployToolkit.Attributes.ValidateGreaterThanZero()]
@@ -112,6 +114,7 @@ function Show-ADTInstallationRestartPrompt
         [System.TimeSpan]$Countdown = [System.TimeSpan]::FromSeconds(60),
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Countdown')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'CountdownSilentRestart')]
         [Alias('CountdownNoHideSeconds')]
         [PSAppDeployToolkit.Attributes.TimeSpanTransformation()]
         [PSAppDeployToolkit.Attributes.ValidateGreaterThanZero()]
@@ -124,10 +127,12 @@ function Show-ADTInstallationRestartPrompt
             })]
         [System.TimeSpan]$CountdownNoHide = [System.TimeSpan]::FromSeconds(30),
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'SilentRestart')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'CountdownSilentRestart')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'NoCountdownSilentRestart')]
         [System.Management.Automation.SwitchParameter]$SilentRestart,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'SilentRestart')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'CountdownSilentRestart')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'NoCountdownSilentRestart')]
         [Alias('SilentCountdownSeconds')]
         [PSAppDeployToolkit.Attributes.TimeSpanTransformation()]
         [PSAppDeployToolkit.Attributes.ValidateGreaterThanZero()]
@@ -140,8 +145,7 @@ function Show-ADTInstallationRestartPrompt
             })]
         [System.TimeSpan]$SilentCountdown = [System.TimeSpan]::FromSeconds(5),
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'NoCountdown')]
-        [Parameter(Mandatory = $false, ParameterSetName = 'Countdown')]
+        [Parameter(Mandatory = $false)]
         [ValidateScript({
                 if ([System.String]::IsNullOrWhiteSpace($_))
                 {
@@ -159,17 +163,14 @@ function Show-ADTInstallationRestartPrompt
         [ValidateNotNullOrEmpty()]
         [PSADT.UserInterface.DialogPosition]$WindowLocation,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'NoCountdown')]
-        [Parameter(Mandatory = $false, ParameterSetName = 'Countdown')]
+        [Parameter(Mandatory = $false)]
         [System.Management.Automation.SwitchParameter]$PersistPrompt,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'NoCountdown')]
-        [Parameter(Mandatory = $false, ParameterSetName = 'Countdown')]
+        [Parameter(Mandatory = $false)]
         [Alias('CustomText')]
         [System.Management.Automation.SwitchParameter]$CustomMessage,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'NoCountdown')]
-        [Parameter(Mandatory = $false, ParameterSetName = 'Countdown')]
+        [Parameter(Mandatory = $false)]
         [PSAppDeployToolkit.Attributes.ValidateNotNullOrWhiteSpace()]
         [System.String]$CustomMessageText,
 
@@ -179,8 +180,7 @@ function Show-ADTInstallationRestartPrompt
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.SwitchParameter]$AllowMove,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'NoCountdown')]
-        [Parameter(Mandatory = $false, ParameterSetName = 'Countdown')]
+        [Parameter(Mandatory = $false)]
         [System.Management.Automation.SwitchParameter]$AllowCancel
     )
 


### PR DESCRIPTION
# Pull Request

## Description

The parameter sets here did not make sense. `-SilentRestart` tells the toolkit "in silent mode, just do the restart". In interactive mode, it shows the dialog as normal, but with most of the parameters (e.g. `-Countdown`, `-CountdownNoHide`, `-PersistPrompt`, `-CustomMessage`, `-CustomMessageText`, `-AllowCancel`, `-ShutdownReasonText`) unavailable.

These options have now been unlocked by adding an additional parameter set.

Fixes #2323

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have tested that the module can build following my changes
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Manual testing with various parameter combinations.
