### PR TITLE
Define ZeroConfig code block as string to avoid CommandTable translation

### DIFF
--- a/modules/PSAppDeployToolkit/Public/New-ADTTemplate.ps1
+++ b/modules/PSAppDeployToolkit/Public/New-ADTTemplate.ps1
@@ -537,18 +537,20 @@ function New-ADTTemplate
         # Handle -ZeroConfig: inject the default MSI scriptblock into Install/Uninstall/Repair phases.
         if ($ZeroConfig)
         {
-            $zeroConfigScriptBlock = {
-                ## Handle Zero-Config MSI actions.
-                if ($adtSession.UseDefaultMsi)
-                {
-                    $ExecuteDefaultMSISplat = @{ Action = $adtSession.DeploymentType; FilePath = $adtSession.DefaultMsiFile }
-                    if ($adtSession.DefaultMstFile)
-                    {
-                        $ExecuteDefaultMSISplat.Add('Transforms', $adtSession.DefaultMstFile)
-                    }
-                    Start-ADTMsiProcess @ExecuteDefaultMSISplat
-                }
-            }
+            # Define as a string initially so that this block does not get translated into CommandTable calls by the build system
+            $zeroConfigScriptBlock = @'
+## Handle Zero-Config MSI actions.
+if ($adtSession.UseDefaultMsi)
+{
+    $ExecuteDefaultMSISplat = @{ Action = $adtSession.DeploymentType; FilePath = $adtSession.DefaultMsiFile }
+    if ($adtSession.DefaultMstFile)
+    {
+        $ExecuteDefaultMSISplat.Add('Transforms', $adtSession.DefaultMstFile)
+    }
+    Start-ADTMsiProcess @ExecuteDefaultMSISplat
+}
+'@
+            $zeroConfigScriptBlock = [System.Management.Automation.ScriptBlock]::Create($zeroConfigScriptBlock)
             foreach ($sbName in 'InstallScriptBlock', 'UninstallScriptBlock', 'RepairScriptBlock')
             {
                 if ($PSBoundParameters.ContainsKey($sbName))


### PR DESCRIPTION
# Pull Request

## Description

Define ZeroConfig code block as string to avoid CommandTable translation during module compilation.

Fixes #2330

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] General code cleanup (non-breaking change which improves readability)

## Checklist

- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my changes to prove my fix is effective
- [x] I have tested that the module can build following my changes
- [x] I have made sure that any script file-encoding is set to UTF8 with BOM, i.e. unchanged.

## How Has This Been Tested?

Generated a zeroconfig template with compiled module and verified results.
